### PR TITLE
Improve firmware visibility in device metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 🔧 Improvements
+- Improved Home Assistant device firmware metadata so aggregate Battery, Microinverter, and Heat Pump devices can show firmware summaries in the Devices table when inventory data includes versions.
+
 ## v3.1.1 - 2026-06-07
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -269,8 +269,8 @@ def _sync_type_devices(
         model_id = _clean_optional_text(inventory_view.type_device_model_id(type_key))
         if _is_redundant_model_id(model, model_id):
             model_id = None
-        sw_version = _clean_optional_text(
-            inventory_view.type_device_sw_version(type_key)
+        sw_version = _inventory_type_device_sw_version_for_registry(
+            inventory_view, type_key
         )
         if not label or not name:
             continue
@@ -318,6 +318,24 @@ def _sync_type_devices(
         if isinstance(ident, tuple) and len(ident) == 2:
             type_devices_by_identifier[ident] = created
     return type_devices
+
+
+def _inventory_type_device_sw_version_for_registry(
+    inventory_view: object, type_key: object
+) -> str | None:
+    sw_version_getter = getattr(inventory_view, "type_device_sw_version_summary", None)
+    if not callable(sw_version_getter):
+        sw_version_getter = getattr(inventory_view, "type_device_sw_version", None)
+        if not callable(sw_version_getter):
+            return None
+        return _clean_optional_text(sw_version_getter(type_key))
+    sw_version = _clean_optional_text(sw_version_getter(type_key))
+    if sw_version is not None:
+        return sw_version
+    single_version_getter = getattr(inventory_view, "type_device_sw_version", None)
+    if not callable(single_version_getter):
+        return None
+    return _clean_optional_text(single_version_getter(type_key))
 
 
 def _sync_charger_devices(
@@ -418,7 +436,9 @@ def _registry_type_metadata_signature(coord) -> tuple[tuple[object, ...], ...]:
                     inventory_view.type_device_serial_number(type_key)
                 ),
                 _clean_optional_text(inventory_view.type_device_model_id(type_key)),
-                _clean_optional_text(inventory_view.type_device_sw_version(type_key)),
+                _inventory_type_device_sw_version_for_registry(
+                    inventory_view, type_key
+                ),
             )
         )
     return tuple(signature)

--- a/custom_components/enphase_ev/inventory_view.py
+++ b/custom_components/enphase_ev/inventory_view.py
@@ -576,9 +576,15 @@ class InventoryView:
             "envoy_sw_version",
             "sw_version",
             "firmware_version",
+            "firmwareVersion",
+            "firmware-version",
             "software_version",
+            "softwareVersion",
+            "software-version",
             "system_version",
             "application_version",
+            "applicationVersion",
+            "application-version",
         )
         if normalized == "envoy":
             member = self._envoy_preferred_member()
@@ -599,18 +605,53 @@ class InventoryView:
             sw_version = self._type_member_single_value(
                 self._type_bucket_members(normalized), *sw_keys
             )
-            if sw_version:
-                return sw_version
-            return self._type_member_summary(
-                self._type_bucket_members(normalized), *sw_keys
-            )
+            return sw_version
         if normalized in ("encharge", "iqevse", "generator"):
             return self._type_member_single_value(
-                self._type_bucket_members(normalized),
-                *sw_keys,
+                self._type_bucket_members(normalized), *sw_keys
             )
         if normalized == "microinverter":
             return self._type_member_single_value(
+                self._type_bucket_members(normalized),
+                "fw1",
+                "fw2",
+                *sw_keys,
+            )
+        return None
+
+    def type_device_sw_version_summary(
+        self, type_key: object
+    ) -> str | None:  # pragma: no cover
+        normalized = normalize_type_key(type_key)
+        if not normalized:
+            return None
+        sw_version = self.type_device_sw_version(normalized)
+        if sw_version:
+            return sw_version
+        sw_keys = (
+            "envoy_sw_version",
+            "sw_version",
+            "firmware_version",
+            "firmwareVersion",
+            "firmware-version",
+            "software_version",
+            "softwareVersion",
+            "software-version",
+            "system_version",
+            "application_version",
+            "applicationVersion",
+            "application-version",
+        )
+        if normalized in ("encharge", "generator"):
+            return self._type_member_summary(
+                self._type_bucket_members(normalized), *sw_keys
+            )
+        if normalized == "heatpump":
+            return self._type_member_summary(
+                self._type_bucket_members(normalized), *sw_keys
+            )
+        if normalized == "microinverter":
+            return self._type_member_summary(
                 self._type_bucket_members(normalized),
                 "fw1",
                 "fw2",
@@ -704,7 +745,7 @@ class InventoryView:
         model_id = self.type_device_model_id(type_key)
         if model_id:
             info_kwargs["model_id"] = model_id
-        sw_version = self.type_device_sw_version(type_key)
+        sw_version = self.type_device_sw_version_summary(type_key)
         if sw_version:
             info_kwargs["sw_version"] = sw_version
         hw_summary = self.type_device_hw_version(type_key)

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -279,6 +279,29 @@ def test_inventory_view_iter_type_keys_uses_selected_keys_when_no_order_or_bucke
     assert coord.inventory_view.iter_type_keys() == ["envoy", "iqevse"]
 
 
+def test_inventory_view_iter_type_keys_handles_iter_serials_error() -> None:
+    from custom_components.enphase_ev.inventory_view import InventoryView
+
+    def _bad_iter_serials():
+        raise RuntimeError("boom")
+
+    view = InventoryView(
+        SimpleNamespace(
+            site_id=RANDOM_SITE_ID,
+            data={},
+            serials=[],
+            iter_serials=_bad_iter_serials,
+            _type_device_order=None,
+            _type_device_buckets=None,
+            _selected_type_keys=None,
+            _battery_has_encharge=False,
+            _battery_has_acb=False,
+        )
+    )
+
+    assert view.iter_type_keys() == ["envoy"]
+
+
 def test_inventory_view_type_identifier_requires_present_type(
     hass, monkeypatch
 ) -> None:
@@ -582,9 +605,17 @@ def test_type_device_summary_helpers_for_battery_and_microinverter(
     assert coord.inventory_view.type_device_serial_number("encharge") is None
     assert coord.inventory_view.type_device_model_id("encharge") is None
     assert coord.inventory_view.type_device_sw_version("encharge") is None
+    assert (
+        coord.inventory_view.type_device_sw_version_summary("encharge")
+        == "1.0 x2, 2.0 x1"
+    )
     assert coord.inventory_view.type_device_model_id("microinverter") is None
     assert coord.inventory_view.type_device_hw_version("microinverter") is None
     assert coord.inventory_view.type_device_sw_version("microinverter") is None
+    assert (
+        coord.inventory_view.type_device_sw_version_summary("microinverter")
+        == "4.0 x2, 5.0 x1"
+    )
 
 
 def test_type_device_helper_branches_for_mac_and_labels(hass, monkeypatch) -> None:

--- a/tests/components/enphase_ev/test_device_info.py
+++ b/tests/components/enphase_ev/test_device_info.py
@@ -29,6 +29,7 @@ def test_device_info_uses_display_name_and_model():
     assert info["model"] == "Garage Charger (IQ-EVSE-EU-3032)"
     assert "model_id" not in info
     assert info["serial_number"] == "555555555555"
+    assert info["sw_version"] == "3.1"
     assert info["connections"] == {(CONNECTION_NETWORK_MAC, "00:11:22:33:44:55")}
 
 

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -31,6 +31,7 @@ from custom_components.enphase_ev import (
     _migrate_cloud_entities_to_cloud_device,
     _migrate_legacy_gateway_type_devices,
     _migrate_orphaned_update_entities_to_type_devices,
+    _inventory_type_device_sw_version_for_registry,
     _normalize_selected_type_keys,
     _normalize_evse_model_name,
     _registry_charger_metadata_signature,
@@ -82,6 +83,10 @@ def _with_inventory_view(coord):
             coord, "type_device_sw_version", lambda _type_key: None
         ),
     )
+    if hasattr(coord, "type_device_sw_version_summary"):
+        coord.inventory_view.type_device_sw_version_summary = (
+            coord.type_device_sw_version_summary
+        )
     return coord
 
 
@@ -2597,6 +2602,96 @@ def test_sync_type_devices_uses_model_and_hw_summary(config_entry) -> None:
     assert device.model_id == "IQ7A-72-2-US x16"
     assert device.sw_version == "520-00082-r01-v04.30.32 x16"
     assert device.hw_version == "IQ7A-72-2-US x16"
+
+
+def test_sync_type_devices_uses_inventory_view_firmware_summaries(
+    config_entry,
+) -> None:
+    from custom_components.enphase_ev.inventory_view import InventoryView
+
+    site_id = config_entry.data[CONF_SITE_ID]
+    dev_reg = _FakeDeviceRegistry()
+    heatpump_member = {
+        "device_type": "HEAT_PUMP",
+        "device_uid": "HP-1",
+        "name": "Heat Pump",
+        "firmware-version": "3.0",
+        "part-number": "PN-1",
+    }
+    coord = SimpleNamespace(
+        site_id=site_id,
+        _selected_type_keys=None,
+        _type_device_order=["encharge", "microinverter", "heatpump"],
+        _type_device_buckets={
+            "encharge": {
+                "type_key": "encharge",
+                "type_label": "Battery",
+                "count": 3,
+                "devices": [
+                    {"serial_number": "BAT-1", "sw_version": "1.0"},
+                    {"serial_number": "BAT-2", "sw_version": "1.0"},
+                    {"serial_number": "BAT-3", "sw_version": "2.0"},
+                ],
+            },
+            "microinverter": {
+                "type_key": "microinverter",
+                "type_label": "Microinverters",
+                "count": 3,
+                "devices": [
+                    {"serial_number": "INV-1", "fw1": "4.0"},
+                    {"serial_number": "INV-2", "fw1": "4.0"},
+                    {"serial_number": "INV-3", "fw2": "5.0"},
+                ],
+            },
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [heatpump_member],
+            },
+        },
+        heatpump_runtime=SimpleNamespace(
+            _heatpump_primary_member=lambda: heatpump_member
+        ),
+        inventory_runtime=SimpleNamespace(),
+    )
+    coord.inventory_view = InventoryView(coord)
+
+    type_devices = _sync_type_devices(config_entry, coord, dev_reg, site_id)
+
+    assert type_devices["encharge"].sw_version == "1.0 x2, 2.0 x1"
+    assert type_devices["microinverter"].sw_version == "4.0 x2, 5.0 x1"
+    assert type_devices["heatpump"].sw_version == "3.0"
+
+
+def test_inventory_type_device_sw_version_for_registry_fallbacks() -> None:
+    assert (
+        _inventory_type_device_sw_version_for_registry(SimpleNamespace(), "envoy")
+        is None
+    )
+    assert (
+        _inventory_type_device_sw_version_for_registry(
+            SimpleNamespace(type_device_sw_version=lambda _key: "7.0"), "envoy"
+        )
+        == "7.0"
+    )
+    assert (
+        _inventory_type_device_sw_version_for_registry(
+            SimpleNamespace(
+                type_device_sw_version_summary=lambda _key: " ",
+                type_device_sw_version=lambda _key: "8.0",
+            ),
+            "envoy",
+        )
+        == "8.0"
+    )
+    assert (
+        _inventory_type_device_sw_version_for_registry(
+            SimpleNamespace(type_device_sw_version_summary=lambda _key: " "),
+            "envoy",
+        )
+        is None
+    )
 
 
 def test_sync_type_devices_updates_existing_hw_summary(config_entry) -> None:

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -248,6 +248,34 @@ def test_inventory_runtime_summary_and_inverter_helper_paths(
         }
     }
     assert coord.inventory_view.type_device_sw_version("microinverter") is None
+    coord._type_device_buckets = {  # noqa: SLF001
+        "encharge": {
+            "type_key": "encharge",
+            "type_label": "Battery",
+            "count": 3,
+            "devices": [
+                {"serial_number": "BAT-1", "sw_version": "1.0"},
+                {"serial_number": "BAT-2", "sw_version": "1.0"},
+                {"serial_number": "BAT-3", "sw_version": "2.0"},
+            ],
+        },
+        "microinverter": {
+            "type_key": "microinverter",
+            "type_label": "Microinverters",
+            "count": 3,
+            "devices": [
+                {"serial_number": "INV-1", "fw1": "4.0"},
+                {"serial_number": "INV-2", "fw1": "4.0"},
+                {"serial_number": "INV-3", "fw2": "5.0"},
+            ],
+        },
+    }
+    battery_info = coord.inventory_view.type_device_info("encharge")
+    inverter_info = coord.inventory_view.type_device_info("microinverter")
+    assert battery_info is not None
+    assert inverter_info is not None
+    assert battery_info["sw_version"] == "1.0 x2, 2.0 x1"
+    assert inverter_info["sw_version"] == "4.0 x2, 5.0 x1"
     coord._type_device_buckets = {"encharge": "bad"}  # noqa: SLF001
     assert coord.inventory_view.type_device_hw_version("encharge") is None
     coord._type_device_buckets = {  # noqa: SLF001
@@ -1970,6 +1998,9 @@ def test_inventory_runtime_merge_heatpump_bucket_uses_worst_status_fallback(
     }
     assert bucket["model_summary"] == "PN-1 x1"
     assert bucket["firmware_summary"] == "1.2.3 x1"
+    info = coord.inventory_view.type_device_info("heatpump")
+    assert info is not None
+    assert info["sw_version"] == "1.2.3"
 
 
 def test_inventory_runtime_system_dashboard_and_microinverter_edge_paths(

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -952,6 +952,33 @@ def test_helper_functions_cover_edge_paths() -> None:
     assert _as_bool(_BadStr()) is None
 
 
+def test_charger_installed_version_ignores_mixed_iqevse_inventory_summary() -> None:
+    from custom_components.enphase_ev.inventory_view import InventoryView
+
+    coord = SimpleNamespace(
+        site_id=TEST_EVSE_SITE_ID,
+        data={},
+        _type_device_buckets={
+            "iqevse": {
+                "type_key": "iqevse",
+                "type_label": "EV Chargers",
+                "count": 2,
+                "devices": [
+                    {"serial_number": "SN1", "sw_version": "1.0"},
+                    {"serial_number": "SN2", "sw_version": "2.0"},
+                ],
+            }
+        },
+        _type_device_order=["iqevse"],
+        _selected_type_keys=None,
+    )
+    coord.inventory_view = InventoryView(coord)
+
+    assert coord.inventory_view.type_device_sw_version("iqevse") is None
+    assert coord.inventory_view.type_device_sw_version_summary("iqevse") is None
+    assert _charger_installed_version(coord, "SN1") is None
+
+
 def test_device_info_falls_back_when_coordinator_does_not_supply_info() -> None:
     coord = DummyCoordinator()
     coord.inventory_view.type_device_info = lambda _type: None


### PR DESCRIPTION
## Summary

Improve Home Assistant 2026.6 Devices table firmware visibility by separating single-device firmware values from aggregate firmware summaries. Aggregate Battery, Microinverter, and Heat Pump devices can now expose firmware summaries in device registry metadata when inventory data has versions, while charger firmware update entities continue to use only concrete per-charger versions.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Improvement for Home Assistant device metadata visibility.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/inventory_view.py tests/components/enphase_ev/test_device_info.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_update_module.py tests/components/enphase_ev/test_init_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/inventory_view.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
python3 -m pre_commit run --all-files
```

Note: `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"` was attempted first, but the Codex worktree `.git` file points to a host-only gitdir path that is not mounted in the container, so pre-commit could not detect the repository. The same pre-commit hooks were run successfully from the host with `python3 -m pre_commit run --all-files`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No screenshots. The visible behavior is in Home Assistant 2026.6's hidden-by-default Firmware column on the Devices page.