### PR TITLE
Fix battery profile status confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 🐛 Bug fixes
+- Fixed IQ Battery system profile status so successful BatteryConfig profile writes are promoted from the authoritative profile endpoint, stale live/status payloads do not revert the selected profile, and unconfirmed writes remain pending until the cloud confirms or the pending repair timeout is reached.
+
 ## v3.0.11 - 2026-05-23
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -39,6 +39,7 @@ from .const import (
     BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL,
     BATTERY_MIN_SOC_FALLBACK,
     BATTERY_PROFILE_DEFAULT_RESERVE,
+    BATTERY_PROFILE_PENDING_TIMEOUT_S,
     BATTERY_PROFILE_WRITE_DEBOUNCE_S,
     BATTERY_SETTINGS_CACHE_TTL,
     BATTERY_SETTINGS_WRITE_DEBOUNCE_S,
@@ -388,16 +389,146 @@ class BatteryRuntime:
             return func(sub_type)
         return None
 
-    def clear_battery_pending(self) -> None:
+    def clear_battery_pending(self, *, clear_optimistic: bool = True) -> None:
         state = self.battery_state
         state._battery_pending_profile = None
         state._battery_pending_reserve = None
         state._battery_pending_sub_type = None
         state._battery_pending_requested_at = None
+        state._battery_pending_requested_mono = None
         state._battery_pending_require_exact_settings = True
+        state._battery_pending_authoritative_confirmation_required = False
         state._battery_backend_profile_update_pending = None
         state._battery_backend_not_pending_observed_at = None
+        if clear_optimistic:
+            self.clear_battery_optimistic_profile()
         self._sync_battery_profile_pending_issue()
+
+    def clear_battery_optimistic_profile(self) -> None:
+        state = self.battery_state
+        state._battery_optimistic_profile = None
+        state._battery_optimistic_reserve = None
+        state._battery_optimistic_sub_type = None
+        state._battery_optimistic_until_mono = None
+
+    def set_battery_optimistic_profile(
+        self, profile: str, reserve: int | None, sub_type: str | None
+    ) -> None:
+        state = self.battery_state
+        normalized_profile = self.normalize_battery_profile_key(profile)
+        if not normalized_profile:
+            self.clear_battery_optimistic_profile()
+            return
+        state._battery_optimistic_profile = normalized_profile
+        state._battery_optimistic_reserve = reserve
+        state._battery_optimistic_sub_type = self._normalize_pending_sub_type(
+            self.coordinator,
+            normalized_profile,
+            sub_type,
+        )
+        state._battery_optimistic_until_mono = (
+            time.monotonic() + BATTERY_PROFILE_PENDING_TIMEOUT_S
+        )
+
+    def optimistic_battery_profile(self) -> str | None:
+        state = self.battery_state
+        profile = getattr(state, "_battery_optimistic_profile", None)
+        until = getattr(state, "_battery_optimistic_until_mono", None)
+        if profile is None or until is None:
+            return None
+        try:
+            expired = time.monotonic() >= float(until)
+        except Exception:  # noqa: BLE001
+            expired = True
+        if expired:
+            self.clear_battery_optimistic_profile()
+            return None
+        return profile
+
+    def optimistic_battery_reserve(self) -> int | None:
+        if self.optimistic_battery_profile() is None:
+            return None
+        return self._coerce_optional_int(
+            getattr(self.battery_state, "_battery_optimistic_reserve", None)
+        )
+
+    def optimistic_battery_sub_type(self) -> str | None:
+        if self.optimistic_battery_profile() is None:
+            return None
+        return self._normalize_battery_sub_type(
+            getattr(self.battery_state, "_battery_optimistic_sub_type", None)
+        )
+
+    def _read_profile_is_stale_after_write(self, profile: str | None) -> bool:
+        optimistic_profile = self.optimistic_battery_profile()
+        return (
+            optimistic_profile is not None
+            and profile is not None
+            and profile != optimistic_profile
+        )
+
+    def _note_authoritative_profile_read(self, profile: str | None) -> None:
+        state = self.battery_state
+        if profile is not None:
+            state._battery_profile_authoritative_seen = True
+            state._battery_profile_authoritative_seen_mono = time.monotonic()
+        optimistic_profile = self.optimistic_battery_profile()
+        if (
+            optimistic_profile is not None
+            and profile == optimistic_profile
+            and getattr(state, "_battery_pending_profile", None) is None
+        ):
+            self.clear_battery_optimistic_profile()
+
+    def _profile_authoritative_read_is_fresh(self) -> bool:
+        state = self.battery_state
+        last_seen = getattr(state, "_battery_profile_authoritative_seen_mono", None)
+        if last_seen is None:
+            return False
+        try:
+            age = time.monotonic() - float(last_seen)
+        except Exception:  # noqa: BLE001
+            return False
+        return age <= self._battery_profile_refresh_cache_ttl_seconds(
+            BATTERY_SETTINGS_CACHE_TTL
+        )
+
+    def _settings_profile_is_stale_after_authoritative_read(
+        self, profile: str | None
+    ) -> bool:
+        if profile is None:
+            return False
+        state = self.battery_state
+        return (
+            bool(getattr(state, "_battery_profile_authoritative_seen", False))
+            and self._profile_authoritative_read_is_fresh()
+            and getattr(state, "_battery_profile", None) is not None
+            and profile != getattr(state, "_battery_profile", None)
+        )
+
+    def _pending_requires_authoritative_confirmation(self) -> bool:
+        return bool(
+            getattr(
+                self.battery_state,
+                "_battery_pending_authoritative_confirmation_required",
+                False,
+            )
+        )
+
+    def _pending_authoritative_confirmation_received(self) -> bool:
+        if not self._pending_requires_authoritative_confirmation():
+            return True
+        state = self.battery_state
+        pending_requested_mono = getattr(state, "_battery_pending_requested_mono", None)
+        authoritative_seen_mono = getattr(
+            state, "_battery_profile_authoritative_seen_mono", None
+        )
+        if pending_requested_mono is None or authoritative_seen_mono is None:
+            return False
+        try:
+            return float(authoritative_seen_mono) >= float(pending_requested_mono)
+        except Exception:  # noqa: BLE001
+            return False
 
     def confirm_battery_pending(self) -> None:
         state = self.battery_state
@@ -459,9 +590,12 @@ class BatteryRuntime:
             coord, profile, sub_type
         )
         state._battery_pending_requested_at = dt_util.utcnow()
+        state._battery_pending_requested_mono = time.monotonic()
         state._battery_pending_require_exact_settings = bool(require_exact_settings)
+        state._battery_pending_authoritative_confirmation_required = True
         state._battery_backend_profile_update_pending = None
         state._battery_backend_not_pending_observed_at = None
+        self.set_battery_optimistic_profile(profile, reserve, sub_type)
         self._sync_battery_profile_pending_issue()
 
     def _backend_not_pending_clear_grace_seconds(self) -> int:
@@ -672,7 +806,10 @@ class BatteryRuntime:
         if getattr(state, "_battery_pending_profile", None) is None:
             state._battery_backend_not_pending_observed_at = None
             return
-        if self.effective_profile_matches_pending():
+        if (
+            self.effective_profile_matches_pending()
+            and self._pending_authoritative_confirmation_received()
+        ):
             self.confirm_battery_pending()
             return
         now = dt_util.utcnow()
@@ -686,9 +823,11 @@ class BatteryRuntime:
         if pending_age is None:
             return
         if pending_age >= self._backend_not_pending_clear_grace_seconds():
-            # The backend may briefly report no pending task before the updated
-            # settings are reflected, so pending state is cleared only after a
-            # poll-sized grace window.
+            # A locally accepted write still needs a matching profile read before
+            # it is treated as successful; otherwise the pending timeout can
+            # surface the unconfirmed change.
+            if self._pending_requires_authoritative_confirmation():
+                return
             self.clear_battery_pending()
 
     def effective_profile_matches_pending(self) -> bool:
@@ -696,9 +835,9 @@ class BatteryRuntime:
         pending_profile = getattr(state, "_battery_pending_profile", None)
         if not pending_profile:
             return False
-        effective_profile = getattr(state, "_battery_live_profile", None)
+        effective_profile = getattr(state, "_battery_profile", None)
         if effective_profile is None:
-            effective_profile = getattr(state, "_battery_profile", None)
+            effective_profile = getattr(state, "_battery_live_profile", None)
         if effective_profile != pending_profile:
             return False
         if not getattr(state, "_battery_pending_require_exact_settings", True):
@@ -2357,9 +2496,11 @@ class BatteryRuntime:
                             ),
                         }
 
-        if profile is not None:
+        stale_profile_read = self._read_profile_is_stale_after_write(profile)
+        if profile is not None and not stale_profile_read:
             state._battery_profile = profile
-        if reserve is not None:
+            self._note_authoritative_profile_read(profile)
+        if reserve is not None and not stale_profile_read:
             normalized_reserve = self.normalize_battery_reserve_for_profile(
                 profile or state._battery_profile or "self-consumption",
                 reserve,
@@ -2368,9 +2509,12 @@ class BatteryRuntime:
             self.remember_battery_reserve(
                 profile or state._battery_profile, normalized_reserve
             )
-        if subtype is not None:
+        if subtype is not None and not stale_profile_read:
             state._battery_operation_mode_sub_type = subtype
-        elif profile not in {"cost_savings", "ai_optimisation"}:
+        elif not stale_profile_read and profile not in {
+            "cost_savings",
+            "ai_optimisation",
+        }:
             state._battery_operation_mode_sub_type = None
         if supports_mqtt is not None:
             state._battery_supports_mqtt = supports_mqtt
@@ -2389,7 +2533,10 @@ class BatteryRuntime:
             state._battery_profile_evse_device = profile_evse_device
         self.sync_backend_battery_profile_pending(data.get("isBatteryChangePending"))
 
-        if self.effective_profile_matches_pending():
+        if (
+            self.effective_profile_matches_pending()
+            and self._pending_authoritative_confirmation_received()
+        ):
             self.confirm_battery_pending()
 
     def parse_battery_status_payload(self, payload: object) -> None:
@@ -2579,7 +2726,10 @@ class BatteryRuntime:
         }
         self._sync_ac_battery_from_battery_status(snapshots)
         self._refresh_cached_topology()
-        if self.effective_profile_matches_pending():
+        if (
+            self.effective_profile_matches_pending()
+            and self._pending_authoritative_confirmation_received()
+        ):
             self.confirm_battery_pending()
 
     def _sync_ac_battery_from_battery_status(
@@ -2879,7 +3029,23 @@ class BatteryRuntime:
             data.get("previousBatteryBackupPercentage")
         )
         settings_profile = self.normalize_battery_profile_key(data.get("profile"))
-        if settings_profile is not None:
+        profile_write_awaiting_authoritative_read = (
+            self._pending_requires_authoritative_confirmation()
+        )
+        stale_profile_read = (
+            profile_write_awaiting_authoritative_read
+            or self._settings_profile_is_stale_after_authoritative_read(
+                settings_profile
+            )
+        )
+        if (
+            settings_profile is not None
+            and not stale_profile_read
+            and (
+                not getattr(state, "_battery_profile_authoritative_seen", False)
+                or not self._profile_authoritative_read_is_fresh()
+            )
+        ):
             state._battery_profile = settings_profile
         settings_reserve = self._coerce_optional_int(
             data.get("batteryBackupPercentage")
@@ -2902,7 +3068,7 @@ class BatteryRuntime:
             )
         elif clear_missing_reserve_bounds:
             state._battery_backup_percentage_max = None
-        if settings_reserve is not None:
+        if settings_reserve is not None and not stale_profile_read:
             state._battery_backup_percentage = (
                 self.normalize_battery_reserve_for_profile(
                     settings_profile or state._battery_profile or "self-consumption",
@@ -2916,9 +3082,11 @@ class BatteryRuntime:
         settings_subtype = self._normalize_battery_sub_type(
             data.get("operationModeSubType")
         )
-        if settings_subtype is not None:
+        if settings_subtype is not None and not stale_profile_read:
             state._battery_operation_mode_sub_type = settings_subtype
-        elif (settings_profile or state._battery_profile) not in {
+        elif not stale_profile_read and (
+            settings_profile or state._battery_profile
+        ) not in {
             "cost_savings",
             "ai_optimisation",
         }:
@@ -2960,7 +3128,10 @@ class BatteryRuntime:
                     state._battery_use_battery_for_self_consumption = use_battery
         self.sync_backend_battery_profile_pending(data.get("isBatteryChangePending"))
 
-        if self.effective_profile_matches_pending():
+        if (
+            self.effective_profile_matches_pending()
+            and self._pending_authoritative_confirmation_received()
+        ):
             self.confirm_battery_pending()
 
     def parse_battery_schedules_payload(self, payload: object) -> None:
@@ -3798,6 +3969,7 @@ class BatteryRuntime:
         state = self.battery_state
         if not coord.battery_profile_pending:
             self.clear_battery_pending()
+            self.clear_battery_optimistic_profile()
             return
         await self.async_assert_battery_profile_write_allowed()
         async with state._battery_profile_write_lock:
@@ -3812,6 +3984,7 @@ class BatteryRuntime:
                     redact_site_id(coord.site_id),
                 )
         self.clear_battery_pending()
+        self.clear_battery_optimistic_profile()
         state._storm_guard_cache_until = None
         coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
         await coord.async_request_refresh()

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5222,7 +5222,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @property
     def battery_effective_profile(self) -> str | None:
-        return self.battery_live_profile or getattr(self, "_battery_profile", None)
+        optimistic_profile = self.battery_runtime.optimistic_battery_profile()
+        if optimistic_profile is not None:
+            return optimistic_profile
+        return getattr(self, "_battery_profile", None) or self.battery_live_profile
 
     @property
     def battery_profile_pending(self) -> bool:
@@ -5234,10 +5237,16 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @property
     def battery_effective_backup_percentage(self) -> int | None:
+        optimistic_reserve = self.battery_runtime.optimistic_battery_reserve()
+        if optimistic_reserve is not None:
+            return optimistic_reserve
         return getattr(self, "_battery_backup_percentage", None)
 
     @property
     def battery_effective_operation_mode_sub_type(self) -> str | None:
+        optimistic_sub_type = self.battery_runtime.optimistic_battery_sub_type()
+        if optimistic_sub_type is not None:
+            return optimistic_sub_type
         return getattr(self, "_battery_operation_mode_sub_type", None)
 
     @property
@@ -5251,7 +5260,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return (
             getattr(self, "_battery_pending_reserve", None)
             if getattr(self, "_battery_pending_reserve", None) is not None
-            else getattr(self, "_battery_backup_percentage", None)
+            else self.battery_effective_backup_percentage
         )
 
     @property
@@ -5260,7 +5269,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             getattr(self, "_battery_pending_sub_type", None)
             if getattr(self, "_battery_pending_profile", None)
             in {"cost_savings", "ai_optimisation"}
-            else getattr(self, "_battery_operation_mode_sub_type", None)
+            else self.battery_effective_operation_mode_sub_type
         )
 
     @property

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -204,6 +204,12 @@ class CoordinatorDiagnostics:
             except Exception:
                 return False
 
+        def _safe_attr(name: str, default: object = None) -> object:
+            try:
+                return getattr(coord, name)
+            except Exception:
+                return default
+
         backoff_until = coord._backoff_until or 0.0
         backoff_active = bool(backoff_until and backoff_until > time.monotonic())
         scheduler_backoff_active = coord._scheduler_backoff_active()
@@ -544,7 +550,7 @@ class CoordinatorDiagnostics:
             "battery_profile_selection_available": (
                 coord.battery_profile_selection_available
             ),
-            "battery_reserve_editable": coord.battery_reserve_editable,
+            "battery_reserve_editable": _safe_attr("battery_reserve_editable", False),
             "battery_shutdown_level_available": getattr(
                 coord, "battery_shutdown_level_available", None
             ),
@@ -595,7 +601,7 @@ class CoordinatorDiagnostics:
                 _coordinator_available()
                 and battery_type_available
                 and battery_write_access
-                and coord.battery_reserve_editable
+                and bool(_safe_attr("battery_reserve_editable", False))
             ),
             "battery_shutdown_level_number_available": (
                 _coordinator_available()

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -8792,7 +8792,10 @@ class EnphaseSystemProfileStatusSensor(_SiteBaseEntity):
     @property
     def native_value(self):
         if self._coord.battery_profile_pending:
-            return "Updating..."
+            return (
+                self._coord.battery_profile_display
+                or self._coord.battery_effective_profile_display
+            )
         return self._coord.battery_effective_profile_display
 
     @property

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -353,6 +353,8 @@ class BatteryState:
     _battery_site_status_text: str | None = None
     _battery_site_status_severity: str | None = None
     _battery_profile: str | None = None
+    _battery_profile_authoritative_seen: bool = False
+    _battery_profile_authoritative_seen_mono: float | None = None
     _battery_live_profile: str | None = None
     _battery_live_profile_label: str | None = None
     _battery_live_profile_sample_utc: datetime | None = None
@@ -377,7 +379,13 @@ class BatteryState:
     _battery_pending_reserve: int | None = None
     _battery_pending_sub_type: str | None = None
     _battery_pending_requested_at: datetime | None = None
+    _battery_pending_requested_mono: float | None = None
     _battery_pending_require_exact_settings: bool = True
+    _battery_pending_authoritative_confirmation_required: bool = False
+    _battery_optimistic_profile: str | None = None
+    _battery_optimistic_reserve: int | None = None
+    _battery_optimistic_sub_type: str | None = None
+    _battery_optimistic_until_mono: float | None = None
     _battery_backend_profile_update_pending: bool | None = None
     _battery_backend_not_pending_observed_at: datetime | None = None
     _battery_profile_reserve_memory: dict[str, int] = field(

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -3883,7 +3883,7 @@ Observed structure:
 - `excluded` has been observed as `false`; `true` is still the documented exclusion indicator when a battery is omitted from active fleet calculations.
 - Percentage fields (`current_charge`, `battery_soh`) are string percentages in observed payloads.
 - Status appears as normalized code (`status`) plus a display label (`statusText`); observed pair so far: `normal` / `Normal`.
-- `battery_mode` is a human-readable profile label from the live battery controller. The integration normalizes observed labels such as `Self-Consumption`, `Self - Consumption`, `Full Backup`, `Savings`, and `AI Optimization` back to BatteryConfig profile keys and treats this field as the live/effective profile signal when it disagrees with the configured BatteryConfig `profile`.
+- `battery_mode` is a human-readable profile label from the live battery controller. The integration normalizes observed labels such as `Self-Consumption`, `Self - Consumption`, `Full Backup`, `Savings`, and `AI Optimization` back to BatteryConfig profile keys. A confirmed BatteryConfig `profile` is the authoritative selected/effective profile; `battery_mode` is retained as live controller telemetry and fallback context when BatteryConfig profile data is unavailable or stale.
 - `battery_phase_count` and `is_flex_phase` vary by hardware/site topology; observed combinations so far: `1` / `false` and `3` / `true`.
 - `led_status` is the raw battery LED/runtime status code. The integration currently interprets `12` as charging, `13` as discharging, `14` as idle, `15` as idle, and `17` as idle; any other value is treated as unknown runtime state.
 - `led_status` should be interpreted alongside `status`/`statusText`; observed values in captures so far: `12` and `17`.
@@ -6168,7 +6168,7 @@ There is no single universal header set; the implementation varies headers by en
 | `storages[].led_status` | Raw battery LED/runtime status code; observed values so far: `12`, `17` |
 | `storages[].status` / `storages[].statusText` | Battery status code + display label; observed pair so far: `normal` / `Normal` |
 | `storages[].last_report` | Epoch seconds for latest battery telemetry |
-| `storages[].battery_mode` | Human-readable live controller profile label for the individual storage unit. The integration normalizes this to the effective profile and uses it to detect split states where BatteryConfig reports the requested profile but the controller is still running another mode; observed value so far: `Self-Consumption` |
+| `storages[].battery_mode` | Human-readable live controller profile label for the individual storage unit. The integration normalizes this as live controller telemetry and fallback profile context, but a confirmed BatteryConfig `profile` remains authoritative for the selected/effective system profile; observed value so far: `Self-Consumption` |
 | `storages[].battery_phase_count` | Number of AC phases exposed for that battery/system view; observed values so far: `1`, `3` |
 | `storages[].is_flex_phase` | Flex-phase capability flag observed on three-phase systems; observed values so far: `false`, `true` |
 | `storages[].battery_soh` | Battery state-of-health percentage string |

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -12,6 +12,7 @@ from homeassistant.util import dt as dt_util
 
 from custom_components.enphase_ev.battery_runtime import BatteryRuntime
 from custom_components.enphase_ev.const import (
+    BATTERY_SETTINGS_CACHE_TTL,
     FAST_TOGGLE_POLL_HOLD_S,
     SAVINGS_OPERATION_MODE_SUBTYPE,
 )
@@ -63,6 +64,52 @@ def test_battery_runtime_pending_helpers_and_matching(
     assert coord._battery_backend_profile_update_pending is None  # noqa: SLF001
     assert coord._battery_backend_not_pending_observed_at is None  # noqa: SLF001
     assert mock_issue_registry.created == []
+
+
+def test_battery_runtime_optimistic_profile_guard_branches(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+
+    runtime.set_battery_optimistic_profile("", None, None)
+    assert runtime.optimistic_battery_profile() is None
+
+    coord._battery_profile_authoritative_seen_mono = None  # noqa: SLF001
+    assert runtime._profile_authoritative_read_is_fresh() is False  # noqa: SLF001
+
+    class BadSeen:
+        def __float__(self) -> float:
+            raise ValueError("boom")
+
+    coord._battery_profile_authoritative_seen_mono = BadSeen()  # noqa: SLF001
+    assert runtime._profile_authoritative_read_is_fresh() is False  # noqa: SLF001
+
+    coord._battery_pending_authoritative_confirmation_required = True  # noqa: SLF001
+    coord._battery_pending_requested_mono = BadSeen()  # noqa: SLF001
+    coord._battery_profile_authoritative_seen_mono = time.monotonic()  # noqa: SLF001
+    assert (  # noqa: SLF001
+        runtime._pending_authoritative_confirmation_received() is False
+    )
+    coord._battery_pending_authoritative_confirmation_required = False  # noqa: SLF001
+
+    runtime.set_battery_optimistic_profile("backup_only", 100, None)
+    runtime._note_authoritative_profile_read("backup_only")  # noqa: SLF001
+    assert runtime.optimistic_battery_profile() is None
+
+    coord._battery_optimistic_profile = "backup_only"  # noqa: SLF001
+    coord._battery_optimistic_until_mono = 0.0  # noqa: SLF001
+    assert runtime.optimistic_battery_profile() is None
+    assert coord._battery_optimistic_profile is None  # noqa: SLF001
+
+    class BadUntil:
+        def __float__(self) -> float:
+            raise ValueError("boom")
+
+    coord._battery_optimistic_profile = "backup_only"  # noqa: SLF001
+    coord._battery_optimistic_until_mono = BadUntil()  # noqa: SLF001
+    assert runtime.optimistic_battery_profile() is None
+    assert coord._battery_optimistic_profile is None  # noqa: SLF001
 
 
 def test_backend_pending_flag_does_not_clear_recent_mismatched_request(
@@ -119,6 +166,402 @@ def test_backend_pending_flag_clears_stale_mismatched_request_after_grace(
     assert coord.battery_profile_pending is False
     assert coord._battery_backend_profile_update_pending is None  # noqa: SLF001
     assert coord._battery_backend_not_pending_observed_at is None  # noqa: SLF001
+
+
+def test_stale_profile_reads_do_not_revert_accepted_write_after_grace(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    requested_at = datetime.now(UTC)
+    second_false = requested_at + timedelta(seconds=FAST_TOGGLE_POLL_HOLD_S + 5)
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 20  # noqa: SLF001
+    coord._battery_polling_interval_s = 45  # noqa: SLF001
+
+    runtime.set_battery_pending(
+        profile="backup_only",
+        reserve=100,
+        sub_type=None,
+        require_exact_settings=False,
+    )
+    coord._battery_pending_requested_at = requested_at  # noqa: SLF001
+    coord._battery_backend_not_pending_observed_at = requested_at  # noqa: SLF001
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_runtime.dt_util.utcnow",
+        lambda: second_false,
+    )
+
+    runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+                "isBatteryChangePending": False,
+            }
+        }
+    )
+
+    assert coord.battery_profile_pending is True
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_selected_profile == "backup_only"
+    assert coord.battery_effective_profile == "backup_only"
+    assert coord.battery_effective_backup_percentage == 100
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+                "isBatteryChangePending": False,
+            }
+        }
+    )
+
+    assert coord.battery_profile_pending is True
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_selected_profile == "backup_only"
+    assert coord.battery_effective_profile == "backup_only"
+    assert coord.battery_effective_backup_percentage == 100
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "backup_only",
+                "batteryBackupPercentage": 100,
+                "isBatteryChangePending": False,
+            }
+        }
+    )
+
+    assert runtime.optimistic_battery_profile() is None
+    assert coord.battery_profile_pending is False
+    assert coord.battery_profile == "backup_only"
+    assert coord.battery_effective_backup_percentage == 100
+
+
+def test_profile_endpoint_wins_over_stale_battery_settings(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "backup_only",
+                "batteryBackupPercentage": 100,
+            }
+        }
+    )
+    runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+            }
+        }
+    )
+
+    assert coord.battery_profile == "backup_only"
+    assert coord.battery_effective_profile == "backup_only"
+    assert coord.battery_effective_backup_percentage == 100
+
+
+def test_stale_profile_endpoint_allows_battery_settings_fallback(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "backup_only",
+                "batteryBackupPercentage": 100,
+            }
+        }
+    )
+    coord._battery_profile_authoritative_seen_mono = (  # noqa: SLF001
+        time.monotonic() - BATTERY_SETTINGS_CACHE_TTL - 1
+    )
+
+    runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+            }
+        }
+    )
+
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_effective_profile == "self-consumption"
+    assert coord.battery_effective_backup_percentage == 20
+
+
+def test_profile_endpoint_confirms_pending_with_stale_live_profile(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_live_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 20  # noqa: SLF001
+
+    runtime.set_battery_pending(
+        profile="backup_only",
+        reserve=100,
+        sub_type=None,
+        require_exact_settings=False,
+    )
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "backup_only",
+                "batteryBackupPercentage": 100,
+                "isBatteryChangePending": True,
+            }
+        }
+    )
+
+    assert runtime.optimistic_battery_profile() is None
+    assert coord.battery_profile_pending is False
+    assert coord.battery_profile == "backup_only"
+    assert coord.battery_live_profile == "self-consumption"
+    assert coord.battery_effective_profile == "backup_only"
+    assert coord.battery_effective_backup_percentage == 100
+
+
+def test_battery_settings_target_payload_does_not_confirm_pending_profile(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 20  # noqa: SLF001
+
+    runtime.set_battery_pending(
+        profile="backup_only",
+        reserve=100,
+        sub_type=None,
+        require_exact_settings=False,
+    )
+
+    runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "profile": "backup_only",
+                "batteryBackupPercentage": 100,
+                "isBatteryChangePending": False,
+            }
+        }
+    )
+
+    assert coord.battery_profile_pending is True
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_selected_profile == "backup_only"
+    assert coord.battery_effective_profile == "backup_only"
+    assert coord.battery_effective_backup_percentage == 100
+
+
+def test_backend_not_pending_does_not_promote_unconfirmed_optimistic_profile(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    requested_at = datetime.now(UTC)
+    second_false = requested_at + timedelta(seconds=FAST_TOGGLE_POLL_HOLD_S + 5)
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 20  # noqa: SLF001
+    coord._battery_polling_interval_s = 45  # noqa: SLF001
+
+    runtime.set_battery_pending(
+        profile="backup_only",
+        reserve=100,
+        sub_type=None,
+        require_exact_settings=False,
+    )
+    coord._battery_pending_requested_at = requested_at  # noqa: SLF001
+    coord._battery_backend_not_pending_observed_at = requested_at  # noqa: SLF001
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_runtime.dt_util.utcnow",
+        lambda: second_false,
+    )
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+                "isBatteryChangePending": False,
+            }
+        }
+    )
+
+    assert coord.battery_profile_pending is True
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_selected_profile == "backup_only"
+    assert coord.battery_effective_profile == "backup_only"
+    assert coord.battery_effective_backup_percentage == 100
+
+
+def test_backend_not_pending_keeps_local_write_pending_after_optimistic_expiry(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    requested_at = datetime.now(UTC)
+    second_false = requested_at + timedelta(seconds=FAST_TOGGLE_POLL_HOLD_S + 5)
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 20  # noqa: SLF001
+    coord._battery_polling_interval_s = 45  # noqa: SLF001
+
+    runtime.set_battery_pending(
+        profile="backup_only",
+        reserve=100,
+        sub_type=None,
+        require_exact_settings=False,
+    )
+    coord._battery_pending_requested_at = requested_at  # noqa: SLF001
+    coord._battery_backend_not_pending_observed_at = requested_at  # noqa: SLF001
+    coord._battery_optimistic_until_mono = 0.0  # noqa: SLF001
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_runtime.dt_util.utcnow",
+        lambda: second_false,
+    )
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+                "isBatteryChangePending": False,
+            }
+        }
+    )
+
+    assert runtime.optimistic_battery_profile() is None
+    assert coord.battery_profile_pending is True
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_selected_profile == "backup_only"
+    assert coord.battery_effective_profile == "self-consumption"
+    assert coord.battery_selected_backup_percentage == 100
+
+
+def test_profile_match_with_stale_reserve_does_not_clear_local_pending(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    requested_at = datetime.now(UTC)
+    second_false = requested_at + timedelta(seconds=FAST_TOGGLE_POLL_HOLD_S + 5)
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 20  # noqa: SLF001
+    coord._battery_polling_interval_s = 45  # noqa: SLF001
+
+    runtime.set_battery_pending(
+        profile="self-consumption",
+        reserve=30,
+        sub_type=None,
+        require_exact_settings=True,
+    )
+    coord._battery_pending_requested_at = requested_at  # noqa: SLF001
+    coord._battery_backend_not_pending_observed_at = requested_at  # noqa: SLF001
+    coord._battery_optimistic_until_mono = 0.0  # noqa: SLF001
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_runtime.dt_util.utcnow",
+        lambda: second_false,
+    )
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+                "isBatteryChangePending": False,
+            }
+        }
+    )
+
+    assert runtime.optimistic_battery_profile() is None
+    assert coord.battery_profile_pending is True
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_effective_backup_percentage == 20
+    assert coord.battery_selected_backup_percentage == 30
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 30,
+                "isBatteryChangePending": False,
+            }
+        }
+    )
+
+    assert coord.battery_profile_pending is False
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_effective_backup_percentage == 30
+
+
+def test_prepopulated_local_target_does_not_confirm_before_profile_read(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    requested_at = datetime.now(UTC)
+    second_false = requested_at + timedelta(seconds=FAST_TOGGLE_POLL_HOLD_S + 5)
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 20  # noqa: SLF001
+    coord._battery_polling_interval_s = 45  # noqa: SLF001
+
+    runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 30,
+            }
+        }
+    )
+    runtime.set_battery_pending(
+        profile="self-consumption",
+        reserve=30,
+        sub_type=None,
+        require_exact_settings=True,
+    )
+    coord._battery_pending_requested_at = requested_at  # noqa: SLF001
+    coord._battery_backend_not_pending_observed_at = requested_at  # noqa: SLF001
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_runtime.dt_util.utcnow",
+        lambda: second_false,
+    )
+
+    runtime.sync_backend_battery_profile_pending(False)
+
+    assert coord.battery_profile_pending is True
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_effective_backup_percentage == 30
+
+    runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 30,
+                "isBatteryChangePending": False,
+            }
+        }
+    )
+
+    assert coord.battery_profile_pending is False
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_effective_backup_percentage == 30
 
 
 def test_backend_pending_true_resets_not_pending_observation(
@@ -1089,6 +1532,7 @@ def test_battery_runtime_parse_profile_payload_branches_and_helpers(
     )
     assert coord.battery_effective_backup_percentage == 100
     assert coord._battery_profile_devices == []  # noqa: SLF001
+    assert coord.battery_profile_devices_payload() is None
 
     coord._battery_profile_devices = [  # noqa: SLF001
         {"chargeMode": "MANUAL", "enable": True},

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -996,6 +996,13 @@ def test_battery_profile_property_helpers_cover_branches(coordinator_factory) ->
     assert coord.battery_effective_backup_percentage == 33
     assert coord.battery_effective_operation_mode_sub_type == "prioritize-energy"
     assert coord.battery_pending_operation_mode_sub_type == "prioritize-energy"
+    coord.battery_runtime.set_battery_optimistic_profile(
+        "ai_optimisation",
+        22,
+        "prioritize-energy",
+    )
+    assert coord.battery_effective_operation_mode_sub_type == "prioritize-energy"
+    coord.battery_runtime.clear_battery_optimistic_profile()
     assert coord.battery_has_encharge is True
     assert coord.battery_show_battery_backup_percentage is True
     assert "cost_savings" in coord.battery_profile_option_keys
@@ -1004,12 +1011,12 @@ def test_battery_profile_property_helpers_cover_branches(coordinator_factory) ->
     assert coord.battery_effective_profile_display == "Self-Consumption"
     coord._battery_live_profile = "backup_only"  # noqa: SLF001
     assert coord.battery_live_profile == "backup_only"
-    assert coord.battery_effective_profile == "backup_only"
+    assert coord.battery_effective_profile == "self-consumption"
     assert coord.battery_selected_profile == "cost_savings"
     assert "backup_only" in coord.battery_profile_option_keys
     coord._battery_pending_profile = None  # noqa: SLF001
-    assert coord.battery_selected_profile == "backup_only"
-    assert coord.battery_effective_profile_display == "Full Backup"
+    assert coord.battery_selected_profile == "self-consumption"
+    assert coord.battery_effective_profile_display == "Self-Consumption"
     coord._battery_live_profile = None  # noqa: SLF001
     coord._battery_pending_profile = "cost_savings"  # noqa: SLF001
     assert coord.savings_use_battery_after_peak is True
@@ -1435,7 +1442,7 @@ def test_live_battery_mode_profile_normalization(coordinator_factory) -> None:
     assert runtime.normalize_live_battery_mode_profile("Savings") == "cost_savings"
 
 
-def test_battery_status_payload_tracks_live_profile_and_clears_pending(
+def test_battery_status_payload_tracks_live_profile_without_clearing_pending(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -1462,7 +1469,8 @@ def test_battery_status_payload_tracks_live_profile_and_clears_pending(
     assert coord._battery_live_profile == "backup_only"  # noqa: SLF001
     assert coord._battery_live_profile_label == "Full Backup"  # noqa: SLF001
     assert coord._battery_live_profile_sample_utc is not None  # noqa: SLF001
-    assert coord.battery_profile_pending is False
+    assert coord.battery_profile_pending is True
+    assert coord.battery_selected_profile == "backup_only"
 
     coord.battery_runtime.parse_battery_status_payload({"storages": [{"id": "123"}]})
     assert coord._battery_live_profile is None  # noqa: SLF001
@@ -1478,7 +1486,32 @@ def test_battery_status_payload_tracks_live_profile_and_clears_pending(
     assert coord._battery_live_profile_sample_utc is None  # noqa: SLF001
 
 
-def test_live_profile_blocks_pending_match_until_controller_updates(
+def test_battery_status_payload_clears_pending_when_no_profile_endpoint_value(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_pending_profile = "backup_only"  # noqa: SLF001
+    coord._battery_pending_reserve = 100  # noqa: SLF001
+    coord._battery_pending_require_exact_settings = False  # noqa: SLF001
+
+    coord.battery_runtime.parse_battery_status_payload(
+        {
+            "storages": [
+                {
+                    "id": "123",
+                    "battery_mode": "Full Backup",
+                    "current_charge": "75%",
+                }
+            ]
+        }
+    )
+
+    assert coord.battery_profile_pending is False
+    assert coord.battery_profile == "backup_only"
+    assert coord.battery_effective_profile == "backup_only"
+
+
+def test_configured_profile_confirms_pending_with_stale_live_profile(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -1489,22 +1522,23 @@ def test_live_profile_blocks_pending_match_until_controller_updates(
     coord._battery_pending_reserve = 20  # noqa: SLF001
     coord._battery_pending_require_exact_settings = False  # noqa: SLF001
 
-    assert coord._effective_profile_matches_pending() is False  # noqa: SLF001
-
-    coord._battery_live_profile = "self-consumption"  # noqa: SLF001
     assert coord._effective_profile_matches_pending() is True  # noqa: SLF001
 
+    coord._battery_profile = "backup_only"  # noqa: SLF001
+    coord._battery_live_profile = "self-consumption"  # noqa: SLF001
+    assert coord._effective_profile_matches_pending() is False  # noqa: SLF001
 
-def test_live_profile_wins_over_stale_configured_profile(
+
+def test_configured_profile_wins_over_stale_live_profile(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
     coord._battery_profile = "backup_only"  # noqa: SLF001
     coord._battery_live_profile = "self-consumption"  # noqa: SLF001
 
-    assert coord.battery_effective_profile == "self-consumption"
-    assert coord.battery_selected_profile == "self-consumption"
-    assert coord.battery_effective_profile_display == "Self-Consumption"
+    assert coord.battery_effective_profile == "backup_only"
+    assert coord.battery_selected_profile == "backup_only"
+    assert coord.battery_effective_profile_display == "Full Backup"
     assert "self-consumption" in coord.battery_profile_option_keys
 
 

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -1904,7 +1904,7 @@ def test_system_profile_status_sensor_states():
     coord.battery_profile_display = "AI Optimisation"
     coord.battery_selected_backup_percentage = 25
     coord.battery_selected_operation_mode_sub_type = "prioritize-energy"
-    assert sensor.native_value == "Updating..."
+    assert sensor.native_value == "AI Optimisation"
     attrs = sensor.extra_state_attributes
     assert attrs["pending"] is True
     assert attrs["effective_profile"] == "self-consumption"


### PR DESCRIPTION
## Summary

Fix IQ Battery system profile status after successful BatteryConfig profile writes. The integration now treats the BatteryConfig profile endpoint as authoritative for selected/effective profile state, keeps stale live/status and batterySettings payloads from reverting a confirmed profile, and keeps locally accepted writes pending until the cloud confirms the profile after the write request.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_battery_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime.py::test_profile_endpoint_confirms_pending_with_stale_live_profile tests/components/enphase_ev/test_battery_runtime.py::test_stale_profile_reads_do_not_revert_accepted_write_after_grace tests/components/enphase_ev/test_battery_runtime.py::test_backend_not_pending_keeps_local_write_pending_after_optimistic_expiry tests/components/enphase_ev/test_battery_runtime.py::test_profile_match_with_stale_reserve_does_not_clear_local_pending tests/components/enphase_ev/test_battery_runtime.py::test_prepopulated_local_target_does_not_confirm_before_profile_read tests/components/enphase_ev/test_coordinator_battery_profile.py::test_configured_profile_wins_over_stale_live_profile tests/components/enphase_ev/test_sensors.py::test_system_profile_status_sensor_states"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_coordinator_battery_profile.py tests/components/enphase_ev/test_sensors.py::test_system_profile_status_sensor_states"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/state_models.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- `storages[].battery_mode` remains live controller telemetry and fallback context.
- Confirmed BatteryConfig profile state is now authoritative for selected/effective profile display.
- No translation string changes were required.
