### PR TITLE
Prepare release 3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,38 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- None
+
 ### 🔧 Improvements
-- Improved Home Assistant device firmware metadata so aggregate Battery, Microinverter, and Heat Pump devices can show firmware summaries in the Devices table when inventory data includes versions.
+- None
+
+### 🔄 Other changes
+- None
+
+## v3.1.2 - 2026-06-08
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Fixed config-entry reload compatibility for Home Assistant 2026.6 by letting active update listeners handle reloads while preserving reload-helper behavior for unloaded or setup-failed entries. (#703)
+
+### 🔧 Improvements
+- Improved Home Assistant device firmware metadata so aggregate Battery, Microinverter, and Heat Pump devices can show firmware summaries in the Devices table when inventory data includes versions. (#706)
+
+### 🔄 Other changes
+- Updated the Codecov GitHub Action from v6 to v7. (#704)
+- Bumped the integration manifest version to `3.1.2`.
 
 ## v3.1.1 - 2026-06-07
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.1.1"
+  "version": "3.1.2"
 }


### PR DESCRIPTION
## Summary

Prepare release 3.1.2 by bumping the integration manifest version and adding the release changelog entry.

The changelog now includes PRs #703, #704, and #706, and includes all standard release headings with `None` where a section has no changes.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation.

## Testing

```bash
python3 -m json.tool custom_components/enphase_ev/manifest.json >/dev/null
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

No Python files were changed, so there were no changed Python files to format with Black and no touched Python modules for targeted coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Release metadata only.
