### PR TITLE
Add rolling refresh telemetry

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -154,6 +154,7 @@ from .session_history import (
     SESSION_HISTORY_FAILURE_BACKOFF_S,
     SessionHistoryManager,
 )
+from .coordinator_refresh_metrics import record_refresh_performance_sample
 from .summary import SummaryStore
 from . import system_dashboard_helpers as sd_helpers
 from .refresh_plan import (
@@ -2902,6 +2903,20 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 self._last_fast_refresh_cloud_calls = request_count
             else:
                 self._last_steady_refresh_cloud_calls = request_count
+        else:
+            request_count = None
+        self._refresh_performance_history = record_refresh_performance_sample(
+            getattr(self, "_refresh_performance_history", []),
+            phase_timings,
+            refresh_started_utc=context.refresh_started_utc,
+            latency_ms=self.latency_ms,
+            cloud_calls=request_count,
+            fast_poll=context.fast_poll,
+            first_refresh=context.first_refresh,
+            payload_using_stale=getattr(context, "status_used_stale", False)
+            or bool(getattr(self, "payload_using_stale", False)),
+            manual_bypass=self.endpoint_manual_bypass_active(),
+        )
         if context.first_refresh:
             self._bootstrap_phase_timings = phase_timings.copy()
         self._refresh_cached_topology()

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -28,7 +28,10 @@ from .const import (
     ISSUE_SITE_ENERGY_UNAVAILABLE,
     OPT_DEGRADED_SERVICE_REPAIR_ISSUES,
 )
-from .coordinator_refresh_metrics import refresh_performance_summary
+from .coordinator_refresh_metrics import (
+    refresh_performance_history_summary,
+    refresh_performance_summary,
+)
 from .log_redaction import redact_text
 from .tariff import TARIFF_ENDPOINT_FAMILY
 
@@ -381,6 +384,9 @@ class CoordinatorDiagnostics:
                     coord, "_last_steady_refresh_cloud_calls", None
                 ),
                 fast_cloud_calls=getattr(coord, "_last_fast_refresh_cloud_calls", None),
+            ),
+            "refresh_performance_history": refresh_performance_history_summary(
+                getattr(coord, "_refresh_performance_history", [])
             ),
             "bootstrap_phase_timings": coord.bootstrap_phase_timings,
             "warmup_phase_timings": coord.warmup_phase_timings,

--- a/custom_components/enphase_ev/coordinator_refresh_metrics.py
+++ b/custom_components/enphase_ev/coordinator_refresh_metrics.py
@@ -2,8 +2,44 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from datetime import datetime
+from math import ceil
+
 REFRESH_TOTAL_BUDGET_S = 30.0
 REFRESH_STAGE_BUDGET_S = 5.0
+REFRESH_PERFORMANCE_HISTORY_LIMIT = 50
+
+
+def _clean_phase_timings(phase_timings: dict[str, float]) -> dict[str, float]:
+    timings: dict[str, float] = {}
+    for key, value in (phase_timings or {}).items():
+        try:
+            timing = float(value)
+        except (TypeError, ValueError):
+            continue
+        if timing < 0:
+            continue
+        timings[str(key)] = round(timing, 3)
+    return timings
+
+
+def _percentile(values: Iterable[float], percentile: float) -> float | None:
+    ordered = sorted(float(value) for value in values)
+    if not ordered:
+        return None
+    rank = max(1, ceil((percentile / 100.0) * len(ordered)))
+    return round(ordered[min(rank, len(ordered)) - 1], 3)
+
+
+def _numeric_summary(values: Iterable[float]) -> dict[str, object]:
+    ordered = sorted(float(value) for value in values)
+    return {
+        "count": len(ordered),
+        "p50_s": _percentile(ordered, 50),
+        "p95_s": _percentile(ordered, 95),
+        "max_s": round(ordered[-1], 3) if ordered else None,
+    }
 
 
 def refresh_performance_summary(
@@ -18,16 +54,7 @@ def refresh_performance_summary(
 ) -> dict[str, object]:
     """Return a compact refresh timing budget summary."""
 
-    timings: dict[str, float] = {}
-    for key, value in (phase_timings or {}).items():
-        try:
-            timing = float(value)
-        except (TypeError, ValueError):
-            continue
-        if timing < 0:
-            continue
-        timings[str(key)] = round(timing, 3)
-
+    timings = _clean_phase_timings(phase_timings)
     stage_timings = {key: value for key, value in timings.items() if key != "total_s"}
     total_s = timings.get("total_s")
     if total_s is None and latency_ms is not None:
@@ -61,4 +88,117 @@ def refresh_performance_summary(
         "cloud_calls": cloud_calls,
         "steady_cloud_calls": steady_cloud_calls,
         "fast_cloud_calls": fast_cloud_calls,
+    }
+
+
+def record_refresh_performance_sample(
+    history: list[dict[str, object]],
+    phase_timings: dict[str, float],
+    *,
+    refresh_started_utc: datetime | None = None,
+    latency_ms: int | None = None,
+    cloud_calls: int | None = None,
+    fast_poll: bool = False,
+    first_refresh: bool = False,
+    payload_using_stale: bool = False,
+    manual_bypass: bool = False,
+    max_samples: int = REFRESH_PERFORMANCE_HISTORY_LIMIT,
+) -> list[dict[str, object]]:
+    """Append a diagnostics-safe refresh sample and return the trimmed history."""
+
+    timings = _clean_phase_timings(phase_timings)
+    if not timings and latency_ms is None:
+        return list(history or [])[-max_samples:]
+
+    summary = refresh_performance_summary(
+        timings,
+        latency_ms=latency_ms,
+        cloud_calls=cloud_calls,
+    )
+    sample: dict[str, object] = {
+        "phase_timings": timings,
+        "total_s": summary["total_s"],
+        "slowest_stage": summary["slowest_stage"],
+        "slowest_stage_s": summary["slowest_stage_s"],
+        "cloud_calls": cloud_calls,
+        "fast_poll": bool(fast_poll),
+        "first_refresh": bool(first_refresh),
+        "payload_using_stale": bool(payload_using_stale),
+        "manual_bypass": bool(manual_bypass),
+    }
+    if refresh_started_utc is not None:
+        try:
+            sample["started_utc"] = refresh_started_utc.isoformat()
+        except Exception:
+            sample["started_utc"] = str(refresh_started_utc)
+
+    samples = [dict(item) for item in (history or []) if isinstance(item, dict)]
+    samples.append(sample)
+    limit = max(1, int(max_samples or REFRESH_PERFORMANCE_HISTORY_LIMIT))
+    return samples[-limit:]
+
+
+def refresh_performance_history_summary(
+    history: list[dict[str, object]],
+) -> dict[str, object]:
+    """Summarize rolling refresh samples for diagnostics."""
+
+    samples = [sample for sample in (history or []) if isinstance(sample, dict)]
+    total_values: list[float] = []
+    cloud_call_values: list[float] = []
+    stage_values: dict[str, list[float]] = {}
+    fast_count = 0
+    first_refresh_count = 0
+    stale_count = 0
+    manual_bypass_count = 0
+    for sample in samples:
+        if sample.get("fast_poll"):
+            fast_count += 1
+        if sample.get("first_refresh"):
+            first_refresh_count += 1
+        if sample.get("payload_using_stale"):
+            stale_count += 1
+        if sample.get("manual_bypass"):
+            manual_bypass_count += 1
+        try:
+            total = float(sample["total_s"])
+        except (KeyError, TypeError, ValueError):
+            total = None
+        if total is not None and total >= 0:
+            total_values.append(total)
+        try:
+            cloud_calls = float(sample["cloud_calls"])
+        except (KeyError, TypeError, ValueError):
+            cloud_calls = None
+        if cloud_calls is not None and cloud_calls >= 0:
+            cloud_call_values.append(cloud_calls)
+        phase_timings = sample.get("phase_timings")
+        if not isinstance(phase_timings, dict):
+            continue
+        for key, value in _clean_phase_timings(phase_timings).items():
+            if key == "total_s":
+                continue
+            stage_values.setdefault(key, []).append(value)
+
+    cloud_summary = _numeric_summary(cloud_call_values)
+    return {
+        "sample_count": len(samples),
+        "window_size": REFRESH_PERFORMANCE_HISTORY_LIMIT,
+        "fast_poll_count": fast_count,
+        "steady_poll_count": max(0, len(samples) - fast_count),
+        "first_refresh_count": first_refresh_count,
+        "payload_using_stale_count": stale_count,
+        "manual_bypass_count": manual_bypass_count,
+        "total_s": _numeric_summary(total_values),
+        "cloud_calls": {
+            "count": cloud_summary["count"],
+            "p50": cloud_summary["p50_s"],
+            "p95": cloud_summary["p95_s"],
+            "max": cloud_summary["max_s"],
+        },
+        "stages": {
+            key: _numeric_summary(values)
+            for key, values in sorted(stage_values.items())
+        },
+        "latest": dict(samples[-1]) if samples else None,
     }

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -153,6 +153,7 @@ class RefreshHealthState:
     _phase_timings: dict[str, float] = field(default_factory=dict)
     _bootstrap_phase_timings: dict[str, float] = field(default_factory=dict)
     _warmup_phase_timings: dict[str, float] = field(default_factory=dict)
+    _refresh_performance_history: list[dict[str, object]] = field(default_factory=list)
     _has_successful_refresh: bool = False
     _session_history_cache_shim: dict[tuple[str, str], tuple[float, list[dict]]] = (
         field(default_factory=dict)

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2074,6 +2074,39 @@ def test_refresh_performance_history_summary_reports_percentiles() -> None:
     }
 
 
+def test_refresh_performance_history_handles_defensive_paths() -> None:
+    class BrokenStarted:
+        def isoformat(self) -> str:
+            raise ValueError("bad timestamp")
+
+        def __str__(self) -> str:
+            return "broken-started"
+
+    existing = [{"total_s": 1.0}]
+
+    assert record_refresh_performance_sample(existing, {}, max_samples=1) == existing
+
+    history = record_refresh_performance_sample(
+        [{"not": "a timing"}],
+        {"status_s": 0.1},
+        refresh_started_utc=BrokenStarted(),  # type: ignore[arg-type]
+        max_samples=2,
+    )
+    assert history[-1]["started_utc"] == "broken-started"
+
+    summary = refresh_performance_history_summary(
+        [
+            {"total_s": "bad", "cloud_calls": "bad", "phase_timings": []},
+            {"total_s": 0.5, "cloud_calls": 2, "phase_timings": {"status_s": 0.1}},
+        ]
+    )
+
+    assert summary["sample_count"] == 2
+    assert summary["total_s"]["count"] == 1
+    assert summary["cloud_calls"]["count"] == 1
+    assert summary["stages"]["status_s"]["count"] == 1
+
+
 def test_collect_site_metrics_skips_negative_hems_age(hass, monkeypatch):
     coord = _make_coordinator(hass, monkeypatch)
     coord._hems_devices_last_success_mono = time.monotonic() + 5  # noqa: SLF001

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -36,6 +36,9 @@ from custom_components.enphase_ev.evse_runtime import (
     ChargeModeResolution,
 )
 from custom_components.enphase_ev.coordinator_refresh_metrics import (
+    REFRESH_PERFORMANCE_HISTORY_LIMIT,
+    record_refresh_performance_sample,
+    refresh_performance_history_summary,
     refresh_performance_summary,
 )
 from custom_components.enphase_ev.session_history import (
@@ -1991,6 +1994,7 @@ def test_collect_site_metrics_and_placeholders(hass, monkeypatch):
         "steady_cloud_calls": 3,
         "fast_cloud_calls": 7,
     }
+    assert metrics["refresh_performance_history"]["sample_count"] == 0
     assert metrics["hems_devices_data_stale"] is True
     assert metrics["hems_devices_last_success_utc"] == now.isoformat()
     assert metrics["hems_devices_last_success_age_s"] >= 0
@@ -2018,13 +2022,56 @@ def test_refresh_pipeline_records_cloud_call_counts(hass, monkeypatch) -> None:
     coord._finish_refresh_pipeline(context)  # noqa: SLF001
     assert coord._last_refresh_cloud_calls == 4  # noqa: SLF001
     assert coord._last_steady_refresh_cloud_calls == 4  # noqa: SLF001
+    assert coord._refresh_performance_history[-1]["cloud_calls"] == 4  # noqa: SLF001
+    assert coord._refresh_performance_history[-1]["fast_poll"] is False  # noqa: SLF001
 
     context = coord._start_refresh_pipeline()  # noqa: SLF001
     context.fast_poll = True
+    context.phase_timings["status_s"] = 0.2
     client.request_count = 6
     coord._finish_refresh_pipeline(context)  # noqa: SLF001
     assert coord._last_refresh_cloud_calls == 6  # noqa: SLF001
     assert coord._last_fast_refresh_cloud_calls == 6  # noqa: SLF001
+    assert coord._refresh_performance_history[-1]["cloud_calls"] == 6  # noqa: SLF001
+    assert coord._refresh_performance_history[-1]["fast_poll"] is True  # noqa: SLF001
+
+
+def test_refresh_performance_history_summary_reports_percentiles() -> None:
+    history = []
+    for index in range(1, REFRESH_PERFORMANCE_HISTORY_LIMIT + 3):
+        history = record_refresh_performance_sample(
+            history,
+            {"status_s": index / 10, "total_s": index / 5},
+            cloud_calls=index,
+            fast_poll=index % 2 == 0,
+            first_refresh=index == 1,
+            payload_using_stale=index == 3,
+            manual_bypass=index == 4,
+        )
+
+    summary = refresh_performance_history_summary(history)
+
+    assert len(history) == REFRESH_PERFORMANCE_HISTORY_LIMIT
+    assert summary["sample_count"] == REFRESH_PERFORMANCE_HISTORY_LIMIT
+    assert summary["fast_poll_count"] == 25
+    assert summary["steady_poll_count"] == 25
+    assert summary["first_refresh_count"] == 0
+    assert summary["payload_using_stale_count"] == 1
+    assert summary["manual_bypass_count"] == 1
+    assert summary["total_s"]["p50_s"] == 5.4
+    assert summary["total_s"]["p95_s"] == 10.0
+    assert summary["stages"]["status_s"] == {
+        "count": REFRESH_PERFORMANCE_HISTORY_LIMIT,
+        "p50_s": 2.7,
+        "p95_s": 5.0,
+        "max_s": 5.2,
+    }
+    assert summary["cloud_calls"] == {
+        "count": REFRESH_PERFORMANCE_HISTORY_LIMIT,
+        "p50": 27.0,
+        "p95": 50.0,
+        "max": 52.0,
+    }
 
 
 def test_collect_site_metrics_skips_negative_hems_age(hass, monkeypatch):

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -2680,6 +2680,7 @@ def test_tariff_runtime_diagnostics(coordinator_factory) -> None:
 
 def test_tariff_sensors_expose_state_attributes_and_gateway_device(
     coordinator_factory,
+    monkeypatch,
 ) -> None:
     coord = coordinator_factory()
     coord.tariff_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
@@ -2708,6 +2709,10 @@ def test_tariff_sensors_expose_state_attributes_and_gateway_device(
             },
         },
         "purchase",
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.tariff.dt_util.now",
+        lambda: datetime(2026, 4, 26, tzinfo=timezone.utc),
     )
 
     billing_sensor = EnphaseTariffBillingSensor(coord)


### PR DESCRIPTION
## Summary

- Add a bounded rolling refresh performance history for coordinator refreshes.
- Record total refresh time, phase timings, cloud-call counts, fast/steady poll state, first-refresh state, stale payload use, and manual endpoint bypass state.
- Expose `refresh_performance_history` in site diagnostics with p50/p95/max summaries for total refresh duration, per-stage duration, and cloud calls.
- Freeze the tariff billing sensor test clock so the expected next billing date is deterministic.

## Testing

- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/coordinator_refresh_metrics.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_coordinator_behavior.py"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_behavior.py::test_collect_site_metrics_and_placeholders tests/components/enphase_ev/test_coordinator_behavior.py::test_refresh_pipeline_records_cloud_call_counts tests/components/enphase_ev/test_coordinator_behavior.py::test_refresh_performance_history_summary_reports_percentiles tests/components/enphase_ev/test_coordinator_behavior.py::test_refresh_performance_summary_flags_budget_and_bad_timings tests/components/enphase_ev/test_performance_audit_regressions.py"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_tariff.py::test_tariff_sensors_expose_state_attributes_and_gateway_device"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_tariff.py && black tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_tariff.py --check"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_behavior.py::test_refresh_performance_history_handles_defensive_paths tests/components/enphase_ev/test_coordinator_behavior.py::test_refresh_performance_history_summary_reports_percentiles tests/components/enphase_ev/test_tariff.py::test_tariff_sensors_expose_state_attributes_and_gateway_device"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/coordinator_refresh_metrics.py,custom_components/enphase_ev/state_models.py --fail-under=100"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger:/Users/james/Documents/GitHub/ha-enphase-ev-charger ha-dev bash -lc "python -m pre_commit run --all-files"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"`
