### PR TITLE
Prepare release 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ## v3.1.0 - 2026-06-04
 
 ### 🐛 Bug fixes
+- Fixed IQ Battery system profile status so successful BatteryConfig profile writes are promoted from the authoritative profile endpoint, stale live/status payloads do not revert the selected profile, and unconfirmed writes remain pending until the cloud confirms or the pending repair timeout is reached. (#694)
 - Suppressed false HEMS auth repair issues for sites without Heat Pump context while keeping optional HEMS polling backoff active. (#697, #698)
 
 ### 🔄 Other changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### 🐛 Bug fixes
-- Suppressed false HEMS auth repair issues for sites without Heat Pump context while keeping optional HEMS polling backoff active. (#697)
+- None
+
+## v3.1.0 - 2026-06-04
+
+### 🐛 Bug fixes
+- Suppressed false HEMS auth repair issues for sites without Heat Pump context while keeping optional HEMS polling backoff active. (#697, #698)
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `3.1.0`.
 
 ## v3.0.12 - 2026-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,18 @@ All notable changes to this project will be documented in this file.
 
 ## v3.1.0 - 2026-06-04
 
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
 ### 🐛 Bug fixes
 - Fixed IQ Battery system profile status so successful BatteryConfig profile writes are promoted from the authoritative profile endpoint, stale live/status payloads do not revert the selected profile, and unconfirmed writes remain pending until the cloud confirms or the pending repair timeout is reached. (#694)
 - Suppressed false HEMS auth repair issues for sites without Heat Pump context while keeping optional HEMS polling backoff active. (#697, #698)
+
+### 🔧 Improvements
+- None
 
 ### 🔄 Other changes
 - Bumped the integration manifest version to `3.1.0`.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.0.12"
+  "version": "3.1.0"
 }


### PR DESCRIPTION
## Summary

Prepare release `3.1.0` by moving the IQ Battery profile status confirmation fix and HEMS auth repair-context fix into a dated release entry, and bumping the integration manifest version.

Fixes #697.

## Related Issues

- #697
- #698
- #694

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release metadata update for `3.1.0`.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m json.tool custom_components/enphase_ev/manifest.json >/tmp/manifest.json.checked"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Targeted coverage for touched Python modules was not run because this PR only changes `CHANGELOG.md` and `manifest.json`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots needed for this release metadata update.
