### PR TITLE
Fix config-entry reload compatibility for 2026.6

### DIFF
--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import re
 import time
+from collections.abc import Mapping
 from typing import Any, cast
 
 import voluptuous as vol
@@ -282,6 +283,49 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
         self._mfa_resend_available_at: float | None = None
         self._mfa_code_sent = False
         self._pending_user_errors: dict[str, str] | None = None
+
+    @callback
+    def _async_update_entry_and_abort(
+        self,
+        entry: EnphaseConfigEntry,
+        *,
+        data: Mapping[str, Any],
+        reason: str,
+        title: str | None = None,
+    ) -> FlowResult:
+        has_update_listeners = bool(getattr(entry, "update_listeners", ()))
+        if has_update_listeners and callable(
+            update_and_abort := getattr(self, "async_update_and_abort", None)
+        ):
+            if title is not None:
+                return update_and_abort(
+                    entry,
+                    title=title,
+                    data=data,
+                    reason=reason,
+                )
+            return update_and_abort(entry, data=data, reason=reason)
+
+        update_reload_and_abort = getattr(self, "async_update_reload_and_abort", None)
+        if callable(update_reload_and_abort):
+            if title is not None:
+                return update_reload_and_abort(
+                    entry,
+                    title=title,
+                    data=data,
+                    reason=reason,
+                )
+            return update_reload_and_abort(entry, data=data, reason=reason)
+
+        update_kwargs: dict[str, Any] = {"data": data}
+        if title is not None:
+            update_kwargs["title"] = title
+        self.hass.config_entries.async_update_entry(entry, **update_kwargs)
+        self.hass.async_create_task(
+            self.hass.config_entries.async_reload(entry.entry_id),
+            f"reload {entry.domain} config entry {entry.entry_id}",
+        )
+        return self.async_abort(reason=reason)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -728,10 +772,6 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
 
             self._abort_if_unique_id_mismatch(reason="wrong_account")
             desired_title = _site_entry_title(str(self._selected_site_id))
-            if self._reconfigure_entry.title != desired_title:
-                self.hass.config_entries.async_update_entry(
-                    self._reconfigure_entry, title=desired_title
-                )
             merged = dict(self._reconfigure_entry.data)
             for key, value in data.items():
                 if value is None:
@@ -750,18 +790,17 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
             merged.pop(CONF_HEMS_AUTH_LAST_REASON, None)
             if not self._remember_password:
                 merged.pop(CONF_PASSWORD, None)
-                return self.async_update_reload_and_abort(
-                    self._reconfigure_entry,
-                    data_updates=merged,
-                    reason=reason,
-                )
-            self.hass.config_entries.async_update_entry(
-                self._reconfigure_entry, data=merged
+            title = (
+                desired_title
+                if self._reconfigure_entry.title != desired_title
+                else None
             )
-            await self.hass.config_entries.async_reload(
-                self._reconfigure_entry.entry_id
+            return self._async_update_entry_and_abort(
+                self._reconfigure_entry,
+                title=title,
+                data=merged,
+                reason=reason,
             )
-            return self.async_abort(reason=reason)
 
         self._abort_if_unique_id_configured()
         title = _site_entry_title(str(self._selected_site_id))

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -284,7 +284,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
         self._mfa_code_sent = False
         self._pending_user_errors: dict[str, str] | None = None
 
-    @callback
+    @callback  # type: ignore[untyped-decorator]
     def _async_update_entry_and_abort(
         self,
         entry: EnphaseConfigEntry,

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -1229,7 +1229,9 @@ async def test_finalize_login_entry_without_state_aborts(hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_finalize_login_entry_reconfigure_uses_core_helper(hass) -> None:
+async def test_finalize_login_entry_reconfigure_uses_reload_helper_without_listener(
+    hass,
+) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1248,6 +1250,7 @@ async def test_finalize_login_entry_reconfigure_uses_core_helper(hass) -> None:
     flow._selected_site_id = "12345"
     flow._remember_password = False
     flow._email = "user@example.com"
+    flow.async_update_and_abort = Mock()
     flow.async_update_reload_and_abort = Mock(
         return_value={"type": FlowResultType.ABORT, "reason": "handled"}
     )
@@ -1255,9 +1258,135 @@ async def test_finalize_login_entry_reconfigure_uses_core_helper(hass) -> None:
     result = await flow._finalize_login_entry(["EV123"], 45)
 
     assert result == {"type": FlowResultType.ABORT, "reason": "handled"}
+    flow.async_update_and_abort.assert_not_called()
     flow.async_update_reload_and_abort.assert_called_once()
     kwargs = flow.async_update_reload_and_abort.call_args.kwargs
-    assert kwargs["data_updates"][CONF_HEATPUMP_DISCOVERY_HANDLED] is True
+    assert kwargs["data"][CONF_HEATPUMP_DISCOVERY_HANDLED] is True
+
+
+@pytest.mark.asyncio
+async def test_finalize_login_entry_reconfigure_uses_update_helper_with_listener(
+    hass,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "12345",
+            CONF_EMAIL: "user@example.com",
+            CONF_REMEMBER_PASSWORD: False,
+            CONF_HEATPUMP_DISCOVERY_HANDLED: True,
+        },
+    )
+    entry.add_to_hass(hass)
+    entry.add_update_listener(AsyncMock())
+
+    flow = _make_flow(hass)
+    flow._reconfigure_entry = entry
+    flow._auth_tokens = TOKENS
+    flow._sites = {"12345": "Garage"}
+    flow._selected_site_id = "12345"
+    flow._remember_password = False
+    flow._email = "user@example.com"
+    flow.async_update_and_abort = Mock(
+        return_value={"type": FlowResultType.ABORT, "reason": "handled"}
+    )
+    flow.async_update_reload_and_abort = Mock()
+
+    result = await flow._finalize_login_entry(["EV123"], 45)
+
+    assert result == {"type": FlowResultType.ABORT, "reason": "handled"}
+    flow.async_update_and_abort.assert_called_once()
+    flow.async_update_reload_and_abort.assert_not_called()
+    kwargs = flow.async_update_and_abort.call_args.kwargs
+    assert kwargs["data"][CONF_HEATPUMP_DISCOVERY_HANDLED] is True
+
+
+def test_update_entry_helper_uses_update_helper_without_title_when_listener_present(
+    hass,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_SITE_ID: "12345"})
+    entry.add_to_hass(hass)
+    entry.add_update_listener(AsyncMock())
+
+    flow = _make_flow(hass)
+    captured: dict[str, object] = {}
+
+    def _sync_update(entry_obj, *, data, reason):
+        captured["entry"] = entry_obj
+        captured["data"] = dict(data)
+        captured["reason"] = reason
+        return {"type": FlowResultType.ABORT, "reason": "sync"}
+
+    flow.async_update_and_abort = _sync_update  # type: ignore[assignment]
+    flow.async_update_reload_and_abort = Mock()
+
+    result = flow._async_update_entry_and_abort(
+        entry,
+        data={CONF_SITE_ID: "12345"},
+        reason="reconfigure_successful",
+    )
+
+    assert result == {"type": FlowResultType.ABORT, "reason": "sync"}
+    assert captured["entry"] is entry
+    assert captured["data"] == {CONF_SITE_ID: "12345"}
+    assert captured["reason"] == "reconfigure_successful"
+    flow.async_update_reload_and_abort.assert_not_called()
+
+
+def test_update_entry_helper_uses_reload_helper_without_title_when_no_listener(
+    hass,
+) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_SITE_ID: "12345"})
+    entry.add_to_hass(hass)
+
+    flow = _make_flow(hass)
+    captured: dict[str, object] = {}
+
+    def _sync_update(entry_obj, *, data, reason):
+        captured["entry"] = entry_obj
+        captured["data"] = dict(data)
+        captured["reason"] = reason
+        return {"type": FlowResultType.ABORT, "reason": "sync"}
+
+    flow.async_update_and_abort = Mock()
+    flow.async_update_reload_and_abort = _sync_update  # type: ignore[assignment]
+
+    result = flow._async_update_entry_and_abort(
+        entry,
+        data={CONF_SITE_ID: "12345"},
+        reason="reconfigure_successful",
+    )
+
+    assert result == {"type": FlowResultType.ABORT, "reason": "sync"}
+    assert captured["entry"] is entry
+    assert captured["data"] == {CONF_SITE_ID: "12345"}
+    assert captured["reason"] == "reconfigure_successful"
+    flow.async_update_and_abort.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_update_entry_helper_falls_back_for_legacy_core(hass) -> None:
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_SITE_ID: "12345"})
+    entry.add_to_hass(hass)
+
+    flow = _make_flow(hass)
+    flow.async_update_and_abort = None  # type: ignore[method-assign]
+    flow.async_update_reload_and_abort = None  # type: ignore[method-assign]
+    reload_entry = AsyncMock(return_value=True)
+
+    with patch.object(hass.config_entries, "async_reload", reload_entry):
+        result = flow._async_update_entry_and_abort(
+            entry,
+            title="Site: 12345",
+            data={CONF_SITE_ID: "12345"},
+            reason="reconfigure_successful",
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.title == "Site: 12345"
+    reload_entry.assert_awaited_once_with(entry.entry_id)
 
 
 @pytest.mark.asyncio
@@ -1396,7 +1525,7 @@ async def test_reauth_step_remember_password_preserves_opt_out(hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_finalize_login_entry_sync_update_removes_none(hass) -> None:
+async def test_finalize_login_entry_reload_helper_removes_none(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="12345",
@@ -1427,12 +1556,13 @@ async def test_finalize_login_entry_sync_update_removes_none(hass) -> None:
     flow._password = None
     flow._email = "user@example.com"
 
-    captured: dict[str, dict] = {}
+    captured: dict[str, object] = {}
 
-    def _sync_update(entry_obj, *, data_updates, reason):
+    def _sync_update(entry_obj, *, data, reason, title=None):
         captured["entry"] = entry_obj
-        captured["data"] = dict(data_updates)
+        captured["data"] = dict(data)
         captured["reason"] = reason
+        captured["title"] = title
         return {"type": FlowResultType.ABORT, "reason": "sync"}
 
     flow.async_update_reload_and_abort = _sync_update  # type: ignore[assignment]
@@ -1442,6 +1572,7 @@ async def test_finalize_login_entry_sync_update_removes_none(hass) -> None:
     assert result == {"type": FlowResultType.ABORT, "reason": "sync"}
     assert captured["entry"] is entry
     assert captured["reason"] == "reconfigure_successful"
+    assert captured["title"] == "Site: 12345"
     assert CONF_PASSWORD not in captured["data"]
     assert CONF_SESSION_ID not in captured["data"]
     assert CONF_COOKIE not in captured["data"]
@@ -1453,7 +1584,7 @@ async def test_finalize_login_entry_sync_update_removes_none(hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_finalize_login_entry_sync_update_passes_reason(hass) -> None:
+async def test_finalize_login_entry_reload_helper_passes_reauth_reason(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="12345",
@@ -1477,10 +1608,11 @@ async def test_finalize_login_entry_sync_update_passes_reason(hass) -> None:
 
     captured: dict[str, object] = {}
 
-    def _sync_update(entry_obj, *, data_updates, reason):
+    def _sync_update(entry_obj, *, data, reason, title=None):
         captured["entry"] = entry_obj
-        captured["data"] = dict(data_updates)
+        captured["data"] = dict(data)
         captured["reason"] = reason
+        captured["title"] = title
         return {"type": FlowResultType.ABORT, "reason": "sync"}
 
     flow.async_update_reload_and_abort = _sync_update  # type: ignore[assignment]
@@ -1490,6 +1622,7 @@ async def test_finalize_login_entry_sync_update_passes_reason(hass) -> None:
     assert result == {"type": FlowResultType.ABORT, "reason": "sync"}
     assert captured["entry"] is entry
     assert captured["reason"] == "reauth_successful"
+    assert captured["title"] == "Site: 12345"
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_reconfigure_flow.py
+++ b/tests/components/enphase_ev/test_reconfigure_flow.py
@@ -200,7 +200,7 @@ async def test_reconfigure_allows_disabling_all_devices(hass, monkeypatch) -> No
     monkeypatch.setattr(
         hass.config_entries,
         "async_update_entry",
-        lambda _entry, **kwargs: updated.update(kwargs),
+        lambda entry=None, **kwargs: updated.update(kwargs),
     )
     monkeypatch.setattr(
         hass.config_entries, "async_reload", AsyncMock(return_value=True)


### PR DESCRIPTION
## Summary

Fix config-entry reload compatibility for Home Assistant 2026.6 by avoiding the deprecated combination of active config-entry update listeners with config-flow reload helpers.

The config flow now uses `async_update_and_abort()` when an entry already has update listeners registered, letting the integration's listener schedule the reload. Entries without listeners still use the reload helper so reauth/reconfigure recovery continues to work for unloaded or setup-failed entries.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'tmp=/tmp/enphase-precommit && rm -rf "$tmp" && mkdir -p "$tmp" && cp -a /workspace/. "$tmp" && cd "$tmp" && rm -f .git && git init -q && git add -A && python -m pre_commit run --all-files'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/config_flow.py --fail-under=100"
```

Pre-commit was run from a temporary Git repository inside the Docker container because this checkout is a linked worktree and the container cannot read the host worktree metadata path directly.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This addresses the Home Assistant developer blog deprecation for using `entry.add_update_listener()` together with config-flow reload helpers, which is deprecated in 2026.6 and becomes an error in 2026.12.
