### PR TITLE
Remove legacy Enphase site device

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -926,17 +926,76 @@ def _migrate_legacy_gateway_type_devices(
             continue
         _move_device_to_gateway(legacy_device, matched_type_key)
 
+    _remove_legacy_site_device(hass, entry, coord, dev_reg, site_id_text)
+
+
+def _is_legacy_site_device(device: object, legacy_site_ident: tuple[str, str]) -> bool:
+    """Return True for the old site-only placeholder device."""
+
+    identifiers = getattr(device, "identifiers", None)
+    if not identifiers:
+        return False
+    return set(identifiers) == {legacy_site_ident}
+
+
+def _remove_legacy_site_device(
+    hass: HomeAssistant,
+    entry: EnphaseConfigEntry,
+    coord,
+    dev_reg,
+    site_id: object,
+) -> None:
+    """Remove the legacy Enphase Site placeholder device."""
+
+    if er is None:
+        return
+    try:
+        site_id_text = str(site_id).strip()
+    except Exception:  # noqa: BLE001
+        site_id_text = ""
+    if not site_id_text:
+        return
+
+    entry_id = getattr(entry, "entry_id", None)
+    gateway_device_id = None
+    gateway_ident = coord.inventory_view.type_identifier("envoy") or (
+        DOMAIN,
+        f"type:{site_id_text}:envoy",
+    )
+    gateway_device = dev_reg.async_get_device(identifiers={gateway_ident})
+    if gateway_device is not None:
+        gateway_device_id = getattr(gateway_device, "id", None)
+
     legacy_site_ident = (DOMAIN, f"site:{site_id_text}")
     legacy_site_device = dev_reg.async_get_device(identifiers={legacy_site_ident})
     if legacy_site_device is None:
         return
+    if not _is_legacy_site_device(legacy_site_device, legacy_site_ident):
+        return
+    config_entries = getattr(legacy_site_device, "config_entries", None)
+    if config_entries is not None and entry_id not in config_entries:
+        return
     legacy_site_device_id = getattr(legacy_site_device, "id", None)
-    if legacy_site_device_id is None or legacy_site_device_id == gateway_device_id:
+    if legacy_site_device_id is None:
+        return
+    if gateway_device_id is not None and legacy_site_device_id == gateway_device_id:
+        return
+
+    try:
+        ent_reg = er.async_get(hass)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug(
+            "Skipping legacy site-device cleanup for site %s: %s",
+            redact_site_id(site_id_text),
+            redact_text(err, site_ids=(site_id_text,)),
+        )
         return
 
     moved_site_entities = 0
     for reg_entry in entries_for_device(ent_reg, legacy_site_device_id):
         if not is_owned_entity(reg_entry, entry_id):
+            continue
+        if gateway_device_id is None:
             continue
         entity_id = getattr(reg_entry, "entity_id", None)
         if not entity_id:
@@ -960,6 +1019,7 @@ def _migrate_legacy_gateway_type_devices(
         )
         return
 
+    remove_device = getattr(dev_reg, "async_remove_device", None)
     if callable(remove_device):
         try:
             remove_device(legacy_site_device_id)
@@ -1211,6 +1271,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     site_id = entry.data.get("site_id")
     dev_reg = dr.async_get(hass)
     _sync_registry_devices(entry, coord, dev_reg, site_id)
+    _remove_legacy_site_device(hass, entry, coord, dev_reg, site_id)
     _remove_evse_type_device_and_entities(hass, entry, dev_reg, site_id)
     _migrate_orphaned_update_entities_to_type_devices(hass, entry, site_id)
     _complete_startup_migrations_if_ready(hass, entry, coord, dev_reg, site_id)
@@ -1226,6 +1287,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
                 _remove_evse_type_device_and_entities(hass, entry, dev_reg, site_id)
                 _migrate_orphaned_update_entities_to_type_devices(hass, entry, site_id)
                 last_registry_signature = current_signature
+            _remove_legacy_site_device(hass, entry, coord, dev_reg, site_id)
             _complete_startup_migrations_if_ready(hass, entry, coord, dev_reg, site_id)
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -39,6 +39,7 @@ from custom_components.enphase_ev import (
     _registry_type_metadata_signature,
     _remove_evse_type_device_and_entities,
     _remove_legacy_inventory_entities,
+    _remove_legacy_site_device,
     _startup_migration_version,
     _sync_charger_devices,
     _sync_type_devices,
@@ -846,6 +847,279 @@ async def test_async_setup_entry_skips_startup_migrations_when_version_current(
 
     migrate_gateway.assert_not_called()
     migrate_cloud.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_removes_legacy_site_device_when_migration_current(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={**config_entry.data, "startup_migration_version": 5},
+    )
+    dev_reg = dr.async_get(hass)
+    legacy_site_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"site:{site_id}")},
+        manufacturer="Enphase",
+        name=f"Enphase Site {site_id}",
+        model="Site",
+    )
+
+    class DummyCoordinator:
+        def __init__(self) -> None:
+            self.site_id = site_id
+
+        async def async_config_entry_first_refresh(self) -> None:
+            return None
+
+        def iter_serials(self) -> list[str]:
+            return []
+
+        def iter_type_keys(self) -> list[str]:
+            return ["envoy"]
+
+        def type_identifier(self, type_key: str):
+            return (DOMAIN, f"type:{site_id}:{type_key}")
+
+        def type_label(self, _type_key: str) -> str:
+            return "Gateway"
+
+        def type_device_name(self, _type_key: str) -> str:
+            return "IQ Gateway"
+
+        def type_device_model(self, _type_key: str) -> str:
+            return "IQ Gateway"
+
+    dummy_coord = _with_inventory_view(DummyCoordinator())
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
+        lambda hass_, entry_data, config_entry=None: dummy_coord,
+    )
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
+
+    assert await async_setup_entry(hass, config_entry)
+
+    assert dev_reg.async_get(legacy_site_device.id) is None
+    assert (
+        dev_reg.async_get_device(identifiers={(DOMAIN, f"type:{site_id}:envoy")})
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_remove_legacy_site_device_preserves_real_devices_with_site_identifier(
+    hass: HomeAssistant, config_entry
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    dev_reg = dr.async_get(hass)
+    gateway = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"type:{site_id}:envoy")},
+        manufacturer="Enphase",
+        name="IQ Gateway",
+    )
+    charger = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, RANDOM_SERIAL), (DOMAIN, f"site:{site_id}")},
+        manufacturer="Enphase",
+        name="IQ EV Charger",
+    )
+    merged_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"site:{site_id}"), ("other_domain", "device-1")},
+        manufacturer="Enphase",
+        name="Merged Site Device",
+    )
+    coord = _with_inventory_view(
+        SimpleNamespace(
+            type_identifier=lambda key: (DOMAIN, f"type:{site_id}:{key}"),
+        )
+    )
+
+    _remove_legacy_site_device(hass, config_entry, coord, dev_reg, site_id)
+
+    assert dev_reg.async_get(gateway.id) is not None
+    assert dev_reg.async_get(charger.id) is not None
+    assert dev_reg.async_get(merged_device.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_remove_legacy_site_device_removes_empty_device_without_gateway(
+    hass: HomeAssistant, config_entry
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    dev_reg = dr.async_get(hass)
+    legacy_site_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"site:{site_id}")},
+        manufacturer="Enphase",
+        name=f"Enphase Site {site_id}",
+        model="Site",
+    )
+    coord = _with_inventory_view(
+        SimpleNamespace(
+            type_identifier=lambda key: (DOMAIN, f"type:{site_id}:{key}"),
+        )
+    )
+
+    _remove_legacy_site_device(hass, config_entry, coord, dev_reg, site_id)
+
+    assert dev_reg.async_get(legacy_site_device.id) is None
+
+
+@pytest.mark.asyncio
+async def test_remove_legacy_site_device_keeps_device_with_entities_without_gateway(
+    hass: HomeAssistant, config_entry
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    legacy_site_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"site:{site_id}")},
+        manufacturer="Enphase",
+        name=f"Enphase Site {site_id}",
+        model="Site",
+    )
+    site_metric = ent_reg.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_site_{site_id}_legacy_site_metric_no_gateway",
+        device_id=legacy_site_device.id,
+        config_entry=config_entry,
+    )
+    coord = _with_inventory_view(
+        SimpleNamespace(
+            type_identifier=lambda key: (DOMAIN, f"type:{site_id}:{key}"),
+        )
+    )
+
+    _remove_legacy_site_device(hass, config_entry, coord, dev_reg, site_id)
+
+    assert dev_reg.async_get(legacy_site_device.id) is not None
+    assert ent_reg.async_get(site_metric.entity_id) is not None
+
+
+def test_remove_legacy_site_device_handles_guard_paths(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    coord = _with_inventory_view(
+        SimpleNamespace(type_identifier=lambda _key: (DOMAIN, "type:site-1:envoy"))
+    )
+    noop_dev_reg = SimpleNamespace(async_get_device=lambda **_kwargs: None)
+
+    monkeypatch.setattr(enphase_init, "er", None)
+    _remove_legacy_site_device(hass, config_entry, coord, noop_dev_reg, "site-1")
+    monkeypatch.setattr(enphase_init, "er", er)
+
+    class BadSiteId:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    _remove_legacy_site_device(hass, config_entry, coord, noop_dev_reg, BadSiteId())
+    _remove_legacy_site_device(hass, config_entry, coord, noop_dev_reg, "   ")
+
+    gateway_no_id = SimpleNamespace(id=None)
+    monkeypatch.setattr(enphase_init, "er", er)
+    _remove_legacy_site_device(
+        hass,
+        config_entry,
+        coord,
+        SimpleNamespace(async_get_device=lambda **_kwargs: gateway_no_id),
+        "site-1",
+    )
+
+    gateway = SimpleNamespace(id="gateway")
+
+    def _device_reg_for(legacy_device):
+        def _get_device(*, identifiers):
+            if (DOMAIN, "type:site-1:envoy") in identifiers:
+                return gateway
+            if (DOMAIN, "site:site-1") in identifiers:
+                return legacy_device
+            return None
+
+        return SimpleNamespace(async_get_device=_get_device)
+
+    legacy_other_entry = SimpleNamespace(
+        id="legacy",
+        identifiers={(DOMAIN, "site:site-1")},
+        config_entries={"other-entry"},
+    )
+    _remove_legacy_site_device(
+        hass, config_entry, coord, _device_reg_for(legacy_other_entry), "site-1"
+    )
+
+    legacy_no_id = SimpleNamespace(
+        id=None,
+        identifiers={(DOMAIN, "site:site-1")},
+        config_entries={config_entry.entry_id},
+    )
+    _remove_legacy_site_device(
+        hass, config_entry, coord, _device_reg_for(legacy_no_id), "site-1"
+    )
+
+    legacy_same_id = SimpleNamespace(
+        id="gateway",
+        identifiers={(DOMAIN, "site:site-1")},
+        config_entries={config_entry.entry_id},
+    )
+    _remove_legacy_site_device(
+        hass, config_entry, coord, _device_reg_for(legacy_same_id), "site-1"
+    )
+
+    legacy = SimpleNamespace(
+        id="legacy",
+        identifiers={(DOMAIN, "site:site-1")},
+        config_entries={config_entry.entry_id},
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er.async_get",
+        lambda _hass: (_ for _ in ()).throw(RuntimeError("registry failed")),
+    )
+    _remove_legacy_site_device(
+        hass, config_entry, coord, _device_reg_for(legacy), "site-1"
+    )
+
+    entry_without_entity_id = SimpleNamespace(
+        platform=DOMAIN,
+        config_entry_id=config_entry.entry_id,
+        entity_id=None,
+        device_id="legacy",
+    )
+    ent_reg_missing_entity_id = SimpleNamespace(
+        entities={"entry": entry_without_entity_id},
+        async_update_entity=Mock(),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er.async_get",
+        lambda _hass: ent_reg_missing_entity_id,
+    )
+    _remove_legacy_site_device(
+        hass, config_entry, coord, _device_reg_for(legacy), "site-1"
+    )
+
+    entry_with_entity_id = SimpleNamespace(
+        platform=DOMAIN,
+        config_entry_id=config_entry.entry_id,
+        entity_id="sensor.legacy_site_metric",
+        device_id="legacy",
+    )
+    ent_reg_update_failure = SimpleNamespace(
+        entities={"entry": entry_with_entity_id},
+        async_update_entity=lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("move failed")
+        ),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er.async_get",
+        lambda _hass: ent_reg_update_failure,
+    )
+    _remove_legacy_site_device(
+        hass, config_entry, coord, _device_reg_for(legacy), "site-1"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Remove the stale legacy Enphase site-only placeholder device from the Home Assistant device registry.

The cleanup now runs during normal integration setup and registry sync, even when the one-time startup migration version is already current. It only removes devices whose identifiers are exactly the legacy site identifier, preserves real or merged devices, and removes an empty site placeholder even when no gateway device exists.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py tests/components/enphase_ev/test_init_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Component coverage result: `3267 passed`; `custom_components/enphase_ev/__init__.py` reported `100%` coverage.

Full test result: `3386 passed`.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No user-facing strings or translations changed.
