### PR TITLE
Fix IQ-EVSE session energy normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed Last Session energy normalization for IQ-EVSE chargers so small Wh payloads such as `140.038 Wh` are reported as `0.14 kWh` instead of `140.04 kWh`. (#708)
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -140,7 +140,9 @@ from .runtime_helpers import (
     coerce_int as helper_coerce_int,
     coerce_optional_int as helper_coerce_optional_int,
     copy_diagnostics_value,
+    evse_session_energy_uses_wh,
     normalize_poll_intervals,
+    normalize_evse_session_energy,
     normalize_iso_date,
     redact_battery_payload,
     resolve_inverter_start_date,
@@ -3555,19 +3557,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 if session_end is None and sess.get("plg_out_at") is not None:
                     session_end = _sec(sess.get("plg_out_at"))
 
-            # Session energy normalization: many deployments report Wh in e_c
-            session_energy_wh = _as_float(sess.get("e_c"))
-            ses_kwh = session_energy_wh
-            if isinstance(ses_kwh, (int, float)):
-                try:
-                    if ses_kwh > 200:
-                        ses_kwh = round(float(ses_kwh) / 1000.0, 2)
-                    else:
-                        ses_kwh = round(float(ses_kwh), 2)
-                except Exception:
-                    ses_kwh = session_energy_wh
-            else:
-                ses_kwh = sess.get("e_c")
+            session_energy_raw = sess.get("e_c")
+            ses_kwh, session_energy_wh, session_energy_unit = (
+                normalize_evse_session_energy(
+                    session_energy_raw,
+                    wh_hint=evse_session_energy_uses_wh(obj, sess),
+                )
+            )
+            if session_energy_raw is not None and ses_kwh is None:
+                ses_kwh = session_energy_raw
 
             display_name = obj.get("displayName") or obj.get("name")
             if display_name is not None:
@@ -3641,6 +3639,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     else None
                 ),
                 "suspended_by_evse": suspended_by_evse,
+                "session_energy_raw": session_energy_raw,
+                "session_energy_unit": session_energy_unit,
                 "session_energy_wh": session_energy_wh,
                 "session_kwh": ses_kwh,
                 "session_miles": session_miles,
@@ -4018,6 +4018,21 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 # Prefer displayName from summary v2 for user-facing names
                 if item.get("displayName"):
                     cur["display_name"] = str(item.get("displayName"))
+                if cur.get("session_energy_raw") is not None and (
+                    cur.get("session_energy_unit") != "Wh"
+                    and evse_session_energy_uses_wh(cur, item)
+                ):
+                    session_kwh, session_wh, session_unit = (
+                        normalize_evse_session_energy(
+                            cur.get("session_energy_raw"),
+                            wh_hint=True,
+                        )
+                    )
+                    if session_kwh is not None:
+                        cur["session_kwh"] = session_kwh
+                    if session_wh is not None:
+                        cur["session_energy_wh"] = session_wh
+                    cur["session_energy_unit"] = session_unit
             self._seed_nominal_voltage_option_from_api()
 
         for sn, cur in out.items():

--- a/custom_components/enphase_ev/runtime_helpers.py
+++ b/custom_components/enphase_ev/runtime_helpers.py
@@ -53,6 +53,86 @@ def coerce_optional_text(value: object) -> str | None:
     return text or None
 
 
+def _text_contains_iq_evse(value: object) -> bool:
+    try:
+        text = str(value).strip().upper()
+    except Exception:  # noqa: BLE001
+        return False
+    return "IQ-EVSE" in text
+
+
+def evse_session_energy_uses_wh(*sources: object) -> bool:
+    """Return true when EVSE session energy is known to be reported as Wh."""
+
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        for key in (
+            "modelId",
+            "model_id",
+            "sku",
+            "model",
+            "modelName",
+            "model_name",
+            "partNumber",
+            "part_number",
+        ):
+            value = source.get(key)
+            if value is not None and _text_contains_iq_evse(value):
+                return True
+        session = source.get("session_d")
+        if isinstance(session, dict) and evse_session_energy_uses_wh(session):
+            return True
+        if any(
+            key in source
+            for key in (
+                "strt_chrg",
+                "plg_in_at",
+                "plg_out_at",
+                "auth_status",
+                "auth_type",
+                "auth_id",
+                "charge_level",
+            )
+        ):
+            return True
+    return False
+
+
+def normalize_evse_session_energy(
+    value: object,
+    *,
+    wh_hint: bool = False,
+) -> tuple[float | None, float | None, str | None]:
+    """Normalize EVSE session energy to kWh, Wh, and the inferred source unit."""
+
+    if value is None:
+        return None, None, None
+    try:
+        numeric_value = float(value)
+    except Exception:  # noqa: BLE001
+        return None, None, None
+
+    if wh_hint or numeric_value > 200:
+        try:
+            return (
+                round(numeric_value / 1000.0, 2),
+                round(numeric_value, 3),
+                "Wh",
+            )
+        except Exception:  # noqa: BLE001
+            return None, None, "Wh"
+
+    try:
+        return (
+            round(numeric_value, 2),
+            round(numeric_value * 1000.0, 3),
+            "kWh",
+        )
+    except Exception:  # noqa: BLE001
+        return None, None, "kWh"
+
+
 def iso_or_none(value: datetime | None) -> str | None:
     if value is None:
         return None

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -66,6 +66,7 @@ from .runtime_helpers import (
     coerce_optional_text as _gateway_clean_text,
     inventory_type_available as _type_available,
     inventory_type_device_info as _type_device_info,
+    normalize_evse_session_energy,
 )
 from .sensor_registry import (
     AC_BATTERY_ENTITY_UNIQUE_SUFFIXES as AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
@@ -1252,18 +1253,14 @@ class EnphaseEnergyTodaySensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):
                 energy_kwh = round(float(session_kwh), 2)
             except Exception:  # noqa: BLE001
                 energy_kwh = None
-        if energy_kwh is None and session_wh is not None:
-            try:
-                wh_val = float(session_wh)
-            except Exception:  # noqa: BLE001
-                wh_val = None
-            if wh_val is not None:
-                if wh_val > 200:
-                    energy_kwh = round(wh_val / 1000.0, 2)
-                    energy_wh = round(wh_val, 3)
-                else:
-                    energy_kwh = round(wh_val, 2)
-                    energy_wh = round(wh_val * 1000.0, 3)
+        if session_wh is not None:
+            wh_kwh, wh_value, _unit = normalize_evse_session_energy(
+                session_wh,
+                wh_hint=True,
+            )
+            if energy_kwh is None:
+                energy_kwh = wh_kwh
+            energy_wh = wh_value
         if energy_kwh is not None and energy_wh is None:
             try:
                 energy_wh = round(energy_kwh * 1000.0, 3)

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -278,7 +278,7 @@ The web-app Live Vitals capture also used the `api/v2` status alias, returning a
 
 Observed field behavior:
 - `session_d` may still describe the most recent completed charge session even when `charging=false` and `pluggedIn=false`.
-- Session energy units vary by response shape; values greater than `200` have been observed as Wh, while smaller values may already be kWh.
+- Session energy units vary by response shape; IQ-EVSE and modern session payloads report `session_d.e_c` as Wh even below `200`, while some legacy payloads may already report smaller values as kWh.
 - `sch_d.status=1` with `sch_d.info[].type="greencharging"` indicates an active green-charging policy window; `startTime` and `endTime` are Unix seconds.
 - `connectorStatusType="AVAILABLE"` can coexist with `connected=true`, meaning the charger is reachable but idle.
 - `smartEV.hasEVDetails` and top-level `isEVDetailsSet` are separate flags and can disagree in the same payload.
@@ -6120,7 +6120,7 @@ There is no single universal header set; the implementation varies headers by en
 | `connectorStatusReason` | Additional enum reason (e.g., `INSUFFICIENT_SOLAR`); observed value so far: `""` |
 | `connectorId` | Connector index within `connectors[]`; observed value so far: `1` |
 | `dlbActive` | Per-connector Dynamic Load Balancing activity flag; observed value so far: `false` |
-| `session_d.e_c` | Session energy (Wh if >200, else kWh) |
+| `session_d.e_c` | Session energy (Wh for IQ-EVSE/modern session payloads; legacy payloads may report small values as kWh) |
 | `session_d.start_time` | Epoch seconds when session started |
 | `chargeLevelDetails.min/max` | Min/max allowed amps |
 | `chargeLevelDetails.granularity` | Charge-current step size as a string; observed value so far: `"1"` |

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -2088,7 +2088,133 @@ async def test_async_update_data_success_enriches_payload(
     assert sn in result
     entry = result[sn]
     assert entry["charge_mode"] == "IDLE"
+    assert entry["session_energy_raw"] == 100
+    assert entry["session_energy_unit"] == "Wh"
+    assert entry["session_energy_wh"] == pytest.approx(100.0)
+    assert entry["session_kwh"] == pytest.approx(0.1)
     assert entry["energy_today_sessions_kwh"] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_normalizes_small_iq_evse_session_wh(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=["EV1"])
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "EV1",
+                    "name": "Garage",
+                    "charging": False,
+                    "pluggedIn": True,
+                    "faulted": False,
+                    "session_d": {
+                        "start_time": 1781370420,
+                        "e_c": 140.038,
+                    },
+                    "connectors": [
+                        {"connectorStatusType": coord_mod.SUSPENDED_EVSE_STATUS}
+                    ],
+                }
+            ],
+            "ts": "2026-06-13T17:15:58Z[UTC]",
+        }
+    )
+    coord._async_resolve_charge_modes = AsyncMock(return_value={})
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **kwargs: True,
+        async_fetch=AsyncMock(
+            return_value=[
+                {
+                    "serialNumber": "EV1",
+                    "modelId": "IQ-EVSE-NA-1080-0100-0100",
+                    "modelName": "IQ-EVSE-80R",
+                }
+            ]
+        ),
+        invalidate=lambda: None,
+    )
+
+    class _DummyHistory:
+        cache_ttl = 60
+
+        def get_cache_view(self, *_args, **_kwargs):
+            return SimpleNamespace(sessions=[], needs_refresh=False, blocked=False)
+
+        def schedule_enrichment(self, *_args, **_kwargs):
+            return None
+
+        def sum_energy(self, sessions):
+            return 0.0
+
+    coord.session_history = _DummyHistory()
+
+    result = await coord._async_update_data()
+
+    entry = result["EV1"]
+    assert entry["session_energy_raw"] == pytest.approx(140.038)
+    assert entry["session_energy_unit"] == "Wh"
+    assert entry["session_energy_wh"] == pytest.approx(140.038)
+    assert entry["session_kwh"] == pytest.approx(0.14)
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_preserves_unparseable_session_energy(
+    coordinator_factory,
+):
+    class BadEnergy:
+        def __float__(self):
+            raise ValueError("bad energy")
+
+    bad_energy = BadEnergy()
+    coord = coordinator_factory(serials=["EV1"])
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "EV1",
+                    "name": "Garage",
+                    "charging": False,
+                    "pluggedIn": True,
+                    "faulted": False,
+                    "session_d": {"e_c": bad_energy},
+                    "connectors": [
+                        {"connectorStatusType": coord_mod.SUSPENDED_EVSE_STATUS}
+                    ],
+                }
+            ],
+            "ts": "2026-06-13T17:15:58Z[UTC]",
+        }
+    )
+    coord._async_resolve_charge_modes = AsyncMock(return_value={})
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **kwargs: False,
+        async_fetch=AsyncMock(return_value=[]),
+        invalidate=lambda: None,
+    )
+
+    class _DummyHistory:
+        cache_ttl = 60
+
+        def get_cache_view(self, *_args, **_kwargs):
+            return SimpleNamespace(sessions=[], needs_refresh=False, blocked=False)
+
+        def schedule_enrichment(self, *_args, **_kwargs):
+            return None
+
+        def sum_energy(self, sessions):
+            return 0.0
+
+    coord.session_history = _DummyHistory()
+
+    result = await coord._async_update_data()
+
+    entry = result["EV1"]
+    assert entry["session_energy_raw"] is bad_energy
+    assert entry["session_energy_unit"] is None
+    assert entry["session_energy_wh"] is None
+    assert entry["session_kwh"] is bad_energy
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -501,6 +501,7 @@ async def test_coordinator_runtime_delegate_helpers_cover_direct_runtime_calls(
 
 
 def test_coordinator_static_and_class_runtime_helpers_cover_delegate_paths():
+    assert coord_mod._coerce_floatish(1) == 1.0  # noqa: SLF001
     assert EnphaseCoordinator._format_inverter_model_summary({"IQ8": 2}) == "IQ8 x2"
     assert (
         EnphaseCoordinator._heatpump_member_primary_id({"device_uid": "HP-1"}) == "HP-1"

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -115,6 +115,36 @@ def test_runtime_helpers_cover_parsing_dates_and_redaction(monkeypatch) -> None:
     }
     assert runtime_helpers.coerce_optional_text("  value  ") == "value"
     assert runtime_helpers.coerce_optional_text(BadStr()) is None
+    assert runtime_helpers.evse_session_energy_uses_wh("bad-source") is False
+    assert runtime_helpers.evse_session_energy_uses_wh({"modelId": BadStr()}) is False
+    assert runtime_helpers.evse_session_energy_uses_wh(
+        {"session_d": {"plg_in_at": "2026-06-13T17:06:43Z"}}
+    )
+    assert runtime_helpers.normalize_evse_session_energy("140.038", wh_hint=True) == (
+        0.14,
+        140.038,
+        "Wh",
+    )
+    assert runtime_helpers.normalize_evse_session_energy("3.52") == (
+        3.52,
+        3520.0,
+        "kWh",
+    )
+    with monkeypatch.context() as ctx:
+        ctx.setattr(
+            "builtins.round",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("boom")),
+        )
+        assert runtime_helpers.normalize_evse_session_energy(250) == (
+            None,
+            None,
+            "Wh",
+        )
+        assert runtime_helpers.normalize_evse_session_energy(2) == (
+            None,
+            None,
+            "kWh",
+        )
 
     inventory_view = MagicMock(
         has_type_for_entities=MagicMock(return_value=True),

--- a/tests/components/enphase_ev/test_sensor_coverage_last_session.py
+++ b/tests/components/enphase_ev/test_sensor_coverage_last_session.py
@@ -78,11 +78,14 @@ def test_last_session_helper_branches(monkeypatch):
 
     # Energy fallback paths
     kwh, wh = sensor._coerce_energy(None, 150.0)
-    assert kwh == pytest.approx(150.0)
-    assert wh == pytest.approx(150000.0)
+    assert kwh == pytest.approx(0.15)
+    assert wh == pytest.approx(150.0)
     kwh2, wh2 = sensor._coerce_energy(None, 250.0)
     assert kwh2 == pytest.approx(0.25)
     assert wh2 == pytest.approx(250.0)
+    kwh3, wh3 = sensor._coerce_energy(None, 140.038)
+    assert kwh3 == pytest.approx(0.14)
+    assert wh3 == pytest.approx(140.038)
 
     # History context when realtime lacks energy
     data = {


### PR DESCRIPTION
## Summary

Fixes #708.

IQ-EVSE session payloads can report `session_d.e_c` as Wh even when the value is below the old `> 200` heuristic. This updates EVSE session-energy normalization so modern/IQ-EVSE payloads such as `140.038 Wh` are exposed as `0.14 kWh` while preserving legacy small-kWh behavior for older payload shapes.

The coordinator now retains the raw reported session energy, inferred unit, normalized Wh, and normalized kWh for diagnostics and entity consumers. The Last Session sensor now treats `session_energy_wh` as actual Wh when deriving fallback attributes.

## Related Issues

Fixes #708

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/runtime_helpers.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/sensor.py --fail-under=100"
```

Results:

- `ruff check .` passed.
- `black custom_components/enphase_ev tests/components/enphase_ev` passed with 159 files unchanged.
- `python -m pre_commit run --all-files` passed.
- `pytest -q` passed with `3381 passed`.
- Full-suite coverage passed with `3381 passed` and 100% coverage for:
  - `custom_components/enphase_ev/runtime_helpers.py`
  - `custom_components/enphase_ev/coordinator.py`
  - `custom_components/enphase_ev/sensor.py`

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No screenshots. Regression coverage includes the issue payload shape where `140.038 Wh` now normalizes to `0.14 kWh`.
