### PR TITLE
Smooth heat pump running power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 🐛 Bug fixes
+- Smoothed running Heat Pump power over longer same-day energy windows to reduce short-window spikes from lumpy site-today energy updates, while keeping raw power diagnostics available. (#680)
+
 ## v3.0.10 - 2026-05-17
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -58,6 +58,21 @@ _HEATPUMP_POWER_DEFAULT_WINDOW_S = 300.0
 _HEATPUMP_POWER_MIN_DELTA_WH = 0.5
 _HEATPUMP_IDLE_SMOOTHING_MIN_WINDOW_S = 15 * 60.0
 _HEATPUMP_IDLE_SMOOTHING_MAX_WINDOW_S = 30 * 60.0
+_HEATPUMP_ACTIVE_SMOOTHING_MIN_WINDOW_S = 15 * 60.0
+_HEATPUMP_ACTIVE_SMOOTHING_MAX_WINDOW_S = 30 * 60.0
+_HEATPUMP_POWER_SEEDED_STALE_AFTER_S = 30 * 60.0
+_HEATPUMP_POWER_HOLD_STALE_ERRORS = {"seeded_waiting_for_delta", "repeated_sample"}
+_SITE_TODAY_HEATPUMP_TOTAL_KEYS = (
+    "consumed_wh",
+    "consumption_wh",
+    "energy_wh",
+    "total_wh",
+    "wh",
+    "consumed",
+    "consumption",
+    "value",
+    "total",
+)
 
 
 class HeatpumpRuntime:
@@ -226,10 +241,11 @@ class HeatpumpRuntime:
         now: float,
         error: str,
         power_snapshot: dict[str, object] | None = None,
+        stale_after_s: float = HEATPUMP_POWER_STALE_AFTER_S,
     ) -> bool:
         if self._heatpump_power_w is not None and self._heatpump_snapshot_is_fresh(
             self._heatpump_power_last_success_mono,
-            HEATPUMP_POWER_STALE_AFTER_S,
+            stale_after_s,
             now,
         ):
             self._heatpump_power_using_stale = True
@@ -1076,15 +1092,13 @@ class HeatpumpRuntime:
         if value is None:
             return None
         if isinstance(value, dict):
-            total = 0.0
-            found = False
-            for nested in value.values():
-                nested_total = cls._site_today_heatpump_numeric_total(nested)
-                if nested_total is None:
+            for key in _SITE_TODAY_HEATPUMP_TOTAL_KEYS:
+                if key not in value:
                     continue
-                total += nested_total
-                found = True
-            return total if found else None
+                nested_total = cls._site_today_heatpump_numeric_total(value.get(key))
+                if nested_total is not None:
+                    return nested_total
+            return None
         if isinstance(value, list):
             total = 0.0
             found = False
@@ -1184,29 +1198,17 @@ class HeatpumpRuntime:
         )
         history[:] = retained
 
-    def _heatpump_idle_smoothed_power(
+    def _heatpump_smoothed_power_from_history(
         self,
         snapshot: dict[str, object],
         *,
         current_energy_wh: float,
         current_sample_utc: datetime,
-        raw_value_w: float | None,
-        raw_validation: str,
+        min_window_s: float,
+        max_window_s: float,
+        validation: str,
+        max_power_w: float | None = None,
     ) -> dict[str, object] | None:
-        if raw_value_w is None:
-            return None
-        if (
-            raw_value_w > _HEATPUMP_IDLE_POWER_MAX_W
-            and raw_validation != _HEATPUMP_IDLE_HIGH_DELTA_PENDING
-        ):
-            return None
-        if raw_validation not in {
-            "accepted_idle_zero",
-            "accepted_idle_repeated_sample",
-            "accepted_idle_delta",
-            _HEATPUMP_IDLE_HIGH_DELTA_PENDING,
-        }:
-            return None
         device_uid = coerce_optional_text(snapshot.get("split_device_uid"))
         day_key = coerce_optional_text(snapshot.get("day_key"))
         timezone_name = coerce_optional_text(snapshot.get("timezone"))
@@ -1217,11 +1219,7 @@ class HeatpumpRuntime:
             if sample_utc is None:
                 continue
             age_s = (current_sample_utc - sample_utc).total_seconds()
-            if not (
-                _HEATPUMP_IDLE_SMOOTHING_MIN_WINDOW_S
-                <= age_s
-                <= _HEATPUMP_IDLE_SMOOTHING_MAX_WINDOW_S
-            ):
+            if not (min_window_s <= age_s <= max_window_s):
                 continue
             if coerce_optional_text(entry.get("device_uid")) != device_uid:
                 continue
@@ -1262,15 +1260,79 @@ class HeatpumpRuntime:
             if delta_wh <= _HEATPUMP_POWER_MIN_DELTA_WH:
                 continue
             value_w = (delta_wh * 3600.0) / window_s
-            if value_w > _HEATPUMP_IDLE_POWER_MAX_W:
+            if max_power_w is not None and value_w > max_power_w:
                 continue
             return {
                 "accepted_value_w": value_w,
                 "window_seconds": window_s,
+                "delta_wh": delta_wh,
                 "series_start_utc": start_utc,
-                "validation": "smoothed_idle_delta",
+                "validation": validation,
             }
         return None
+
+    def _heatpump_idle_smoothed_power(
+        self,
+        snapshot: dict[str, object],
+        *,
+        current_energy_wh: float,
+        current_sample_utc: datetime,
+        raw_value_w: float | None,
+        raw_validation: str,
+    ) -> dict[str, object] | None:
+        if raw_value_w is None:
+            return None
+        if (
+            raw_value_w > _HEATPUMP_IDLE_POWER_MAX_W
+            and raw_validation != _HEATPUMP_IDLE_HIGH_DELTA_PENDING
+        ):
+            return None
+        if raw_validation not in {
+            "accepted_idle_zero",
+            "accepted_idle_repeated_sample",
+            "accepted_idle_delta",
+            _HEATPUMP_IDLE_HIGH_DELTA_PENDING,
+        }:
+            return None
+        return self._heatpump_smoothed_power_from_history(
+            snapshot,
+            current_energy_wh=current_energy_wh,
+            current_sample_utc=current_sample_utc,
+            min_window_s=_HEATPUMP_IDLE_SMOOTHING_MIN_WINDOW_S,
+            max_window_s=_HEATPUMP_IDLE_SMOOTHING_MAX_WINDOW_S,
+            max_power_w=_HEATPUMP_IDLE_POWER_MAX_W,
+            validation="smoothed_idle_delta",
+        )
+
+    def _heatpump_active_smoothed_power(
+        self,
+        snapshot: dict[str, object],
+        *,
+        current_energy_wh: float,
+        current_sample_utc: datetime,
+        raw_validation: str,
+        raw_window_s: float | None,
+    ) -> dict[str, object] | None:
+        if raw_validation not in {"accepted_delta", "accepted_zero_delta"}:
+            return None
+        if raw_validation == "accepted_zero_delta":
+            site_interval_s = coerce_optional_float(
+                snapshot.get("site_interval_seconds")
+            )
+            if (
+                site_interval_s is None
+                or raw_window_s is None
+                or raw_window_s >= site_interval_s
+            ):
+                return None
+        return self._heatpump_smoothed_power_from_history(
+            snapshot,
+            current_energy_wh=current_energy_wh,
+            current_sample_utc=current_sample_utc,
+            min_window_s=_HEATPUMP_ACTIVE_SMOOTHING_MIN_WINDOW_S,
+            max_window_s=_HEATPUMP_ACTIVE_SMOOTHING_MAX_WINDOW_S,
+            validation="smoothed_active_delta",
+        )
 
     def _heatpump_power_summary_from_daily_snapshot(
         self,
@@ -1322,6 +1384,7 @@ class HeatpumpRuntime:
         rejected = False
         validation = "accepted_delta"
         window_s = None
+        delta_wh = None
         series_start_utc = None
         idle_high_delta_pending = False
         power_source = "site_today_heatpump_delta"
@@ -1384,8 +1447,10 @@ class HeatpumpRuntime:
 
         raw_value = accepted_value
         raw_window_s = window_s
+        raw_delta_wh = delta_wh
         raw_validation = validation
         display_window_s = window_s
+        display_delta_wh = delta_wh
         display_validation = validation
         smoothed = False
         if (
@@ -1408,6 +1473,9 @@ class HeatpumpRuntime:
                 display_window_s = coerce_optional_float(
                     smoothed_summary.get("window_seconds")
                 )
+                display_delta_wh = coerce_optional_float(
+                    smoothed_summary.get("delta_wh")
+                )
                 smoothed_start = smoothed_summary.get("series_start_utc")
                 if isinstance(smoothed_start, datetime):
                     series_start_utc = smoothed_start
@@ -1419,6 +1487,35 @@ class HeatpumpRuntime:
                 rejected = True
                 validation = "rejected_idle_high_delta"
                 display_validation = validation
+        elif (
+            not is_idle
+            and not rejected
+            and current_energy_wh is not None
+            and current_sample_utc is not None
+        ):
+            smoothed_summary = self._heatpump_active_smoothed_power(
+                snapshot,
+                current_energy_wh=current_energy_wh,
+                current_sample_utc=current_sample_utc,
+                raw_validation=raw_validation,
+                raw_window_s=raw_window_s,
+            )
+            if smoothed_summary is not None:
+                accepted_value = coerce_optional_float(
+                    smoothed_summary.get("accepted_value_w")
+                )
+                display_window_s = coerce_optional_float(
+                    smoothed_summary.get("window_seconds")
+                )
+                display_delta_wh = coerce_optional_float(
+                    smoothed_summary.get("delta_wh")
+                )
+                smoothed_start = smoothed_summary.get("series_start_utc")
+                if isinstance(smoothed_start, datetime):
+                    series_start_utc = smoothed_start
+                display_validation = str(smoothed_summary["validation"])
+                validation = display_validation
+                smoothed = True
 
         summary: dict[str, object] = {
             "requested_device_ref": (
@@ -1466,6 +1563,12 @@ class HeatpumpRuntime:
             ),
             "power_window_seconds": (
                 round(display_window_s, 3) if display_window_s is not None else None
+            ),
+            "raw_delta_wh": (
+                round(raw_delta_wh, 3) if raw_delta_wh is not None else None
+            ),
+            "power_delta_wh": (
+                round(display_delta_wh, 3) if display_delta_wh is not None else None
             ),
             "daily_energy_wh": snapshot.get("daily_energy_wh"),
             "split_daily_energy_wh": snapshot.get("split_daily_energy_wh"),
@@ -2013,7 +2116,7 @@ class HeatpumpRuntime:
             )
             power_snapshot["last_error"] = error
             power_snapshot["outcome"] = "rejected_value"
-            if error == "rejected_idle_high_delta":
+            if error in {"rejected_idle_high_delta", "seeded_waiting_for_delta"}:
                 self._record_heatpump_power_history_sample(
                     getattr(self, "_heatpump_daily_consumption", None)
                 )
@@ -2021,6 +2124,11 @@ class HeatpumpRuntime:
                 now=now,
                 error=error,
                 power_snapshot=power_snapshot,
+                stale_after_s=(
+                    _HEATPUMP_POWER_SEEDED_STALE_AFTER_S
+                    if error in _HEATPUMP_POWER_HOLD_STALE_ERRORS
+                    else HEATPUMP_POWER_STALE_AFTER_S
+                ),
             )
             self._heatpump_power_backoff_until = getattr(
                 self, "_heatpump_daily_consumption_backoff_until", None

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -1000,7 +1000,7 @@ Observed structure:
 - `stats[0]` contains 96 quarter-hour buckets (`interval_length=900`) plus a `totals` object using the same metric names.
 - The payload co-locates energy-flow arrays, battery state, connection details, and internal logging strings in one response.
 - `heatpump` can be populated even when `production` and `evse` are all zero for the same day.
-- The integration treats this `heatpump` daily total as the authoritative displayed heat-pump energy and the source for derived heat-pump power. The HEMS `energy-consumption` endpoint is optional split metadata for diagnostics and source attribution.
+- The integration treats this `heatpump` daily total as the authoritative displayed heat-pump energy and the source for derived heat-pump power. Running and idle power may be smoothed over longer same-day monotonic energy windows when enough history is available, with raw delta values retained in diagnostics. The HEMS `energy-consumption` endpoint is optional split metadata for diagnostics and source attribution.
 - `siteStatus="normal"` coexisted with `statusDetails.statusSeverity="warning"` in the observed capture.
 - `batteryConfig` mirrors several BatteryConfig-service concepts (`usage`, backup percentage, grid-mode settings, storm state) but adds internal class/ID fields and gateway-serial keyed maps.
 

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -90,6 +90,7 @@ def _heatpump_daily_snapshot(
     timezone_name: str = "UTC",
     device_uid: str | None = "HP-1",
     daily_energy_wh: float | None = None,
+    site_interval_seconds: float | None = None,
 ) -> dict[str, object]:
     if daily_energy_wh is None:
         daily_energy_wh = energy_wh
@@ -109,6 +110,7 @@ def _heatpump_daily_snapshot(
         "endpoint_timestamp": timestamp,
         "sampled_at_utc": parsed.isoformat() if parsed is not None else None,
         "sample_timestamp_source": "last_report_date",
+        "site_interval_seconds": site_interval_seconds,
         "split_endpoint_type": "hems-device-details",
         "split_endpoint_timestamp": timestamp,
         "day_key": day_key,
@@ -270,6 +272,43 @@ async def test_heatpump_power_continues_when_hems_site_is_unsupported(
     assert (
         coord._heatpump_power_snapshot["outcome"] == "selected_sample"
     )  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_heatpump_power_holds_stale_running_repeated_site_sample(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+    _seed_heatpump_auth_test_topology(coord)
+    coord.client.hems_heatpump_state = AsyncMock(
+        return_value={"device_uid": "HP-1", "heatpump_status": "RUNNING"}
+    )
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(100.0, timestamp="2026-04-05T00:05:00Z")
+    )
+    coord.client.hems_energy_consumption = AsyncMock(return_value=None)
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        energy_wh=100.0,
+        daily_energy_wh=100.0,
+        timestamp="2026-04-05T00:05:00Z",
+        day_key="2026-04-05",
+        timezone_name="UTC",
+    )
+    now = time.monotonic()
+    runtime._heatpump_power_w = 512.0  # noqa: SLF001
+    runtime._heatpump_power_last_success_mono = now - 120.0  # noqa: SLF001
+    runtime._heatpump_power_last_success_utc = datetime(  # noqa: SLF001
+        2026, 4, 5, 0, 4, tzinfo=timezone.utc
+    )
+
+    await runtime._async_refresh_heatpump_power(force=True)  # noqa: SLF001
+
+    assert coord.heatpump_power_w == pytest.approx(512.0)
+    assert coord.heatpump_power_using_stale is True
+    assert coord.heatpump_power_last_error == "repeated_sample"
+    assert coord._heatpump_power_snapshot["using_stale"] is True  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -657,7 +696,7 @@ def test_heatpump_power_summary_rejects_unsmoothed_idle_high_delta(
     assert summary["rejected"] is True
 
 
-def test_heatpump_power_summary_does_not_smooth_non_idle_zero(
+def test_heatpump_power_summary_smooths_running_zero_from_history(
     coordinator_factory,
 ) -> None:
     runtime = coordinator_factory(serials=[]).heatpump_runtime
@@ -681,12 +720,125 @@ def test_heatpump_power_summary_does_not_smooth_non_idle_zero(
         _heatpump_daily_snapshot(
             energy_wh=105.0,
             timestamp="2026-04-02T00:20:00Z",
+            site_interval_seconds=900.0,
+        ),
+        runtime_snapshot={"heatpump_status": "RUNNING"},
+    )
+
+    assert summary is not None
+    assert summary["raw_value_w"] == pytest.approx(0.0)
+    assert summary["raw_validation"] == "accepted_zero_delta"
+    assert summary["accepted_value_w"] == pytest.approx(15.0)
+    assert summary["power_window_seconds"] == pytest.approx(1200.0)
+    assert summary["power_validation"] == "smoothed_active_delta"
+    assert summary["smoothed"] is True
+
+
+def test_heatpump_power_summary_smooths_running_spike_from_history(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 200.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 15, tzinfo=timezone.utc),
+        },
+    ]
+    runtime._heatpump_daily_consumption_previous = (  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=200.0,
+            timestamp="2026-04-02T00:15:00Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=250.0,
+            timestamp="2026-04-02T00:20:00Z",
+            site_interval_seconds=900.0,
+        ),
+        runtime_snapshot={"heatpump_status": "RUNNING"},
+    )
+
+    assert summary is not None
+    assert summary["raw_value_w"] == pytest.approx(600.0)
+    assert summary["raw_window_seconds"] == pytest.approx(300.0)
+    assert summary["raw_delta_wh"] == pytest.approx(50.0)
+    assert summary["accepted_value_w"] == pytest.approx(450.0)
+    assert summary["power_window_seconds"] == pytest.approx(1200.0)
+    assert summary["power_delta_wh"] == pytest.approx(150.0)
+    assert summary["power_validation"] == "smoothed_active_delta"
+    assert summary["smoothed"] is True
+
+
+def test_heatpump_power_summary_keeps_running_raw_without_history(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_daily_consumption_previous = (  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=200.0,
+            timestamp="2026-04-02T00:15:00Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=250.0,
+            timestamp="2026-04-02T00:20:00Z",
+        ),
+        runtime_snapshot={"heatpump_status": "RUNNING"},
+    )
+
+    assert summary is not None
+    assert summary["raw_value_w"] == pytest.approx(600.0)
+    assert summary["accepted_value_w"] == pytest.approx(600.0)
+    assert summary["power_validation"] == "accepted_delta"
+    assert summary["smoothed"] is False
+
+
+def test_heatpump_power_summary_keeps_running_zero_after_full_site_interval(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        }
+    ]
+    runtime._heatpump_daily_consumption_previous = (
+        _heatpump_daily_snapshot(  # noqa: SLF001
+            energy_wh=105.0,
+            timestamp="2026-04-02T00:05:00Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=105.0,
+            timestamp="2026-04-02T00:20:00Z",
+            site_interval_seconds=900.0,
         ),
         runtime_snapshot={"heatpump_status": "RUNNING"},
     )
 
     assert summary is not None
     assert summary["accepted_value_w"] == pytest.approx(0.0)
+    assert summary["raw_validation"] == "accepted_zero_delta"
     assert summary["power_validation"] == "accepted_zero_delta"
     assert summary["smoothed"] is False
 
@@ -871,6 +1023,34 @@ def test_heatpump_power_history_helpers_cover_guard_paths(
     ]
 
 
+def test_heatpump_mark_power_stale_can_extend_seeded_stale_window(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    now = time.monotonic()
+    runtime._heatpump_power_w = 512.0  # noqa: SLF001
+    runtime._heatpump_power_last_success_mono = now - 120.0  # noqa: SLF001
+    runtime._heatpump_power_last_success_utc = datetime(  # noqa: SLF001
+        2026, 4, 2, 0, 0, tzinfo=timezone.utc
+    )
+    power_snapshot: dict[str, object] = {}
+
+    assert (
+        runtime._heatpump_mark_power_stale(  # noqa: SLF001
+            now=now,
+            error="seeded_waiting_for_delta",
+            power_snapshot=power_snapshot,
+            stale_after_s=30 * 60.0,
+        )
+        is True
+    )
+
+    assert runtime.heatpump_power_w == pytest.approx(512.0)
+    assert runtime.heatpump_power_using_stale is True
+    assert runtime.heatpump_power_last_error == "seeded_waiting_for_delta"
+    assert power_snapshot["using_stale"] is True
+
+
 @pytest.mark.asyncio
 async def test_refresh_heatpump_power_records_rejected_idle_high_delta_history(
     coordinator_factory,
@@ -965,6 +1145,16 @@ def test_heatpump_idle_smoothing_rejects_invalid_history(
             current_sample_utc=current_sample_utc,
             raw_value_w=25.0,
             raw_validation="accepted_idle_delta",
+        )
+        is None
+    )
+    assert (
+        runtime._heatpump_active_smoothed_power(  # noqa: SLF001
+            snapshot,
+            current_energy_wh=105.0,
+            current_sample_utc=current_sample_utc,
+            raw_validation="repeated_sample",
+            raw_window_s=300.0,
         )
         is None
     )
@@ -3103,10 +3293,16 @@ def test_heatpump_runtime_refresh_due_skips_when_type_missing_and_no_state(
         is None
     )
 
+    assert runtime._site_today_heatpump_numeric_total({"a": {"b": 2}}) is None
     assert runtime._site_today_heatpump_numeric_total(
-        {"a": {"b": 2}}
+        {"consumed_wh": 500, "produced_wh": 200}
     ) == pytest.approx(  # noqa: SLF001
-        2.0
+        500.0
+    )
+    assert runtime._site_today_heatpump_numeric_total(
+        {"value": [1, {"total": 2}]}
+    ) == pytest.approx(  # noqa: SLF001
+        3.0
     )
     assert (
         runtime._site_today_heatpump_numeric_total({"a": "bad"}) is None
@@ -3114,7 +3310,7 @@ def test_heatpump_runtime_refresh_due_skips_when_type_missing_and_no_state(
     assert runtime._site_today_heatpump_numeric_total(
         [1, {"a": 2}]
     ) == pytest.approx(  # noqa: SLF001
-        3.0
+        1.0
     )
     assert (
         runtime._site_today_heatpump_numeric_total([None, "bad"]) is None

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -10,6 +10,7 @@ from homeassistant.exceptions import ServiceValidationError
 
 from custom_components.enphase_ev import coordinator as coord_mod
 from custom_components.enphase_ev import sensor as sensor_mod
+from custom_components.enphase_ev import tariff as tariff_mod
 from custom_components.enphase_ev.api import OptionalEndpointUnavailable
 from custom_components.enphase_ev.const import DOMAIN
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
@@ -2680,7 +2681,14 @@ def test_tariff_runtime_diagnostics(coordinator_factory) -> None:
 
 def test_tariff_sensors_expose_state_attributes_and_gateway_device(
     coordinator_factory,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(
+        tariff_mod.dt_util,
+        "now",
+        lambda time_zone=None: datetime(2026, 4, 26, tzinfo=time_zone or timezone.utc),
+    )
+
     coord = coordinator_factory()
     coord.tariff_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
     coord.tariff_billing = parse_tariff_billing(


### PR DESCRIPTION
## Summary

- Smooth RUNNING Heat Pump power over longer same-day monotonic site-today energy windows to reduce short-window spikes from lumpy cloud updates.
- Hold recent Heat Pump power during repeated site-today samples and day-rollover seed samples so the sensor does not briefly drop unavailable.
- Keep raw delta diagnostics, bound active zero smoothing by the site interval, and harden site-today heat-pump total parsing for nested payloads.

## Related Issues

Related: #680.
Follows #684.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_heatpump_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py && ruff check custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git status --short --branch && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q --ignore=tests/components/enphase_ev/test_tariff.py && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/heatpump_runtime.py --fail-under=100"
```

Full component suite note:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/heatpump_runtime.py --fail-under=100"
```

This currently fails in `tests/components/enphase_ev/test_tariff.py::test_tariff_sensors_expose_state_attributes_and_gateway_device`, where the date-sensitive tariff assertion expects `2026-05-18` but the current date resolves the next bill date to `2026-06-18`. The same coverage command passes when that unrelated tariff file is excluded, with `heatpump_runtime.py` at 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The pre-commit command mounts the repository Git metadata because this Codex checkout is a Git worktree and Docker otherwise cannot resolve the host `.git/worktrees/...` path.
