### PR TITLE
Suppress false HEMS auth repairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### 🐛 Bug fixes
-- None
+- Suppressed false HEMS auth repair issues for sites without Heat Pump context while keeping optional HEMS polling backoff active. (#697)
 
 ## v3.0.12 - 2026-05-30
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -4566,6 +4566,31 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return int(err.status), "forbidden" if err.status == 403 else "unauthorized"
         return None
 
+    def _hems_auth_repair_context_available(self) -> bool:
+        """Return True when HEMS auth failures should be surfaced to the user."""
+
+        selected = getattr(self, "_selected_type_keys", None)
+        if isinstance(selected, (set, list, tuple)) and selected:
+            return any(normalize_type_key(key) == "heatpump" for key in selected)
+        inventory_view = getattr(self, "inventory_view", None)
+        has_type = getattr(inventory_view, "has_type", None)
+        if callable(has_type):
+            try:
+                if has_type("heatpump"):
+                    return True
+            except Exception:  # noqa: BLE001 - defensive diagnostics guard
+                pass
+        if bool(getattr(self, "_heatpump_known_present", False)):
+            return True
+        runtime = getattr(self, "heatpump_runtime", None)
+        established = getattr(runtime, "heatpump_entities_established", None)
+        if callable(established):
+            try:
+                return bool(established())
+            except Exception:  # noqa: BLE001 - defensive diagnostics guard
+                return False
+        return False
+
     def _note_hems_auth_failure(
         self,
         err: BaseException,
@@ -4597,7 +4622,17 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._persist_hems_auth_circuit_state()
         diagnostics = getattr(self, "diagnostics", None)
         if diagnostics is not None:
-            diagnostics.create_hems_auth_degraded_issue()
+            repairs_enabled = bool(
+                getattr(diagnostics, "degraded_service_repair_issues_enabled", True)
+            )
+            if self._hems_auth_repair_context_available() or not repairs_enabled:
+                diagnostics.create_hems_auth_degraded_issue()
+            else:
+                clear_issue = getattr(
+                    diagnostics, "clear_hems_auth_degraded_issue", None
+                )
+                if callable(clear_issue):
+                    clear_issue()
         _LOGGER.warning(
             "Pausing optional HEMS polling for site %s after HEMS auth failure: endpoint=%s status=%s reason=%s failure_count=%s retry_at=%s",
             redact_site_id(self.site_id),

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -3804,6 +3804,7 @@ def test_hems_auth_circuit_is_coordinator_backed(
     mock_issue_registry,
 ):
     coord = coordinator_factory()
+    coord._selected_type_keys = {"heatpump"}  # noqa: SLF001
 
     assert coord._hems_auth_circuit_active() is False  # noqa: SLF001
     assert coord._note_hems_auth_failure(  # noqa: SLF001
@@ -3836,6 +3837,62 @@ def test_hems_auth_circuit_is_coordinator_backed(
     assert coord._hems_auth_backoff_until is None  # noqa: SLF001
     assert coord._hems_auth_last_reason == "unauthorized"  # noqa: SLF001
     assert coord._hems_auth_failure_count == 2  # noqa: SLF001
+
+
+def test_hems_auth_circuit_suppresses_repair_without_heatpump_context(
+    coordinator_factory,
+    mock_issue_registry,
+):
+    coord = coordinator_factory()
+
+    assert coord._note_hems_auth_failure(  # noqa: SLF001
+        coord_mod.Unauthorized(),
+        endpoint="hems_devices",
+    )
+
+    assert coord._hems_auth_circuit_active() is True  # noqa: SLF001
+    assert coord._hems_auth_failure_count == 1  # noqa: SLF001
+    assert not mock_issue_registry.created
+
+
+def test_hems_auth_repair_context_respects_disabled_heatpump_group(
+    coordinator_factory,
+    mock_issue_registry,
+):
+    coord = coordinator_factory()
+    coord._selected_type_keys = {"envoy", "encharge"}  # noqa: SLF001
+    coord.inventory_view.has_type = MagicMock(return_value=True)
+    coord._heatpump_known_present = True  # noqa: SLF001
+
+    assert coord._hems_auth_repair_context_available() is False  # noqa: SLF001
+    assert coord._note_hems_auth_failure(  # noqa: SLF001
+        coord_mod.Unauthorized(),
+        endpoint="hems_devices",
+    )
+    assert not mock_issue_registry.created
+
+
+def test_hems_auth_repair_context_handles_defensive_fallbacks(
+    coordinator_factory,
+):
+    coord = coordinator_factory()
+    coord.inventory_view.has_type = MagicMock(side_effect=RuntimeError("bad"))
+    coord._heatpump_known_present = True  # noqa: SLF001
+
+    assert coord._hems_auth_repair_context_available() is True  # noqa: SLF001
+
+    coord = coordinator_factory()
+    coord.inventory_view.has_type = MagicMock(side_effect=RuntimeError("bad"))
+    coord.heatpump_runtime.heatpump_entities_established = MagicMock(
+        side_effect=RuntimeError("bad")
+    )
+
+    assert coord._hems_auth_repair_context_available() is False  # noqa: SLF001
+
+    coord = coordinator_factory()
+    coord.heatpump_runtime.heatpump_entities_established = None
+
+    assert coord._hems_auth_repair_context_available() is False  # noqa: SLF001
 
 
 def test_hems_auth_circuit_restores_and_persists_config_entry_state(


### PR DESCRIPTION
## Summary

Suppress false HEMS auth repair issues for sites that do not have Heat Pump context.

Root cause: optional HEMS discovery/backoff can run before or without Heat Pump entities being available. When Enphase returns an auth-like HEMS response, the coordinator opened the HEMS repair unconditionally, which told non-Heat-Pump users to disable a Heat Pump group they could not see.

This keeps the optional HEMS auth backoff active so the integration does not hammer Enphase, but only surfaces the repair when Heat Pump is selected, known present, or previously established. Explicitly disabling the Heat Pump group now suppresses the repair even if stale inventory/runtime state still suggests Heat Pump context.

Fixes #697

## Related Issues

- #697

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_additional_coverage.py -k 'hems_auth'"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git status --short && pre-commit run --all-files"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No screenshots. `pre-commit` needed the linked-worktree Git metadata mounted into Docker because this Codex checkout's `.git` file points outside the repository mount.
