### PR TITLE
Fix battery profile confirmation state

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -3621,6 +3621,33 @@ class EnphaseEVClient:
                     if err.status == HTTPStatus.UNAUTHORIZED:
                         raise
                     last_error = err
+                    retry_profile_without_devices = (
+                        write_intent == "profile_update"
+                        and err.status == HTTPStatus.BAD_REQUEST
+                        and isinstance(attempt_json_body, dict)
+                        and "devices" in attempt_json_body
+                        and index < len(attempts) - 1
+                    )
+                    if retry_profile_without_devices:
+                        next_attempt = attempts[index + 1]
+                        next_json_body = self._battery_config_attempt_json_body(
+                            json_body,
+                            family,
+                            next_attempt,
+                        )
+                        next_has_devices = (
+                            isinstance(next_json_body, dict)
+                            and "devices" in next_json_body
+                        )
+                        _LOGGER.debug(
+                            "Retrying BatteryConfig profile write for %s after "
+                            "HTTP 400 with devices (next_attempt=%s, "
+                            "next_devices=%s)",
+                            _request_label(method, url),
+                            next_attempt.attempt_id,
+                            "kept" if next_has_devices else "stripped",
+                        )
+                        continue
                     if err.status != HTTPStatus.FORBIDDEN:
                         raise
                     if index == len(attempts) - 1:

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -399,6 +399,31 @@ class BatteryRuntime:
         state._battery_backend_not_pending_observed_at = None
         self._sync_battery_profile_pending_issue()
 
+    def confirm_battery_pending(self) -> None:
+        state = self.battery_state
+        pending_profile = getattr(state, "_battery_pending_profile", None)
+        if pending_profile and (
+            getattr(state, "_battery_profile", None) == pending_profile
+            or getattr(state, "_battery_live_profile", None) == pending_profile
+        ):
+            pending_reserve = getattr(state, "_battery_pending_reserve", None)
+            pending_sub_type = self._normalize_battery_sub_type(
+                getattr(state, "_battery_pending_sub_type", None)
+            )
+            state._battery_profile = pending_profile
+            if pending_reserve is not None:
+                normalized_reserve = self.normalize_battery_reserve_for_profile(
+                    pending_profile,
+                    pending_reserve,
+                )
+                state._battery_backup_percentage = normalized_reserve
+                self.remember_battery_reserve(pending_profile, normalized_reserve)
+            if pending_profile in {"cost_savings", "ai_optimisation"}:
+                state._battery_operation_mode_sub_type = pending_sub_type
+            else:
+                state._battery_operation_mode_sub_type = None
+        self.clear_battery_pending()
+
     def clear_battery_settings_write_pending(self) -> None:
         self.battery_state._battery_settings_last_write_mono = None
 
@@ -648,7 +673,7 @@ class BatteryRuntime:
             state._battery_backend_not_pending_observed_at = None
             return
         if self.effective_profile_matches_pending():
-            self.clear_battery_pending()
+            self.confirm_battery_pending()
             return
         now = dt_util.utcnow()
         first_observed = getattr(
@@ -1903,7 +1928,7 @@ class BatteryRuntime:
                     profile=normalized_profile,
                     battery_backup_percentage=normalized_reserve,
                     operation_mode_sub_type=normalized_sub_type,
-                    devices=coord.battery_profile_devices_payload(),
+                    devices=None,
                 )
             except aiohttp.ClientResponseError as err:
                 if err.status == HTTPStatus.FORBIDDEN:
@@ -2365,7 +2390,7 @@ class BatteryRuntime:
         self.sync_backend_battery_profile_pending(data.get("isBatteryChangePending"))
 
         if self.effective_profile_matches_pending():
-            self.clear_battery_pending()
+            self.confirm_battery_pending()
 
     def parse_battery_status_payload(self, payload: object) -> None:
         state = self.battery_state
@@ -2555,7 +2580,7 @@ class BatteryRuntime:
         self._sync_ac_battery_from_battery_status(snapshots)
         self._refresh_cached_topology()
         if self.effective_profile_matches_pending():
-            self.clear_battery_pending()
+            self.confirm_battery_pending()
 
     def _sync_ac_battery_from_battery_status(
         self, snapshots: dict[str, dict[str, object]]
@@ -2936,7 +2961,7 @@ class BatteryRuntime:
         self.sync_backend_battery_profile_pending(data.get("isBatteryChangePending"))
 
         if self.effective_profile_matches_pending():
-            self.clear_battery_pending()
+            self.confirm_battery_pending()
 
     def parse_battery_schedules_payload(self, payload: object) -> None:
         state = self.battery_state

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -6182,6 +6182,36 @@ async def test_set_battery_profile_retries_without_devices_then_without_source()
 
 
 @pytest.mark.asyncio
+async def test_set_battery_profile_retries_without_devices_after_400() -> None:
+    client = _make_client()
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._json = AsyncMock(
+        side_effect=[
+            _make_cre(400, "Bad Request"),
+            {"message": "success"},
+        ]
+    )
+
+    out = await client.set_battery_profile(
+        profile="backup_only",
+        battery_backup_percentage=100,
+        devices=[{"uuid": "abc", "deviceType": "iqEvse", "enable": False}],
+    )
+
+    assert out == {"message": "success"}
+    first_call, second_call = client._json.await_args_list
+    assert first_call.kwargs["json"] == {
+        "profile": "backup_only",
+        "batteryBackupPercentage": 100,
+        "devices": [{"uuid": "abc", "deviceType": "iqEvse", "enable": False}],
+    }
+    assert second_call.kwargs["json"] == {
+        "profile": "backup_only",
+        "batteryBackupPercentage": 100,
+    }
+
+
+@pytest.mark.asyncio
 async def test_set_battery_settings_retries_disclaimer_as_boolean_true_after_403() -> (
     None
 ):

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -1109,6 +1109,7 @@ def test_battery_runtime_parse_profile_payload_branches_and_helpers(
     payload = coord._battery_profile_devices_payload()  # noqa: SLF001
     assert payload is not None
     assert len(payload) == 3
+    assert payload[0]["deviceType"] == "iqEvse"
     assert payload[0].get("chargeMode") is None
     assert payload[1]["chargeMode"] == "MANUAL"
     assert payload[2]["chargeMode"] == "SCHEDULED"

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -137,6 +137,7 @@ async def test_set_system_profile_uses_remembered_reserve(coordinator_factory) -
     kwargs = coord.client.set_battery_profile.await_args.kwargs
     assert kwargs["profile"] == "cost_savings"
     assert kwargs["battery_backup_percentage"] == 35
+    assert kwargs["devices"] is None
     assert coord.battery_pending_profile == "cost_savings"
     assert coord.battery_pending_backup_percentage == 35
     assert coord._battery_pending_require_exact_settings is False  # noqa: SLF001
@@ -1492,6 +1493,65 @@ def test_live_profile_blocks_pending_match_until_controller_updates(
 
     coord._battery_live_profile = "self-consumption"  # noqa: SLF001
     assert coord._effective_profile_matches_pending() is True  # noqa: SLF001
+
+
+def test_live_profile_wins_over_stale_configured_profile(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "backup_only"  # noqa: SLF001
+    coord._battery_live_profile = "self-consumption"  # noqa: SLF001
+
+    assert coord.battery_effective_profile == "self-consumption"
+    assert coord.battery_selected_profile == "self-consumption"
+    assert coord.battery_effective_profile_display == "Self-Consumption"
+    assert "self-consumption" in coord.battery_profile_option_keys
+
+
+def test_live_profile_confirmation_promotes_pending_profile(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "backup_only"  # noqa: SLF001
+    coord._battery_backup_percentage = 100  # noqa: SLF001
+    coord._battery_live_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_pending_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_pending_reserve = 20  # noqa: SLF001
+    coord._battery_pending_require_exact_settings = False  # noqa: SLF001
+
+    coord.battery_runtime.confirm_battery_pending()
+
+    assert coord.battery_profile_pending is False
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_effective_profile == "self-consumption"
+    assert coord.battery_effective_backup_percentage == 20
+    assert coord.battery_selected_profile == "self-consumption"
+    assert coord.battery_selected_backup_percentage == 20
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_profile_change_does_not_promote_live_match(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "backup_only"  # noqa: SLF001
+    coord._battery_backup_percentage = 100  # noqa: SLF001
+    coord._battery_live_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_pending_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_pending_reserve = 20  # noqa: SLF001
+    coord._battery_pending_requested_at = datetime.now(timezone.utc)  # noqa: SLF001
+    coord.client.cancel_battery_profile_update = AsyncMock(
+        return_value={"message": "success"}
+    )
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+
+    await coord.async_cancel_pending_profile_change()
+
+    coord.client.cancel_battery_profile_update.assert_awaited_once()
+    assert coord.battery_profile_pending is False
+    assert coord.battery_profile == "backup_only"
+    assert coord.battery_effective_backup_percentage == 100
 
 
 def test_collect_site_metrics_includes_live_battery_profile(

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -2680,8 +2680,14 @@ def test_tariff_runtime_diagnostics(coordinator_factory) -> None:
 
 def test_tariff_sensors_expose_state_attributes_and_gateway_device(
     coordinator_factory,
+    monkeypatch,
 ) -> None:
     coord = coordinator_factory()
+    monkeypatch.setattr(
+        sensor_mod,
+        "next_billing_date",
+        lambda snapshot: next_billing_date(snapshot, today=date(2026, 4, 26)),
+    )
     coord.tariff_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
     coord.tariff_billing = parse_tariff_billing(
         {


### PR DESCRIPTION
## Summary
- Send system profile writes without EVSE devices to avoid Enphase accepting a write while leaving BatteryConfig and live profile state split.
- Promote pending profile reserve/subtype only when the live or configured profile confirms the pending target, while keeping cancel as a pure pending clear.
- Add regression coverage for stale configured profile display, live-confirmed pending promotion, cancel without promotion, device-stripping retry behavior, and the date-sensitive tariff test.

## Testing
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_coordinator_battery_profile.py tests/components/enphase_ev/test_tariff.py"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/battery_runtime.py --fail-under=100"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
