### PR TITLE
Retain battery site entities during startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v3.1.4 - 2026-06-14
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Fixed IQ Battery and Storm Guard entities disappearing during startup when early refreshes completed before BatteryConfig control capability details were fully populated.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `3.1.4`.
+
 ## v3.1.3 - 2026-06-14
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.1.3"
+  "version": "3.1.4"
 }

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -47,6 +47,15 @@ def _battery_write_access_confirmed(coord: EnphaseCoordinator) -> bool:
     return False
 
 
+def _battery_write_access_explicitly_denied(coord: EnphaseCoordinator) -> bool:
+    if getattr(coord, "battery_write_access_confirmed", None) is True:
+        return False
+    return (
+        getattr(coord, "battery_user_is_owner", None) is False
+        and getattr(coord, "battery_user_is_installer", None) is False
+    )
+
+
 def _battery_schedule_editor_active(
     coord: EnphaseCoordinator, entry: EnphaseConfigEntry | None
 ) -> bool:
@@ -66,17 +75,16 @@ def _retained_site_number_unique_ids(
     unique_ids: set[str] = set()
     if not _type_available(coord, "encharge"):
         return unique_ids
+    write_access_denied = _battery_write_access_explicitly_denied(coord)
+    core_unique_ids = {
+        f"{DOMAIN}_site_{coord.site_id}_battery_reserve",
+        f"{DOMAIN}_site_{coord.site_id}_battery_shutdown_level",
+    }
     if not battery_scheduler_enabled(entry):
-        if _battery_write_access_confirmed(coord):
-            if getattr(coord, "battery_reserve_editable", False):
-                unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_reserve")
-            unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_shutdown_level")
-        return unique_ids
+        return set() if write_access_denied else core_unique_ids
     editor_active = _battery_schedule_editor_active(coord, entry)
-    if _battery_write_access_confirmed(coord):
-        if getattr(coord, "battery_reserve_editable", False):
-            unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_reserve")
-        unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_shutdown_level")
+    if not write_access_denied:
+        unique_ids |= core_unique_ids
     if editor_active:
         unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit")
     return unique_ids
@@ -145,7 +153,6 @@ async def async_setup_entry(
         retained_site_number_unique_ids: set[str],
     ) -> dict[str, NumberEntity]:
         site_entities: dict[str, NumberEntity] = {}
-        write_access_confirmed = _battery_write_access_confirmed(coord)
 
         entity_factories: dict[str, Callable[[], NumberEntity]] = {
             f"{DOMAIN}_site_{coord.site_id}_battery_reserve": lambda: BatteryReserveNumber(
@@ -161,9 +168,9 @@ async def async_setup_entry(
                 f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit"
             ] = lambda: BatteryScheduleEditLimitNumber(coord, entry)
 
-        active_site_number_unique_ids: set[str] = set()
-        if write_access_confirmed:
-            active_site_number_unique_ids |= _core_site_number_unique_ids()
+        active_site_number_unique_ids = (
+            retained_site_number_unique_ids & _core_site_number_unique_ids()
+        )
         if battery_scheduler_enabled(entry):
             active_site_number_unique_ids |= retained_site_number_unique_ids & {
                 f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit"
@@ -190,9 +197,9 @@ async def async_setup_entry(
             if unique_id not in added_site_number_unique_ids
         )
         if _site_has_battery(coord) and _type_available(coord, "encharge"):
-            if _battery_write_access_confirmed(coord):
-                active_site_number_unique_ids = _core_site_number_unique_ids()
-                active_site_number_unique_ids |= set(tariff_entities)
+            active_site_number_unique_ids |= (
+                retained_site_number_unique_ids & _core_site_number_unique_ids()
+            )
             if battery_scheduler_enabled(entry):
                 active_site_number_unique_ids |= retained_site_number_unique_ids & {
                     f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit"
@@ -223,13 +230,25 @@ async def async_setup_entry(
             async_add_entities(entities, update_before_add=False)
         known_serials.intersection_update(current_serials)
         known_serials.update(serials)
-        added_site_number_unique_ids.intersection_update(active_site_number_unique_ids)
 
         if not inventory_ready:
             return
 
         # Registry cleanup waits for inventory so numbers are not removed while
         # optional BatteryConfig endpoints are still warming up.
+        if _site_has_battery(coord) and _type_available(coord, "encharge"):
+            loaded_site_number_unique_ids = {
+                unique_id
+                for unique_id in added_site_number_unique_ids
+                if unique_id in _managed_site_number_unique_ids()
+            }
+        else:
+            loaded_site_number_unique_ids = set()
+        loaded_tariff_number_unique_ids = {
+            unique_id
+            for unique_id in added_site_number_unique_ids
+            if _tariff_number_managed(unique_id)
+        }
         active_charger_unique_ids = {
             _charger_number_unique_id(sn) for sn in current_serials
         }
@@ -239,6 +258,8 @@ async def async_setup_entry(
             domain="number",
             active_unique_ids={
                 *active_site_number_unique_ids,
+                *loaded_site_number_unique_ids,
+                *loaded_tariff_number_unique_ids,
                 *active_charger_unique_ids,
             },
             is_managed=lambda unique_id: (

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -26,6 +26,7 @@ from .ac_battery_support import (
     AC_BATTERY_SOC_OPTIONS,
     ac_battery_control_available,
     ac_battery_device_info,
+    ac_battery_entities_available,
     ac_battery_soc_option_label,
 )
 from .const import DOMAIN
@@ -141,6 +142,15 @@ def _battery_write_access_confirmed(coord: EnphaseCoordinator) -> bool:
     return owner is True or installer is True
 
 
+def _battery_write_access_explicitly_denied(coord: EnphaseCoordinator) -> bool:
+    if getattr(coord, "battery_write_access_confirmed", None) is True:
+        return False
+    return (
+        getattr(coord, "battery_user_is_owner", None) is False
+        and getattr(coord, "battery_user_is_installer", None) is False
+    )
+
+
 def _retain_system_profile(coord: EnphaseCoordinator) -> bool:
     if not _site_has_battery(coord):
         return False
@@ -148,14 +158,12 @@ def _retain_system_profile(coord: EnphaseCoordinator) -> bool:
         return False
     available = getattr(coord, "battery_profile_selection_available", None)
     if available is not None:
-        return bool(available and _battery_write_access_confirmed(coord))
+        return bool(available and not _battery_write_access_explicitly_denied(coord))
     if not getattr(coord, "battery_controls_available", False):
         return False
-    owner = getattr(coord, "battery_user_is_owner", None)
-    installer = getattr(coord, "battery_user_is_installer", None)
-    if owner is False and installer is False:
+    if _battery_write_access_explicitly_denied(coord):
         return False
-    return _battery_write_access_confirmed(coord)
+    return True
 
 
 def _retain_ac_battery_target_soc(coord: EnphaseCoordinator) -> bool:
@@ -241,12 +249,7 @@ async def async_setup_entry(
         retain_system_profile = _retain_system_profile(coord)
         retain_ac_battery_target_soc = _retain_ac_battery_target_soc(coord)
         retain_battery_schedule_editor = _retain_battery_schedule_editor(coord, entry)
-        if (
-            not site_entity_added
-            and _site_has_battery(coord)
-            and _battery_write_access_confirmed(coord)
-            and _type_available(coord, "envoy")
-        ):
+        if not site_entity_added and retain_system_profile:
             async_add_entities([SystemProfileSelect(coord)], update_before_add=False)
             site_entity_added = True
         if not ac_battery_select_added and retain_ac_battery_target_soc:
@@ -263,16 +266,23 @@ async def async_setup_entry(
                 update_before_add=False,
             )
             battery_schedule_editor_added = True
-        if not retain_system_profile:
-            site_entity_added = False
-        if not retain_ac_battery_target_soc:
-            ac_battery_select_added = False
-        if not retain_battery_schedule_editor:
-            battery_schedule_editor_added = False
         if not inventory_ready:
             return
         # Site-level selects are dynamic because BatteryConfig permissions and
         # AC Battery support are learned after setup.
+        system_profile_loaded = (
+            site_entity_added
+            and _site_has_battery(coord)
+            and _type_available(coord, "envoy")
+        )
+        ac_battery_target_soc_loaded = (
+            ac_battery_select_added and ac_battery_entities_available(coord)
+        )
+        battery_schedule_editor_loaded = (
+            battery_schedule_editor_added
+            and _site_has_battery(coord)
+            and _type_available(coord, "encharge")
+        )
         prune_managed_entities(
             ent_reg,
             entry.entry_id,
@@ -280,18 +290,23 @@ async def async_setup_entry(
             active_unique_ids={
                 unique_id
                 for unique_id, retained in (
-                    (_system_profile_unique_id(), retain_system_profile),
+                    (
+                        _system_profile_unique_id(),
+                        retain_system_profile or system_profile_loaded,
+                    ),
                     (
                         f"{DOMAIN}_site_{coord.site_id}_ac_battery_target_state_of_charge",
-                        retain_ac_battery_target_soc,
+                        retain_ac_battery_target_soc or ac_battery_target_soc_loaded,
                     ),
                     (
                         _battery_schedule_select_unique_id(),
-                        retain_battery_schedule_editor,
+                        retain_battery_schedule_editor
+                        or battery_schedule_editor_loaded,
                     ),
                     (
                         _battery_new_schedule_type_unique_id(),
-                        retain_battery_schedule_editor,
+                        retain_battery_schedule_editor
+                        or battery_schedule_editor_loaded,
                     ),
                 )
                 if retained

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -203,9 +203,48 @@ def _battery_write_access_confirmed(coord: EnphaseCoordinator) -> bool:
     return False
 
 
+def _battery_write_access_explicitly_denied(coord: EnphaseCoordinator) -> bool:
+    if getattr(coord, "battery_write_access_confirmed", None) is True:
+        return False
+    return (
+        getattr(coord, "battery_user_is_owner", None) is False
+        and getattr(coord, "battery_user_is_installer", None) is False
+    )
+
+
 def _storm_guard_visible(coord: EnphaseCoordinator) -> bool:
     show_storm_guard = getattr(coord, "battery_show_storm_guard", None)
     return show_storm_guard is not False
+
+
+def _charge_from_grid_retained(coord: EnphaseCoordinator) -> bool:
+    if getattr(coord, "battery_system_task", None) is True:
+        return False
+    cfg_show = getattr(coord, "battery_cfg_control_show", None)
+    if cfg_show is False:
+        return False
+    if (
+        cfg_show is None
+        and getattr(coord, "_battery_hide_charge_from_grid", None) is True
+    ):
+        return False
+    if getattr(coord, "battery_cfg_control_locked", None) is True:
+        return False
+    return True
+
+
+def _charge_from_grid_schedule_retained(coord: EnphaseCoordinator) -> bool:
+    if not _charge_from_grid_retained(coord):
+        return False
+    show_day_schedule = getattr(coord, "battery_cfg_control_show_day_schedule", None)
+    if show_day_schedule is False:
+        return False
+    force_supported = getattr(
+        coord,
+        "battery_cfg_control_force_schedule_supported",
+        None,
+    )
+    return force_supported is not False
 
 
 def _retained_site_switch_keys(
@@ -216,21 +255,18 @@ def _retained_site_switch_keys(
     if (
         _site_has_battery(coord)
         and _type_available(coord, "envoy")
-        and _battery_write_access_confirmed(coord)
+        and not _battery_write_access_explicitly_denied(coord)
         and _storm_guard_visible(coord)
-        and getattr(coord, "storm_guard_state", None) is not None
-        and getattr(coord, "storm_evse_enabled", None) is not None
     ):
         retained.add("storm_guard")
-    if _type_available(coord, "encharge") and _battery_write_access_confirmed(coord):
+    if _type_available(
+        coord, "encharge"
+    ) and not _battery_write_access_explicitly_denied(coord):
         if getattr(coord, "savings_use_battery_switch_available", None) is not False:
             retained.add("savings_use_battery_after_peak")
-        if getattr(coord, "charge_from_grid_control_available", None) is not False:
+        if _charge_from_grid_retained(coord):
             retained.add("charge_from_grid")
-        if (
-            getattr(coord, "charge_from_grid_force_schedule_available", None)
-            is not False
-        ):
+        if _charge_from_grid_schedule_retained(coord):
             retained.add("charge_from_grid_schedule")
         if getattr(coord, "discharge_to_grid_schedule_available", None) is not False:
             retained.add("discharge_to_grid_schedule")

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -247,12 +247,94 @@ async def test_async_setup_entry_prunes_stale_number_entities_when_inventory_rea
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_skips_site_numbers_without_confirmed_write_access(
+async def test_async_setup_entry_keeps_site_numbers_while_permission_unknown(
+    hass, config_entry, monkeypatch
+) -> None:
+    coord = SimpleNamespace()
+    coord.site_id = "123456"
+    coord.battery_write_access_confirmed = False
+    coord.inventory_view = SimpleNamespace(
+        has_type_for_entities=lambda type_key: type_key == "encharge",
+        type_device_info=lambda _type_key: None,
+    )
+    coord.serials = {RANDOM_SERIAL}
+    coord._serial_order = [RANDOM_SERIAL]
+    coord.data = {RANDOM_SERIAL: {"name": "Garage EV"}}
+    coord.iter_serials = lambda: [RANDOM_SERIAL]
+    listener_callbacks = []
+
+    def _capture_listener(callback):
+        listener_callbacks.append(callback)
+        return lambda: None
+
+    coord.async_add_listener = MagicMock(side_effect=_capture_listener)
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord.last_update_success = True
+
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    prune_spy = MagicMock()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.number.prune_managed_entities", prune_spy
+    )
+
+    added = []
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    assert any(isinstance(ent, ChargingAmpsNumber) for ent in added)
+    reserve = next(ent for ent in added if isinstance(ent, BatteryReserveNumber))
+    shutdown = next(ent for ent in added if isinstance(ent, BatteryShutdownLevelNumber))
+    assert reserve.available is False
+    assert shutdown.available is False
+    assert not any(isinstance(ent, BatteryScheduleEditLimitNumber) for ent in added)
+
+    reserve_unique_id = f"enphase_ev_site_{coord.site_id}_battery_reserve"
+    shutdown_unique_id = f"enphase_ev_site_{coord.site_id}_battery_shutdown_level"
+
+    added.clear()
+    prune_spy.reset_mock()
+    coord.battery_user_is_owner = False
+    coord.battery_user_is_installer = False
+    listener_callbacks[0]()
+
+    active_unique_ids = prune_spy.call_args.kwargs["active_unique_ids"]
+    assert reserve_unique_id in active_unique_ids
+    assert shutdown_unique_id in active_unique_ids
+
+    prune_spy.reset_mock()
+    coord.battery_write_access_confirmed = True
+    listener_callbacks[0]()
+
+    assert not any(isinstance(ent, BatteryReserveNumber) for ent in added)
+    assert not any(isinstance(ent, BatteryShutdownLevelNumber) for ent in added)
+    active_unique_ids = prune_spy.call_args.kwargs["active_unique_ids"]
+    assert reserve_unique_id in active_unique_ids
+    assert shutdown_unique_id in active_unique_ids
+
+    prune_spy.reset_mock()
+    coord.inventory_view = SimpleNamespace(
+        has_type_for_entities=lambda _type_key: False,
+        type_device_info=lambda _type_key: None,
+    )
+    listener_callbacks[0]()
+
+    active_unique_ids = prune_spy.call_args.kwargs["active_unique_ids"]
+    assert reserve_unique_id not in active_unique_ids
+    assert shutdown_unique_id not in active_unique_ids
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_site_numbers_when_write_access_denied(
     hass, config_entry
 ) -> None:
     coord = SimpleNamespace()
     coord.site_id = "123456"
     coord.battery_write_access_confirmed = False
+    coord.battery_user_is_owner = False
+    coord.battery_user_is_installer = False
     coord.inventory_view = SimpleNamespace(
         has_type_for_entities=lambda type_key: type_key == "encharge",
         type_device_info=lambda _type_key: None,
@@ -276,7 +358,6 @@ async def test_async_setup_entry_skips_site_numbers_without_confirmed_write_acce
     assert any(isinstance(ent, ChargingAmpsNumber) for ent in added)
     assert not any(isinstance(ent, BatteryReserveNumber) for ent in added)
     assert not any(isinstance(ent, BatteryShutdownLevelNumber) for ent in added)
-    assert not any(isinstance(ent, BatteryScheduleEditLimitNumber) for ent in added)
 
 
 def test_charging_number_converts_values(hass, config_entry) -> None:
@@ -788,3 +869,71 @@ async def test_tariff_rate_numbers_are_created_and_stale_entries_pruned(
         f"enphase_ev_site_{coord.site_id}_tariff_import_rate_default_week_off_peak_number"
     ]
     assert ent_reg.async_get_entity_id("number", "enphase_ev", stale_unique_id) is None
+
+
+@pytest.mark.asyncio
+async def test_tariff_rate_number_registry_is_kept_when_loaded_spec_disappears(
+    hass, config_entry, monkeypatch
+) -> None:
+    payload = {
+        "purchase": {
+            "typeKind": "single",
+            "typeId": "flat",
+            "seasons": [
+                {
+                    "id": "default",
+                    "days": [
+                        {
+                            "id": "week",
+                            "periods": [{"id": "off-peak", "rate": "0.18"}],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    coord = _make_coordinator(hass, config_entry, {})
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord.tariff_import_rate = parse_tariff_rate(payload, "purchase")
+    listener_callbacks = []
+
+    def _capture_listener(callback):
+        listener_callbacks.append(callback)
+        return lambda: None
+
+    coord.async_add_listener = MagicMock(side_effect=_capture_listener)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    prune_spy = MagicMock()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.number.prune_managed_entities", prune_spy
+    )
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    unique_id = (
+        f"enphase_ev_site_{coord.site_id}"
+        "_tariff_import_rate_default_week_off_peak_number"
+    )
+    assert any(
+        isinstance(entity, EnphaseTariffRateNumber) and entity.unique_id == unique_id
+        for entity in added
+    )
+
+    added.clear()
+    prune_spy.reset_mock()
+    coord.tariff_import_rate = None
+    listener_callbacks[0]()
+
+    active_unique_ids = prune_spy.call_args.kwargs["active_unique_ids"]
+    assert unique_id in active_unique_ids
+
+    prune_spy.reset_mock()
+    coord.tariff_import_rate = parse_tariff_rate(payload, "purchase")
+    listener_callbacks[0]()
+
+    assert not any(isinstance(entity, EnphaseTariffRateNumber) for entity in added)
+    active_unique_ids = prune_spy.call_args.kwargs["active_unique_ids"]
+    assert unique_id in active_unique_ids

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -789,8 +789,8 @@ async def test_select_platform_skips_system_profile_without_battery(
 
 
 @pytest.mark.asyncio
-async def test_select_platform_adds_system_profile_after_permission_refresh(
-    hass, config_entry, coordinator_factory
+async def test_select_platform_retains_system_profile_while_permission_unknown(
+    hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
     from custom_components.enphase_ev.const import (
         OPT_BATTERY_SCHEDULES_ENABLED,
@@ -807,6 +807,7 @@ async def test_select_platform_adds_system_profile_after_permission_refresh(
     coord._battery_profile = "self-consumption"  # noqa: SLF001
     coord._battery_user_is_owner = None  # noqa: SLF001
     coord._battery_user_is_installer = None  # noqa: SLF001
+    coord._devices_inventory_ready = True  # noqa: SLF001
     object.__setattr__(
         config_entry,
         "options",
@@ -833,20 +834,43 @@ async def test_select_platform_adds_system_profile_after_permission_refresh(
     coord.async_add_topology_listener = capture_topology  # type: ignore[attr-defined]
     coord.async_add_listener = capture_update  # type: ignore[attr-defined]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    prune_spy = MagicMock()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.select.prune_managed_entities", prune_spy
+    )
 
     await async_setup_entry(hass, config_entry, capture_add)
 
-    assert len(added) == 1
-    assert all(isinstance(entity, ChargeModeSelect) for entity in added[0])
     assert len(topology_callbacks) == 1
     assert len(update_callbacks) == 1
+    flat_added = [entity for group in added for entity in group]
+    system_profile = next(
+        entity for entity in flat_added if isinstance(entity, SystemProfileSelect)
+    )
+    assert system_profile.available is False
+    assert any(
+        isinstance(entity, ChargeModeSelect) and entity._sn == "1111"
+        for entity in flat_added
+    )
 
+    system_profile_unique_id = f"enphase_ev_site_{coord.site_id}_system_profile"
+    prune_spy.reset_mock()
+    coord._battery_user_is_owner = False  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    update_callbacks[0]()
+
+    active_unique_ids = prune_spy.call_args.kwargs["active_unique_ids"]
+    assert system_profile_unique_id in active_unique_ids
+
+    prune_spy.reset_mock()
     coord._battery_user_is_owner = True  # noqa: SLF001
     coord._battery_user_is_installer = False  # noqa: SLF001
     update_callbacks[0]()
 
     flat_added = [entity for group in added for entity in group]
-    assert any(isinstance(entity, SystemProfileSelect) for entity in flat_added)
+    assert sum(isinstance(entity, SystemProfileSelect) for entity in flat_added) == 1
+    active_unique_ids = prune_spy.call_args.kwargs["active_unique_ids"]
+    assert system_profile_unique_id in active_unique_ids
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -268,6 +268,35 @@ def test_switch_battery_write_access_confirmed_falls_back_to_false() -> None:
     assert switch_mod._battery_write_access_confirmed(coord) is False
 
 
+def test_charge_from_grid_retention_honors_explicit_negative_flags() -> None:
+    coord = SimpleNamespace()
+
+    coord.battery_system_task = True
+    assert switch_mod._charge_from_grid_retained(coord) is False
+
+    coord.battery_system_task = False
+    coord.battery_cfg_control_show = False
+    assert switch_mod._charge_from_grid_retained(coord) is False
+
+    coord.battery_cfg_control_show = None
+    coord._battery_hide_charge_from_grid = True  # noqa: SLF001
+    assert switch_mod._charge_from_grid_retained(coord) is False
+
+    coord._battery_hide_charge_from_grid = False  # noqa: SLF001
+    coord.battery_cfg_control_locked = True
+    assert switch_mod._charge_from_grid_retained(coord) is False
+
+    coord.battery_cfg_control_locked = False
+    assert switch_mod._charge_from_grid_retained(coord) is True
+
+    coord.battery_system_task = True
+    assert switch_mod._charge_from_grid_schedule_retained(coord) is False
+
+    coord.battery_system_task = False
+    coord.battery_cfg_control_show_day_schedule = False
+    assert switch_mod._charge_from_grid_schedule_retained(coord) is False
+
+
 def test_switch_pending_helper_edge_paths() -> None:
     entity = SimpleNamespace(
         hass=object(),
@@ -564,7 +593,7 @@ async def test_async_setup_entry_syncs_chargers(
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_adds_cfg_switches_when_support_becomes_available(
+async def test_async_setup_entry_keeps_cfg_switches_while_permission_unknown(
     hass, config_entry, coordinator_factory
 ) -> None:
     coord = coordinator_factory()
@@ -588,8 +617,18 @@ async def test_async_setup_entry_adds_cfg_switches_when_support_becomes_availabl
 
     await async_setup_entry(hass, config_entry, _capture)
 
-    assert not any(isinstance(entity, ChargeFromGridSwitch) for entity in added)
-    assert not any(isinstance(entity, ChargeFromGridScheduleSwitch) for entity in added)
+    charge_switch = next(
+        entity for entity in added if isinstance(entity, ChargeFromGridSwitch)
+    )
+    schedule_switch = next(
+        entity for entity in added if isinstance(entity, ChargeFromGridScheduleSwitch)
+    )
+    storm_guard_switch = next(
+        entity for entity in added if isinstance(entity, StormGuardSwitch)
+    )
+    assert charge_switch.available is False
+    assert schedule_switch.available is False
+    assert storm_guard_switch.available is False
 
     coord._battery_user_is_owner = True  # noqa: SLF001
     coord._battery_charge_from_grid = True  # noqa: SLF001
@@ -599,8 +638,12 @@ async def test_async_setup_entry_adds_cfg_switches_when_support_becomes_availabl
 
     listener_callbacks[0]()
 
-    assert any(isinstance(entity, ChargeFromGridSwitch) for entity in added)
-    assert any(isinstance(entity, ChargeFromGridScheduleSwitch) for entity in added)
+    assert charge_switch.available is True
+    assert schedule_switch.available is True
+    assert sum(isinstance(entity, ChargeFromGridSwitch) for entity in added) == 1
+    assert (
+        sum(isinstance(entity, ChargeFromGridScheduleSwitch) for entity in added) == 1
+    )
 
 
 @pytest.mark.asyncio
@@ -680,6 +723,88 @@ async def test_async_setup_entry_adds_supported_battery_site_switches_and_prunes
         not in active_unique_ids
     )
     assert f"enphase_ev_site_{coord.site_id}_charge_from_grid" not in active_unique_ids
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_keeps_loaded_site_switches_when_support_disproven(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = None  # noqa: SLF001
+    coord._battery_user_is_installer = None  # noqa: SLF001
+    coord._battery_show_storm_guard = True  # noqa: SLF001
+    listener_callbacks = []
+    original_add_listener = coord.async_add_listener
+
+    def _capture_listener(callback):
+        listener_callbacks.append(callback)
+        return original_add_listener(callback)
+
+    coord.async_add_listener = MagicMock(side_effect=_capture_listener)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    prune_spy = MagicMock()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.switch.prune_managed_entities", prune_spy
+    )
+
+    added = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+
+    assert any(isinstance(entity, StormGuardSwitch) for entity in added)
+    assert any(isinstance(entity, ChargeFromGridSwitch) for entity in added)
+    assert any(isinstance(entity, ChargeFromGridScheduleSwitch) for entity in added)
+
+    prune_spy.reset_mock()
+    coord._battery_show_storm_guard = False  # noqa: SLF001
+    coord._battery_cfg_control = (  # noqa: SLF001
+        coord.battery_runtime._parse_battery_control_capability(
+            {
+                "show": False,
+                "showDaySchedule": False,
+                "forceScheduleSupported": False,
+            }
+        )
+    )
+    listener_callbacks[0]()
+
+    active_unique_ids = prune_spy.call_args_list[0].kwargs["active_unique_ids"]
+    assert f"enphase_ev_site_{coord.site_id}_storm_guard" in active_unique_ids
+    assert f"enphase_ev_site_{coord.site_id}_charge_from_grid" in active_unique_ids
+    assert (
+        f"enphase_ev_site_{coord.site_id}_charge_from_grid_schedule"
+        in active_unique_ids
+    )
+
+    added.clear()
+    prune_spy.reset_mock()
+    coord._battery_show_storm_guard = True  # noqa: SLF001
+    coord._battery_cfg_control = (  # noqa: SLF001
+        coord.battery_runtime._parse_battery_control_capability(
+            {
+                "show": True,
+                "showDaySchedule": True,
+                "forceScheduleSupported": True,
+            }
+        )
+    )
+    listener_callbacks[0]()
+
+    assert not any(isinstance(entity, StormGuardSwitch) for entity in added)
+    assert not any(isinstance(entity, ChargeFromGridSwitch) for entity in added)
+    assert not any(isinstance(entity, ChargeFromGridScheduleSwitch) for entity in added)
+    active_unique_ids = prune_spy.call_args_list[0].kwargs["active_unique_ids"]
+    assert f"enphase_ev_site_{coord.site_id}_storm_guard" in active_unique_ids
+    assert f"enphase_ev_site_{coord.site_id}_charge_from_grid" in active_unique_ids
+    assert (
+        f"enphase_ev_site_{coord.site_id}_charge_from_grid_schedule"
+        in active_unique_ids
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes a startup entity lifecycle regression where IQ Battery and Storm Guard controls could be removed from the Home Assistant entity registry when early refreshes completed before BatteryConfig capability and permission details were fully populated.

The change keeps already-loaded site-level battery selects, numbers, switches, and tariff number entities active during registry cleanup while preserving structural cleanup when the underlying device family is genuinely absent. This prevents live platform entities from becoming unregistered and failing to recover cleanly on later refreshes.

## Related Issues

Related to the 3.1.3 regression where these entities could disappear and later reappear after a full BatteryConfig refresh:

- `select.gateway_1_system_profile`
- `switch.battery_2_charge_battery_from_grid`
- `switch.enphase_site_3381244_storm_guard`

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/select.py custom_components/enphase_ev/number.py custom_components/enphase_ev/switch.py tests/components/enphase_ev/test_select_charge_mode.py tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_switch_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/select.py,custom_components/enphase_ev/switch.py,custom_components/enphase_ev/number.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
git diff --check
```

Results:

- Component coverage run: `3271 passed`; `select.py`, `number.py`, and `switch.py` all reported `100%` coverage.
- Full repository pytest: `3390 passed`.
- Ruff, pre-commit, Black, quality-scale validation, and `git diff --check` passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Documentation and translations were not changed because this is a registry lifecycle bug fix with no new user-facing strings or configuration options. GitHub Actions had not run yet at PR creation time.
