### PR TITLE
Prepare release 3.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v3.0.11 - 2026-05-23
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
 ### 🐛 Bug fixes
-- Smoothed running Heat Pump power over longer same-day energy windows to reduce short-window spikes from lumpy site-today energy updates, while keeping raw power diagnostics available. (#680)
+- Smoothed running Heat Pump power over longer same-day energy windows to reduce short-window spikes from lumpy site-today energy updates, while keeping raw power diagnostics available. (#690)
+- Fixed IQ Battery profile confirmation so pending reserve and profile subtype changes are only promoted after live or configured profile state confirms the target, and retried system profile writes without EVSE devices when needed. (#692)
+
+### 🔧 Improvements
+- Added rolling coordinator refresh telemetry to diagnostics, including total refresh duration, phase timings, cloud-call counts, polling state, stale payload use, manual endpoint bypass state, and p50/p95/max summaries. (#691)
+
+### 🔄 Other changes
+- Refactored EVSE power derivation, EVSE runtime writes, and sensor registry setup into focused helper modules while preserving existing behavior. (#688)
+- Bumped the integration manifest version to `3.0.11`.
 
 ## v3.0.10 - 2026-05-17
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.0.10"
+  "version": "3.0.11"
 }


### PR DESCRIPTION
## Summary

Prepare release 3.0.11 by bumping the integration manifest version and moving the unreleased changelog entries into a dated release section.

Included merged PRs since v3.0.10:

- #688 Refactor Enphase EV architecture
- #690 Smooth heat pump running power
- #691 Add rolling refresh telemetry
- #692 Fix battery profile confirmation state

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release metadata update.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m json.tool custom_components/enphase_ev/manifest.json >/tmp/enphase_ev_manifest.json"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
git diff --check
```

Results:

- `ruff check .`: passed
- manifest JSON validation: passed
- `python -m pre_commit run --all-files`: passed
- service translation tests: 33 passed
- component tests: 3235 passed
- full pytest: 3354 passed
- `git diff --check`: passed

Coverage note:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/manifest.json --fail-under=100"
```

The coverage wrapper reran the full component suite successfully with 3235 passed, then exited with `No data to report` because the touched integration file is JSON and no Python modules changed.

Black note: no Python files changed, so the repository's `black <changed-python-files>` step is not applicable. An overly broad `black --check CHANGELOG.md custom_components/enphase_ev/manifest.json` was attempted and rejected because Black does not parse Markdown and would reformat JSON outside the changed-Python-file scope.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots are needed for this release metadata PR.
