### PR TITLE
Fix startup battery entity availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v3.1.5 - 2026-06-14
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Fixed System Profile, Storm Guard, and IQ Battery control entities staying unavailable during startup while BatteryConfig permission details were still loading.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `3.1.5`.
+
 ## v3.1.4 - 2026-06-14
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.1.4"
+  "version": "3.1.5"
 }

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -292,7 +292,7 @@ class BatteryReserveNumber(CoordinatorEntity, NumberEntity):
             return False
         return (
             _type_available(self._coord, "encharge")
-            and _battery_write_access_confirmed(self._coord)
+            and not _battery_write_access_explicitly_denied(self._coord)
             and self._coord.battery_reserve_editable
         )
 
@@ -444,7 +444,7 @@ class BatteryShutdownLevelNumber(CoordinatorEntity, NumberEntity):
             return False
         return (
             _type_available(self._coord, "encharge")
-            and _battery_write_access_confirmed(self._coord)
+            and not _battery_write_access_explicitly_denied(self._coord)
             and self._coord.battery_shutdown_level_available
         )
 

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -404,7 +404,7 @@ class SystemProfileSelect(CoordinatorEntity, SelectEntity):
                 return False
         elif not available:
             return False
-        if not _battery_write_access_confirmed(self._coord):
+        if _battery_write_access_explicitly_denied(self._coord):
             return False
         return bool(self.options)
 

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -601,16 +601,13 @@ class StormGuardSwitch(CoordinatorEntity, SwitchEntity):
     def available(self) -> bool:  # type: ignore[override]
         if not super().available:
             return False
-        if not _battery_write_access_confirmed(self._coord):
+        if _battery_write_access_explicitly_denied(self._coord):
             return False
         if not _storm_guard_visible(self._coord):
             return False
         if not _type_available(self._coord, "envoy"):
             return False
-        return (
-            self._coord.storm_guard_state is not None
-            and self._coord.storm_evse_enabled is not None
-        )
+        return self._coord.storm_guard_state is not None
 
     @property
     def is_on(self) -> bool:
@@ -656,7 +653,7 @@ class SavingsUseBatteryAfterPeakSwitch(CoordinatorEntity, SwitchEntity):
             return False
         return (
             _type_available(self._coord, "encharge")
-            and _battery_write_access_confirmed(self._coord)
+            and not _battery_write_access_explicitly_denied(self._coord)
             and self._coord.savings_use_battery_switch_available
         )
 
@@ -696,7 +693,7 @@ class ChargeFromGridSwitch(CoordinatorEntity, SwitchEntity):
             return False
         return (
             _type_available(self._coord, "encharge")
-            and _battery_write_access_confirmed(self._coord)
+            and not _battery_write_access_explicitly_denied(self._coord)
             and self._coord.charge_from_grid_control_available
         )
 
@@ -746,7 +743,7 @@ class ChargeFromGridScheduleSwitch(CoordinatorEntity, SwitchEntity):
             return False
         return (
             _type_available(self._coord, "encharge")
-            and _battery_write_access_confirmed(self._coord)
+            and not _battery_write_access_explicitly_denied(self._coord)
             and self._coord.charge_from_grid_force_schedule_available
         )
 
@@ -814,7 +811,7 @@ class _BaseBatteryScheduleSwitch(CoordinatorEntity, SwitchEntity):
             return False
         return (
             _type_available(self._coord, "encharge")
-            and _battery_write_access_confirmed(self._coord)
+            and not _battery_write_access_explicitly_denied(self._coord)
             and bool(getattr(self._coord, self._availability_attr, False))
         )
 

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -270,6 +270,8 @@ async def test_async_setup_entry_keeps_site_numbers_while_permission_unknown(
     coord.async_add_listener = MagicMock(side_effect=_capture_listener)
     coord._devices_inventory_ready = True  # noqa: SLF001
     coord.last_update_success = True
+    coord.battery_reserve_editable = True
+    coord.battery_shutdown_level_available = True
 
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
     prune_spy = MagicMock()
@@ -287,8 +289,8 @@ async def test_async_setup_entry_keeps_site_numbers_while_permission_unknown(
     assert any(isinstance(ent, ChargingAmpsNumber) for ent in added)
     reserve = next(ent for ent in added if isinstance(ent, BatteryReserveNumber))
     shutdown = next(ent for ent in added if isinstance(ent, BatteryShutdownLevelNumber))
-    assert reserve.available is False
-    assert shutdown.available is False
+    assert reserve.available is True
+    assert shutdown.available is True
     assert not any(isinstance(ent, BatteryScheduleEditLimitNumber) for ent in added)
 
     reserve_unique_id = f"enphase_ev_site_{coord.site_id}_battery_reserve"
@@ -303,6 +305,8 @@ async def test_async_setup_entry_keeps_site_numbers_while_permission_unknown(
     active_unique_ids = prune_spy.call_args.kwargs["active_unique_ids"]
     assert reserve_unique_id in active_unique_ids
     assert shutdown_unique_id in active_unique_ids
+    assert reserve.available is False
+    assert shutdown.available is False
 
     prune_spy.reset_mock()
     coord.battery_write_access_confirmed = True

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -283,6 +283,10 @@ def test_select_helper_fallbacks() -> None:
     assert select_mod._battery_write_access_confirmed(coord) is True
     assert select_mod._retain_system_profile(coord) is True
 
+    coord.battery_write_access_confirmed = False
+    assert select_mod._battery_write_access_confirmed(coord) is False
+    coord.battery_write_access_confirmed = None
+
     coord.battery_profile_selection_available = False
     assert select_mod._retain_system_profile(coord) is False
 
@@ -847,7 +851,7 @@ async def test_select_platform_retains_system_profile_while_permission_unknown(
     system_profile = next(
         entity for entity in flat_added if isinstance(entity, SystemProfileSelect)
     )
-    assert system_profile.available is False
+    assert system_profile.available is True
     assert any(
         isinstance(entity, ChargeModeSelect) and entity._sn == "1111"
         for entity in flat_added
@@ -1093,7 +1097,29 @@ def test_system_profile_select_unavailable_for_read_only_user(coordinator_factor
     assert sel.available is False
 
 
-def test_system_profile_select_unavailable_without_confirmed_write_access(
+def test_system_profile_select_unavailable_when_fallback_permission_denied() -> None:
+    from custom_components.enphase_ev.select import SystemProfileSelect
+
+    coord = SimpleNamespace(
+        site_id="site",
+        hass=None,
+        last_update_success=True,
+        battery_profile_selection_available=True,
+        battery_write_access_confirmed=False,
+        battery_user_is_owner=False,
+        battery_user_is_installer=False,
+        battery_profile_option_labels={"self-consumption": "Self-Consumption"},
+        battery_profile_option_keys=["self-consumption"],
+        battery_selected_profile="self-consumption",
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda type_key: type_key == "envoy"
+        ),
+    )
+
+    assert SystemProfileSelect(coord).available is False
+
+
+def test_system_profile_select_available_while_write_access_unknown(
     coordinator_factory,
 ):
     from custom_components.enphase_ev.select import SystemProfileSelect
@@ -1105,7 +1131,7 @@ def test_system_profile_select_unavailable_without_confirmed_write_access(
     coord._battery_user_is_installer = None  # noqa: SLF001
     sel = SystemProfileSelect(coord)
 
-    assert sel.available is False
+    assert sel.available is True
 
 
 @pytest.mark.asyncio
@@ -1275,22 +1301,32 @@ def test_system_profile_select_availability_fallback_and_device_info(
 ) -> None:
     from custom_components.enphase_ev.select import SystemProfileSelect
 
-    coord = coordinator_factory()
-    coord.inventory_view.type_device_info = lambda _type_key: None
-    coord._battery_profile_selection_available = None  # noqa: SLF001
-    coord._battery_controls_available = False  # noqa: SLF001
-    coord._battery_show_charge_from_grid = True  # noqa: SLF001
-    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord = SimpleNamespace(
+        site_id="site",
+        hass=None,
+        last_update_success=True,
+        battery_has_encharge=True,
+        battery_profile_selection_available=None,
+        battery_controls_available=False,
+        battery_write_access_confirmed=None,
+        battery_user_is_owner=True,
+        battery_user_is_installer=False,
+        battery_profile_option_labels={"self-consumption": "Self-Consumption"},
+        battery_profile_option_keys=["self-consumption"],
+        battery_selected_profile="self-consumption",
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda type_key: type_key == "envoy",
+            type_device_info=lambda _type_key: None,
+        ),
+    )
 
     sel = SystemProfileSelect(coord)
     assert sel.available is False
-    assert sel.device_info["identifiers"] == {
-        ("enphase_ev", f"type:{coord.site_id}:envoy")
-    }
+    assert sel.device_info["identifiers"] == {("enphase_ev", "type:site:envoy")}
 
-    coord._battery_controls_available = True  # noqa: SLF001
-    coord._battery_user_is_owner = False  # noqa: SLF001
-    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.battery_controls_available = True
+    coord.battery_user_is_owner = False
+    coord.battery_user_is_installer = False
     assert sel.available is False
 
     coord.inventory_view.has_type_for_entities = lambda _type_key: False

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -600,6 +600,12 @@ async def test_async_setup_entry_keeps_cfg_switches_while_permission_unknown(
     coord._battery_write_access_confirmed = False  # noqa: SLF001
     coord._battery_user_is_owner = None  # noqa: SLF001
     coord._battery_user_is_installer = None  # noqa: SLF001
+    coord._storm_guard_state = "disabled"  # noqa: SLF001
+    coord._storm_evse_enabled = None  # noqa: SLF001
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_charge_from_grid_schedule_enabled = True  # noqa: SLF001
+    coord._battery_charge_begin_time = 120  # noqa: SLF001
+    coord._battery_charge_end_time = 300  # noqa: SLF001
     listener_callbacks = []
     original_add_listener = coord.async_add_listener
 
@@ -626,9 +632,9 @@ async def test_async_setup_entry_keeps_cfg_switches_while_permission_unknown(
     storm_guard_switch = next(
         entity for entity in added if isinstance(entity, StormGuardSwitch)
     )
-    assert charge_switch.available is False
-    assert schedule_switch.available is False
-    assert storm_guard_switch.available is False
+    assert charge_switch.available is True
+    assert schedule_switch.available is True
+    assert storm_guard_switch.available is True
 
     coord._battery_user_is_owner = True  # noqa: SLF001
     coord._battery_charge_from_grid = True  # noqa: SLF001
@@ -1921,7 +1927,7 @@ def test_storm_guard_switch_is_on_prefers_pending_state(coordinator_factory) -> 
     assert StormGuardSwitch(coord).is_on is True
 
 
-def test_storm_guard_switch_unavailable_without_confirmed_write_access(
+def test_storm_guard_switch_available_while_write_access_unknown(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -1930,7 +1936,19 @@ def test_storm_guard_switch_unavailable_without_confirmed_write_access(
     coord._storm_guard_state = "enabled"  # noqa: SLF001
     coord._storm_evse_enabled = True  # noqa: SLF001
     sw = StormGuardSwitch(coord)
-    assert sw.available is False
+    assert sw.available is True
+
+
+def test_storm_guard_switch_unavailable_when_write_access_denied(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = False  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._storm_guard_state = "enabled"  # noqa: SLF001
+    coord._storm_evse_enabled = True  # noqa: SLF001
+
+    assert StormGuardSwitch(coord).available is False
 
 
 def test_storm_guard_switch_unavailable_without_coordinator(
@@ -1978,7 +1996,7 @@ def test_savings_use_battery_switch_unavailable_without_coordinator(
     assert sw.available is False
 
 
-def test_savings_use_battery_switch_unavailable_without_confirmed_write_access(
+def test_savings_use_battery_switch_available_while_write_access_unknown(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -1987,7 +2005,7 @@ def test_savings_use_battery_switch_unavailable_without_confirmed_write_access(
     coord._battery_show_savings_mode = True  # noqa: SLF001
     coord._battery_profile = "cost_savings"  # noqa: SLF001
     sw = SavingsUseBatteryAfterPeakSwitch(coord)
-    assert sw.available is False
+    assert sw.available is True
 
 
 def test_charge_from_grid_switch_availability(coordinator_factory) -> None:


### PR DESCRIPTION
## Summary

Fixes a startup availability regression where retained System Profile, Storm Guard, and IQ Battery control entities could remain unavailable while BatteryConfig permission details were still loading. The entity gates now treat unknown write permission as a transient startup state, while still hiding controls when permissions are explicitly denied or support is explicitly absent.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/select.py custom_components/enphase_ev/switch.py custom_components/enphase_ev/number.py tests/components/enphase_ev/test_select_charge_mode.py tests/components/enphase_ev/test_switch_module.py tests/components/enphase_ev/test_number_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/select.py,custom_components/enphase_ev/switch.py,custom_components/enphase_ev/number.py --fail-under=100"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Bumped the integration manifest version to `3.1.5`.
- No translation files changed; no new user-facing strings were added.
