### PR TITLE
Avoid startup session history repair noise

### DIFF
--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -1342,7 +1342,10 @@ class CoordinatorDiagnostics:
                         continue
                     if bool(getattr(view, "has_valid_cache", False)):
                         continue
-                    if getattr(view, "state", None) == "unavailable":
+                    if getattr(view, "state", None) == "unavailable" and (
+                        getattr(view, "last_error", None)
+                        or getattr(view, "cache_age", None) is not None
+                    ):
                         has_current_day_unavailable = True
                         break
         if available and not has_current_day_unavailable:

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -928,6 +928,8 @@ def test_sync_session_history_issue_uses_current_day_unavailable_view(
         get_cache_view=lambda *_args, **_kwargs: SimpleNamespace(
             has_valid_cache=False,
             state="unavailable",
+            last_error="503 Service Unavailable",
+            cache_age=1.0,
         ),
     )
 
@@ -942,6 +944,8 @@ def test_sync_session_history_issue_uses_current_day_unavailable_view(
     coord.session_history.get_cache_view = lambda *_args, **_kwargs: SimpleNamespace(
         has_valid_cache=True,
         state="valid",
+        last_error=None,
+        cache_age=1.0,
     )
     coord._sync_session_history_issue()  # noqa: SLF001
 
@@ -966,6 +970,8 @@ def test_sync_session_history_issue_handles_fallback_day_resolution(
         get_cache_view=lambda serial, _day_key: SimpleNamespace(
             has_valid_cache=serial == "bad",
             state="unavailable",
+            last_error=None if serial == "bad" else "fetch failed",
+            cache_age=1.0,
         ),
     )
     monkeypatch.setattr(
@@ -977,6 +983,56 @@ def test_sync_session_history_issue_handles_fallback_day_resolution(
         coord_diag_mod.dt_util,
         "as_local",
         lambda _value: (_ for _ in ()).throw(ValueError("boom")),
+    )
+
+    coord._sync_session_history_issue()  # noqa: SLF001
+
+    assert coord._session_history_issue_reported is True  # noqa: SLF001
+    assert any(
+        issue[1] == ISSUE_SESSION_HISTORY_UNAVAILABLE
+        for issue in mock_issue_registry.created
+    )
+
+
+def test_sync_session_history_issue_ignores_startup_missing_cache(
+    coordinator_factory, mock_issue_registry
+) -> None:
+    coord = coordinator_factory()
+    coord.data = {SERIAL_ONE: {"display_name": "Garage EV"}}
+    coord._session_history_day = lambda payload, default: default  # type: ignore[method-assign]  # noqa: SLF001
+    coord.session_history = SimpleNamespace(
+        service_available=True,
+        get_cache_view=lambda *_args, **_kwargs: SimpleNamespace(
+            has_valid_cache=False,
+            state="unavailable",
+            last_error=None,
+            cache_age=None,
+        ),
+    )
+
+    coord._sync_session_history_issue()  # noqa: SLF001
+
+    assert coord._session_history_issue_reported is False  # noqa: SLF001
+    assert not any(
+        issue[1] == ISSUE_SESSION_HISTORY_UNAVAILABLE
+        for issue in mock_issue_registry.created
+    )
+
+
+def test_sync_session_history_issue_reports_materialized_unavailable_cache(
+    coordinator_factory, mock_issue_registry
+) -> None:
+    coord = coordinator_factory()
+    coord.data = {SERIAL_ONE: {"display_name": "Garage EV"}}
+    coord._session_history_day = lambda payload, default: default  # type: ignore[method-assign]  # noqa: SLF001
+    coord.session_history = SimpleNamespace(
+        service_available=True,
+        get_cache_view=lambda *_args, **_kwargs: SimpleNamespace(
+            has_valid_cache=False,
+            state="unavailable",
+            last_error=None,
+            cache_age=1.0,
+        ),
     )
 
     coord._sync_session_history_issue()  # noqa: SLF001


### PR DESCRIPTION
## Summary

Prevent the session-history repair warning from being raised during startup before the first session-history fetch has materialized a cache entry.

The session-history cache view uses `state="unavailable"` both when there is no cache yet and when a failed lookup has been stored. The repair check now only treats a current-day unavailable view as actionable when it has an actual error or a materialized cache age, preserving real outage reporting while avoiding startup noise.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator_diagnostics.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator_diagnostics.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_additional_coverage.py -k 'session_history_issue'"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator_diagnostics.py --fail-under=100"
```

Results:

- Focused session-history repair tests: 5 passed
- Pre-commit: passed
- Full pytest: 3370 passed
- Component coverage run: 3251 passed
- Targeted coverage for `custom_components/enphase_ev/coordinator_diagnostics.py`: 100%

Note: the pre-commit command includes an extra Git metadata mount because this checkout is a Git worktree and the container otherwise cannot resolve the external worktree Git directory.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The provided diagnostics snapshot showed session history healthy after startup (`available: true`, `failures: 0`, valid cache entries), while the startup repair warning had appeared earlier. This change avoids reporting the repair for the empty-cache startup state while retaining reporting for real unavailable cache entries.
