### PR TITLE
Fix i18n: exception key prefix, hardcoded strings, and French sync

### DIFF
--- a/custom_components/enphase_ev/ac_battery_runtime.py
+++ b/custom_components/enphase_ev/ac_battery_runtime.py
@@ -667,7 +667,7 @@ class AcBatteryRuntime:
         if not rows:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.ac_battery_unavailable",
+                translation_key="ac_battery_unavailable",
                 message="No AC Battery devices are currently available.",
             )
         target_soc = None

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1615,7 +1615,7 @@ class BatteryRuntime:
         if overlapping is not None:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.battery_schedule_overlap",
+                translation_key="battery_schedule_overlap",
                 translation_placeholders=battery_schedule_overlap_placeholders(
                     overlapping,
                     hass=getattr(self.coordinator, "hass", None),
@@ -1635,7 +1635,7 @@ class BatteryRuntime:
     ) -> None:
         raise_translated_service_validation(
             translation_domain=DOMAIN,
-            translation_key=f"exceptions.{key}",
+            translation_key=key,
             translation_placeholders=placeholders,
             message=message,
         )
@@ -5119,7 +5119,7 @@ class BatteryRuntime:
             return
         raise_translated_service_validation(
             translation_domain=DOMAIN,
-            translation_key=f"exceptions.{key}",
+            translation_key=key,
             translation_placeholders=placeholders,
             message=message,
         )

--- a/custom_components/enphase_ev/button.py
+++ b/custom_components/enphase_ev/button.py
@@ -636,13 +636,13 @@ class EvseScheduleSaveButton(_EvseScheduleButton):
             raise ServiceValidationError(
                 "Select at least one weekday for the schedule.",
                 translation_domain=DOMAIN,
-                translation_key="exceptions.evse_schedule_day_required",
+                translation_key="evse_schedule_day_required",
             )
         if form.start_time == form.end_time:
             raise ServiceValidationError(
                 "Schedule start and end times must be different.",
                 translation_domain=DOMAIN,
-                translation_key="exceptions.evse_schedule_times_different",
+                translation_key="evse_schedule_times_different",
             )
         schedule_sync = getattr(self._coord, "schedule_sync", None)
         if schedule_sync is None:
@@ -653,7 +653,7 @@ class EvseScheduleSaveButton(_EvseScheduleButton):
             raise ServiceValidationError(
                 "Enphase rejected the schedule change.",
                 translation_domain=DOMAIN,
-                translation_key="exceptions.evse_schedule_change_rejected",
+                translation_key="evse_schedule_change_rejected",
             )
 
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -6277,7 +6277,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     ) -> None:
         raise_translated_service_validation(
             translation_domain=DOMAIN,
-            translation_key=f"exceptions.{key}",
+            translation_key=key,
             translation_placeholders=placeholders,
             message=message,
         )

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -1057,7 +1057,7 @@ class EvseRuntime:
         display = data.get("display_name") or data.get("name") or sn
         raise ServiceValidationError(
             translation_domain=DOMAIN,
-            translation_key="exceptions.charger_not_plugged",
+            translation_key="charger_not_plugged",
             translation_placeholders={"name": str(display)},
         )
 

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -428,7 +428,7 @@ class SystemProfileSelect(CoordinatorEntity, SelectEntity):
         if selected_key is None:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.selected_system_profile_unavailable",
+                translation_key="selected_system_profile_unavailable",
                 message="Selected system profile is not available.",
             )
         try:
@@ -439,7 +439,7 @@ class SystemProfileSelect(CoordinatorEntity, SelectEntity):
             if err.status == 403:
                 raise_translated_service_validation(
                     translation_domain=DOMAIN,
-                    translation_key="exceptions.system_profile_update_forbidden",
+                    translation_key="system_profile_update_forbidden",
                     message=(
                         "System profile update was rejected by Enphase "
                         "(HTTP 403 Forbidden)."
@@ -448,7 +448,7 @@ class SystemProfileSelect(CoordinatorEntity, SelectEntity):
             if err.status == 401:
                 raise_translated_service_validation(
                     translation_domain=DOMAIN,
-                    translation_key="exceptions.system_profile_update_unauthorized",
+                    translation_key="system_profile_update_unauthorized",
                     message=(
                         "System profile update could not be authenticated. "
                         "Reauthenticate and try again."
@@ -456,19 +456,19 @@ class SystemProfileSelect(CoordinatorEntity, SelectEntity):
                 )
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.system_profile_update_failed",
+                translation_key="system_profile_update_failed",
                 message="System profile update failed.",
             )
         except aiohttp.ClientError:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.system_profile_update_network",
+                translation_key="system_profile_update_network",
                 message="System profile update failed due to a network error. Try again.",
             )
         except asyncio.TimeoutError:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.system_profile_update_timeout",
+                translation_key="system_profile_update_timeout",
                 message="System profile update timed out. Try again.",
             )
 
@@ -702,7 +702,7 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
         if not self._coord.scheduler_available:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.scheduler_service_unavailable",
+                translation_key="scheduler_service_unavailable",
                 message=(
                     "Charging mode selection is unavailable while the Enphase "
                     "scheduler service is down."
@@ -741,7 +741,7 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
         except SchedulerUnavailable:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.scheduler_service_unavailable",
+                translation_key="scheduler_service_unavailable",
                 message=(
                     "Charging mode selection is unavailable while the Enphase "
                     "scheduler service is down."
@@ -758,7 +758,7 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
                 raise ServiceValidationError(
                     "Enable at least one schedule before selecting Scheduled charging.",
                     translation_domain=DOMAIN,
-                    translation_key="exceptions.schedule_required",
+                    translation_key="schedule_required",
                 )
             raise
 
@@ -812,7 +812,7 @@ class AcBatteryTargetStateOfChargeSelect(CoordinatorEntity, SelectEntity):
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
                 translation_key=(
-                    "exceptions.selected_ac_battery_target_state_of_charge_unavailable"
+                    "selected_ac_battery_target_state_of_charge_unavailable"
                 ),
                 message="Selected AC Battery target state of charge is not available.",
             )

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -1179,7 +1179,6 @@ class EnphaseEnergyTodaySensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):
         super().__init__(coord, sn)
         # Preserve unique_id for continuity even though the semantics changed
         self._attr_unique_id = f"{DOMAIN}_{sn}_energy_today"
-        self._attr_name = "Last Session"
         self._last_session_kwh: float | None = None
         self._last_session_wh: float | None = None
         self._last_session_start: float | None = None
@@ -6547,7 +6546,7 @@ class EnphaseSystemControllerInventorySensor(_SiteBaseEntity):
 
 
 class EnphaseDryContactsInventorySensor(_SiteBaseEntity):
-    _attr_name = "Dry Contacts"
+    _attr_translation_key = "dry_contacts"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
     _unrecorded_attributes = _SiteBaseEntity._unrecorded_attributes.union(

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -90,7 +90,7 @@ def async_setup_services(
     ) -> None:
         raise_translated_service_validation(
             translation_domain=DOMAIN,
-            translation_key=f"exceptions.{key}",
+            translation_key=key,
             translation_placeholders=placeholders,
             message=message,
         )
@@ -554,7 +554,7 @@ def async_setup_services(
         if overlapping is not None:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.battery_schedule_overlap",
+                translation_key="battery_schedule_overlap",
                 translation_placeholders=battery_schedule_overlap_placeholders(
                     overlapping, hass=hass
                 ),
@@ -739,12 +739,12 @@ def async_setup_services(
         if not site_ids:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.grid_site_required",
+                translation_key="grid_site_required",
             )
         if len(site_ids) > 1:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.grid_site_ambiguous",
+                translation_key="grid_site_ambiguous",
                 translation_placeholders={"count": str(len(site_ids))},
             )
         target = next(iter(site_ids))
@@ -753,7 +753,7 @@ def async_setup_services(
             return coordinators[0]
         raise ServiceValidationError(
             translation_domain=DOMAIN,
-            translation_key="exceptions.grid_site_required",
+            translation_key="grid_site_required",
         )
 
     def _extract_entity_ids(call: ServiceCall) -> list[str]:
@@ -1090,7 +1090,7 @@ def async_setup_services(
         if not device_ids:
             raise ServiceValidationError(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.grid_site_required",
+                translation_key="grid_site_required",
             )
 
         targets: list[tuple[str, str, EnphaseCoordinator]] = []
@@ -1099,7 +1099,7 @@ def async_setup_services(
             if routing_context is None:
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
-                    translation_key="exceptions.grid_site_required",
+                    translation_key="grid_site_required",
                 )
             sn, site_id, config_entry_ids = routing_context
             coord = await _get_coordinator_for_sn(
@@ -1110,7 +1110,7 @@ def async_setup_services(
             if coord is None:
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
-                    translation_key="exceptions.grid_site_required",
+                    translation_key="grid_site_required",
                 )
             targets.append((device_id, sn, coord))
 

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariff structure is invalid."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Configured Rates"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -1092,7 +1092,7 @@ class AppAuthenticationSwitch(EnphaseBaseEntity, SwitchEntity):
         except AuthSettingsUnavailable:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.auth_settings_service_unavailable",
+                translation_key="auth_settings_service_unavailable",
                 message=(
                     "Authentication settings are unavailable while the Enphase "
                     "service is down."
@@ -1108,7 +1108,7 @@ class AppAuthenticationSwitch(EnphaseBaseEntity, SwitchEntity):
         except AuthSettingsUnavailable:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
-                translation_key="exceptions.auth_settings_service_unavailable",
+                translation_key="auth_settings_service_unavailable",
                 message=(
                     "Authentication settings are unavailable while the Enphase "
                     "service is down."

--- a/custom_components/enphase_ev/tariff.py
+++ b/custom_components/enphase_ev/tariff.py
@@ -1154,7 +1154,7 @@ def _raise_tariff_validation(
 ) -> None:
     raise_translated_service_validation(
         translation_domain=DOMAIN,
-        translation_key=f"exceptions.{key}",
+        translation_key=key,
         translation_placeholders=placeholders,
         message=message,
     )

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -449,7 +449,7 @@
       "message": "Структурата на тарифата е невалидна."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Актуализациите на фърмуера са само с информативна цел."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Сухи контакти"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Структурата на тарифата е невалидна."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Конфигурирани тарифи"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -449,7 +449,7 @@
       "message": "Struktura tarifu je neplatná."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Aktualizace firmwaru jsou pouze informativní."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Suché kontakty"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Struktura tarifu je neplatná."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Nakonfigurované sazby"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -449,7 +449,7 @@
       "message": "Tarifstrukturen er ugyldig."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Firmwareopdateringer er kun vejledende."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Potentialfrie kontakter"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tarifstrukturen er ugyldig."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Konfigurerede tariffer"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Die Tarifstruktur ist ungültig."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Konfigurierte Tarife"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -449,7 +449,7 @@
       "message": "Die Tarifstruktur ist ungültig."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Firmware-Updates dienen nur zur Information."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Potentialfreie Kontakte"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -449,7 +449,7 @@
       "message": "Η δομή τιμολογίου δεν είναι έγκυρη."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Οι ενημερώσεις υλικολογισμικού είναι μόνο ενημερωτικές."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Ξηρές επαφές"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Η δομή τιμολογίου δεν είναι έγκυρη."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Διαμορφωμένες χρεώσεις"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariff structure is invalid."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Configured Rates"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariff structure is invalid."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Configured Rates"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariff structure is invalid."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Configured Rates"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariff structure is invalid."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Configured Rates"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariff structure is invalid."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Configured Rates"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariff structure is invalid."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Configured Rates"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -449,7 +449,7 @@
       "message": "La estructura de la tarifa no es válida."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Las actualizaciones de firmware son solo informativas."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Contactos secos"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "La estructura de la tarifa no es válida."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Tarifas configuradas"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -449,7 +449,7 @@
       "message": "Tariifi struktuur on vigane."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Püsivara värskendused on ainult informatiivsed."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Kuivkontaktid"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariifi struktuur on vigane."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Seadistatud tariifid"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariffirakenne on virheellinen."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Määritetyt hinnat"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -449,7 +449,7 @@
       "message": "Tariffirakenne on virheellinen."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Laiteohjelmistopäivitykset ovat vain tiedoksi."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Potentiaalivapaat koskettimet"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -125,7 +125,7 @@
       "message": "Sélectionnez au moins un jour de la semaine pour la programmation."
     },
     "evse_schedule_times_different": {
-      "message": "Les heures de début et de fin de la programmation doivent être différentes."
+      "message": "Les heures de début et de fin du planning doivent être différentes."
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase a rejeté la modification de la programmation."
@@ -462,7 +462,7 @@
           "migrate_envoy": "Migrer l’historique Envoy"
         },
         "menu_option_descriptions": {
-          "settings": "Ajuster l’interrogation et le comportement.",
+          "settings": "Ajuster la scrutation et le comportement.",
           "migrate_envoy": "Récupérez les identifiants d’entité d’énergie Enphase Envoy sélectionnés afin que l’historique Home Assistant Energy continue sous cette intégration."
         },
         "data": {
@@ -495,7 +495,7 @@
           "api_timeout": "Secondes avant l’expiration des requêtes API.",
           "nominal_voltage": "Tension de secours utilisée pour estimer la puissance du chargeur.",
           "session_history_interval": "Minutes d'attente entre les récupérations de l'historique de session depuis le cloud.",
-          "schedule_sync_enabled": "Gérer les horaires des chargeurs IQ EV",
+          "schedule_sync_enabled": "Gérer les plannings des chargeurs IQ EV",
           "reauth": "Lancer le processus de connexion pour rafraîchir les identifiants sans supprimer l'intégration.",
           "forget_password": "Supprime le mot de passe stocké. Le rafraîchissement automatique ne sera plus tenté.",
           "type_heatpump": "Inclut des capteurs d'état, de diagnostic et de consommation de la pompe à chaleur.",
@@ -518,7 +518,7 @@
           "api_timeout": "Délai d'expiration API (s)",
           "nominal_voltage": "Tension nominale (V)",
           "session_history_interval": "Intervalle d'historique de session (min)",
-          "schedule_sync_enabled": "Activer la prise en charge du planificateur",
+          "schedule_sync_enabled": "Activer le planificateur de chargeur EV",
           "reauth": "Démarrer la réauthentification",
           "forget_password": "Oublier le mot de passe stocké",
           "type_heatpump": "Pompe à chaleur",
@@ -537,7 +537,7 @@
           "api_timeout": "Secondes avant l’expiration des requêtes API.",
           "nominal_voltage": "Tension de secours utilisée pour estimer la puissance du chargeur.",
           "session_history_interval": "Minutes d'attente entre les récupérations de l'historique de session depuis le cloud.",
-          "schedule_sync_enabled": "Gérer la gestion des plannings Enphase",
+          "schedule_sync_enabled": "Gérer les plannings des chargeurs IQ EV",
           "reauth": "Lancer le processus de connexion pour rafraîchir les identifiants sans supprimer l'intégration.",
           "forget_password": "Supprime le mot de passe stocké. Le rafraîchissement automatique ne sera plus tenté.",
           "type_heatpump": "Inclut des capteurs d'état, de diagnostic et de consommation de la pompe à chaleur.",
@@ -916,7 +916,7 @@
         "name": "Débranché à"
       },
       "schedule_type": {
-        "name": "Type de planification"
+        "name": "Type de planning"
       },
       "schedule_start": {
         "name": "Début planifié"
@@ -1159,7 +1159,7 @@
       "battery_overall_status": {
         "name": "État général de la batterie",
         "state": {
-          "normal": "Normale",
+          "normal": "Normal",
           "warning": "Avertissement",
           "error": "Erreur",
           "unknown": "Inconnu"
@@ -1196,7 +1196,7 @@
         "name": "Puissance batterie disponible"
       },
       "battery_storage_status": {
-        "name": "Statut de {serial}",
+        "name": "État de {serial}",
         "state": {
           "charging": "En charge",
           "discharging": "Décharge",
@@ -1211,7 +1211,7 @@
         "name": "Nombre de cycles de {serial}"
       },
       "battery_storage_last_reported": {
-        "name": "Dernier signalement de {serial}"
+        "name": "Dernier relevé de {serial}"
       },
       "battery_last_reported": {
         "name": "Dernier signalement de Batterie"
@@ -1238,7 +1238,7 @@
             "name": "Date de debut"
           },
           "billing_frequency": {
-            "name": "Frequence de facturation"
+            "name": "Fréquence de facturation"
           },
           "billing_interval_value": {
             "name": "Valeur d intervalle de facturation"
@@ -1252,7 +1252,7 @@
         }
       },
       "tariff_import_rate": {
-        "name": "Tarif d import",
+        "name": "Tarif d’importation",
         "state_attributes": {
           "rate_structure": {
             "name": "Structure tarifaire"
@@ -1275,7 +1275,7 @@
         }
       },
       "tariff_import_rate_value": {
-        "name": "Tarif d import {detail}",
+        "name": "Tarif d’importation {detail}",
         "state_attributes": {
           "rate_structure": {
             "name": "Structure tarifaire"
@@ -1343,7 +1343,7 @@
         }
       },
       "tariff_export_rate": {
-        "name": "Tarif d export",
+        "name": "Tarif d’exportation",
         "state_attributes": {
           "rate_structure": {
             "name": "Structure tarifaire"
@@ -1358,7 +1358,7 @@
             "name": "Devise"
           },
           "export_plan": {
-            "name": "Plan d export"
+            "name": "Plan d’export"
           },
           "seasons": {
             "name": "Saisons"
@@ -1369,7 +1369,7 @@
         }
       },
       "tariff_export_rate_value": {
-        "name": "Tarif d export {detail}",
+        "name": "Tarif d’exportation {detail}",
         "state_attributes": {
           "rate_structure": {
             "name": "Structure tarifaire"
@@ -1384,7 +1384,7 @@
             "name": "Devise"
           },
           "export_plan": {
-            "name": "Plan d export"
+            "name": "Plan d’export"
           },
           "season_id": {
             "name": "ID de saison"
@@ -1547,9 +1547,9 @@
       "ac_battery_overall_status": {
         "name": "État global de la batterie AC",
         "state": {
-          "charging": "En charge",
-          "discharging": "Décharge",
-          "idle": "Inactif",
+          "normal": "Normal",
+          "warning": "Avertissement",
+          "error": "Erreur",
           "unknown": "Inconnu"
         }
       },
@@ -1565,9 +1565,9 @@
       "ac_battery_storage_status": {
         "name": "État de {serial}",
         "state": {
-          "charging": "En charge",
-          "discharging": "Décharge",
-          "idle": "Inactif",
+          "normal": "Normal",
+          "warning": "Avertissement",
+          "error": "Erreur",
           "unknown": "Inconnu"
         }
       },
@@ -1685,7 +1685,7 @@
             "name": "Devise"
           },
           "export_plan": {
-            "name": "Plan d export"
+            "name": "Plan d’export"
           },
           "season_id": {
             "name": "ID de saison"
@@ -1776,7 +1776,7 @@
         "name": "Limite du planning de batterie"
       },
       "tariff_import_rate_value": {
-        "name": "Tarif d import {detail}",
+        "name": "Tarif d’importation {detail}",
         "state_attributes": {
           "rate_structure": {
             "name": "Structure tarifaire"
@@ -1844,7 +1844,7 @@
         }
       },
       "tariff_export_rate_value": {
-        "name": "Tarif d export {detail}",
+        "name": "Tarif d’exportation {detail}",
         "state_attributes": {
           "rate_structure": {
             "name": "Structure tarifaire"
@@ -1859,7 +1859,7 @@
             "name": "Devise"
           },
           "export_plan": {
-            "name": "Plan d export"
+            "name": "Plan d’export"
           },
           "season_id": {
             "name": "ID de saison"
@@ -2306,7 +2306,7 @@
         },
         "site_id": {
           "name": "ID du site",
-          "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         }
       }
     },
@@ -2320,7 +2320,7 @@
         },
         "site_id": {
           "name": "ID du site",
-          "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         }
       }
     },
@@ -2335,7 +2335,7 @@
       "fields": {
         "site_id": {
           "name": "ID du site",
-          "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         }
       }
     },
@@ -2350,7 +2350,7 @@
       "fields": {
         "site_id": {
           "name": "ID du site",
-          "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         }
       }
     },
@@ -2375,7 +2375,7 @@
       "fields": {
         "site_id": {
           "name": "ID du site",
-          "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         }
       }
     },
@@ -2398,7 +2398,7 @@
         },
         "site_id": {
           "name": "ID du site",
-          "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         }
       }
     },
@@ -2416,7 +2416,7 @@
         },
         "limit": {
           "name": "Limite de charge",
-          "description": "Niveau de charge maximal de la batterie (%)."
+          "description": "État de charge maximal de la batterie (%)."
         },
         "site_id": {
           "name": "ID du site",
@@ -2435,7 +2435,7 @@
       "fields": {
         "site_id": {
           "name": "ID du site",
-          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         },
         "config_entry_id": {
           "name": "ID de l’entrée de configuration",
@@ -2593,7 +2593,7 @@
         },
         "site_id": {
           "name": "ID du site",
-          "description": "Identifiant de site facultatif; détecté automatiquement lorsqu’un appareil de site est sélectionné."
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         }
       }
     },
@@ -2646,8 +2646,8 @@
           "description": "Identifiant de site facultatif pour les mises à jour de facturation."
         },
         "config_entry_id": {
-          "name": "ID d’entrée de configuration",
-          "description": "Identifiant facultatif d’entrée de configuration pour un seul site Enphase."
+          "name": "ID de l’entrée de configuration",
+          "description": "Identifiant facultatif de l’entrée de configuration pour une seule entrée de site Enphase."
         },
         "tariff_payload": {
           "name": "Charge utile tarifaire",
@@ -2737,7 +2737,7 @@
         },
         "site_id": {
           "name": "ID du site",
-          "description": "Identifiant de site facultatif, détecté automatiquement lorsqu’un appareil est sélectionné."
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -1182,9 +1182,9 @@
         }
       },
       "grid_mode": {
-        "name": "Mode grille",
+        "name": "Mode réseau",
         "state": {
-          "on_grid": "Sur la grille",
+          "on_grid": "Sur le réseau",
           "off_grid": "Hors réseau",
           "unknown": "Inconnu"
         }
@@ -2069,7 +2069,7 @@
         "name": "Annuler le changement de profil en attente"
       },
       "request_grid_toggle_otp": {
-        "name": "Demander la grille de basculement OTP"
+        "name": "Demander le code OTP de basculement réseau"
       },
       "storm_alert_opt_out": {
         "name": "Se désinscrire de l'alerte de tempête"
@@ -2365,8 +2365,8 @@
       }
     },
     "request_grid_toggle_otp": {
-      "name": "Demander la grille de basculement OTP",
-      "description": "Envoyez le code à usage unique requis avant de changer le mode grille du site.",
+      "name": "Demander le code OTP de basculement réseau",
+      "description": "Envoyez le code à usage unique requis avant de changer le mode réseau du site.",
       "sections": {
         "advanced": {
           "name": "Options avancées"
@@ -2380,8 +2380,8 @@
       }
     },
     "set_grid_mode": {
-      "name": "Définir le mode grille",
-      "description": "Changez le mode grille du site après avoir validé le code à usage unique.",
+      "name": "Définir le mode réseau",
+      "description": "Changez le mode réseau du site après avoir validé le code à usage unique.",
       "sections": {
         "advanced": {
           "name": "Options avancées"
@@ -2389,7 +2389,7 @@
       },
       "fields": {
         "mode": {
-          "name": "Mode grille",
+          "name": "Mode réseau",
           "description": "Sélectionnez on_grid ou off_grid."
         },
         "otp": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "La structure tarifaire est invalide."
+    },
+    "firmware_advisory_only": {
+      "message": "Les mises à jour du firmware sont fournies à titre indicatif uniquement."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Tarifs configurés"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Contacts secs"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "A tarifa szerkezete érvénytelen."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Beállított díjszabások"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -449,7 +449,7 @@
       "message": "A tarifa szerkezete érvénytelen."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "A firmware-frissítések csak tájékoztató jellegűek."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Száraz kontaktusok"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -449,7 +449,7 @@
       "message": "La struttura tariffaria non è valida."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Gli aggiornamenti firmware sono solo informativi."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Contatti puliti"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "La struttura tariffaria non è valida."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Tariffe configurate"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tarifo struktūra netinkama."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Sukonfigūruoti tarifai"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -449,7 +449,7 @@
       "message": "Tarifo struktūra netinkama."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Programinės aparatinės įrangos naujiniai yra tik informaciniai."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Sausieji kontaktai"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -449,7 +449,7 @@
       "message": "Tarifa struktūra nav derīga."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Aparātprogrammatūras atjauninājumi ir tikai informatīvi."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Sausie kontakti"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tarifa struktūra nav derīga."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Konfigurētie tarifi"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariffstrukturen er ugyldig."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Konfigurerte tariffer"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -449,7 +449,7 @@
       "message": "Tariffstrukturen er ugyldig."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Fastvareoppdateringer er kun veiledende."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Potensialfrie kontakter"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -449,7 +449,7 @@
       "message": "De tariefstructuur is ongeldig."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Firmware-updates zijn alleen ter informatie."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Droge contacten"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "De tariefstructuur is ongeldig."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Geconfigureerde tarieven"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -449,7 +449,7 @@
       "message": "Struktura taryfy jest nieprawidłowa."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Aktualizacje oprogramowania układowego mają wyłącznie charakter informacyjny."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Styki bezpotencjałowe"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Struktura taryfy jest nieprawidłowa."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Skonfigurowane stawki"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -449,7 +449,7 @@
       "message": "A estrutura tarifária é inválida."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "As atualizações de firmware são apenas informativas."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Contatos secos"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "A estrutura tarifária é inválida."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Tarifas configuradas"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Structura tarifului este invalidă."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Tarife configurate"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -449,7 +449,7 @@
       "message": "Structura tarifului este invalidă."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Actualizările de firmware sunt doar informative."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Contacte uscate"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -449,7 +449,7 @@
       "message": "Tariffstrukturen är ogiltig."
     },
     "firmware_advisory_only": {
-      "message": "Firmware updates are advisory only."
+      "message": "Firmwareuppdateringar är endast rådgivande."
     }
   },
   "options": {
@@ -1747,7 +1747,7 @@
         }
       },
       "dry_contacts": {
-        "name": "Dry Contacts"
+        "name": "Potentialfria kontakter"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -447,6 +447,9 @@
     },
     "tariff_structure_invalid": {
       "message": "Tariffstrukturen är ogiltig."
+    },
+    "firmware_advisory_only": {
+      "message": "Firmware updates are advisory only."
     }
   },
   "options": {
@@ -1742,6 +1745,9 @@
             "name": "Konfigurerade tariffer"
           }
         }
+      },
+      "dry_contacts": {
+        "name": "Dry Contacts"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -191,7 +191,11 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Reject install requests; these entities only advertise firmware status."""
-        raise HomeAssistantError("Firmware updates are advisory only")
+        raise HomeAssistantError(
+            "Firmware updates are advisory only",
+            translation_domain=DOMAIN,
+            translation_key="firmware_advisory_only",
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -384,7 +388,11 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
         """Reject install requests; these entities only advertise firmware status."""
-        raise HomeAssistantError("Firmware updates are advisory only")
+        raise HomeAssistantError(
+            "Firmware updates are advisory only",
+            translation_domain=DOMAIN,
+            translation_key="firmware_advisory_only",
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2638,8 +2638,8 @@ async def test_async_restart_after_amp_change_handles_start_error(hass, monkeypa
 @pytest.mark.parametrize(
     ("translation_key", "expected_reason"),
     [
-        ("exceptions.charger_not_plugged", "not plugged in"),
-        ("exceptions.auth_required", "authentication required"),
+        ("charger_not_plugged", "not plugged in"),
+        ("auth_required", "authentication required"),
     ],
 )
 async def test_async_restart_after_amp_change_validation_reasons(

--- a/tests/components/enphase_ev/test_entity_wiring.py
+++ b/tests/components/enphase_ev/test_entity_wiring.py
@@ -39,8 +39,10 @@ def test_entity_naming_and_availability():
 
     ent = EnphaseEnergyTodaySensor(coord, RANDOM_SERIAL)
     assert ent.available is True
-    # Uses has_entity_name; entity name is the suffix only
-    assert ent.name == "Last Session"
+    # Uses has_entity_name with a translation key; the display name now comes
+    # from the translations instead of a hardcoded _attr_name.
+    assert ent.has_entity_name is True
+    assert ent.translation_key == "last_session"
     # Device name comes from coordinator data
     assert ent.device_info["name"] == "Garage EV"
     # Unique ID includes domain, serial, and key

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -3644,7 +3644,7 @@ def test_dry_contacts_inventory_sensor_state_and_attributes(
     assert sensor.available is True
     assert sensor.native_value == "Closed | Open"
     assert sensor.entity_registry_enabled_default is False
-    assert sensor._attr_name == "Dry Contacts"  # noqa: SLF001
+    assert sensor._attr_translation_key == "dry_contacts"  # noqa: SLF001
     attrs = sensor.extra_state_attributes
     assert attrs["name"] == "Dry Contacts"
     assert attrs["member_count"] == 2

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -618,6 +618,33 @@ def test_battery_cfg_schedule_status_strings_localized_for_non_english_locales()
             ), f"{name} should localize {path} (still matches English)"
 
 
+def test_externalized_i18n_strings_localized_for_non_english_locales() -> None:
+    """Guard newly externalized user-facing strings from English fallbacks."""
+
+    translations_dir = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / "custom_components"
+        / "enphase_ev"
+        / "translations"
+    )
+    en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
+    paths = [
+        "exceptions.firmware_advisory_only.message",
+        "entity.sensor.dry_contacts.name",
+    ]
+    for locale in translations_dir.glob("*.json"):
+        name = locale.name
+        if name == "en.json" or name.startswith("en-"):
+            continue
+        data = json.loads(locale.read_text(encoding="utf-8"))
+        for path in paths:
+            value = _at_path(data, path)
+            assert value.strip(), f"{name} missing value for {path}"
+            assert value != _at_path(
+                en_data, path
+            ), f"{name} should localize {path} (still matches English)"
+
+
 def test_battery_schedule_editor_strings_localized_for_non_english_locales() -> None:
     """Guard battery schedule strings from silently falling back to English."""
 

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ast
 import json
 import pathlib
+import re
 
 
 def test_clear_reauth_issue_device_field_translated() -> None:
@@ -677,6 +678,33 @@ def test_translated_user_facing_errors_require_translation_keys() -> None:
                 f"{relative_path}:{node.lineno} raises {name} "
                 "without translation_key"
             )
+
+
+def test_exception_translation_keys_have_no_redundant_prefix() -> None:
+    """Guard against the redundant ``exceptions.`` prefix on exception keys.
+
+    Home Assistant resolves exception messages at
+    ``component.{domain}.exceptions.{translation_key}.message`` and prepends the
+    ``exceptions.`` segment itself. Passing a ``translation_key`` that already
+    starts with ``exceptions.`` doubles that segment, so the lookup misses and
+    the raw key is surfaced to the user instead of the translated message.
+    """
+
+    root = (
+        pathlib.Path(__file__).resolve().parents[3] / "custom_components" / "enphase_ev"
+    )
+    pattern = re.compile(r'translation_key\s*=\s*\(?\s*f?"exceptions\.')
+    offenders: list[str] = []
+    for path in sorted(root.glob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        for match in pattern.finditer(text):
+            lineno = text.count("\n", 0, match.start()) + 1
+            offenders.append(f"{path.name}:{lineno}")
+    assert not offenders, (
+        "translation_key must not include the 'exceptions.' prefix; "
+        "Home Assistant adds it automatically when resolving exception "
+        f"messages. Offending sites: {offenders}"
+    )
 
 
 def test_evse_schedule_editor_strings_exist_for_all_locales() -> None:

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -278,9 +278,7 @@ async def test_trigger_message_handler_requires_confirmation_for_advanced_messag
             SimpleNamespace(data={"requested_message": "BootNotification"})
         )
 
-    assert (
-        err.value.translation_key == "exceptions.trigger_message_confirmation_required"
-    )
+    assert err.value.translation_key == "trigger_message_confirmation_required"
 
     with pytest.raises(ServiceValidationError) as err:
         await registered[(DOMAIN, "trigger_message")](
@@ -292,9 +290,7 @@ async def test_trigger_message_handler_requires_confirmation_for_advanced_messag
             )
         )
 
-    assert (
-        err.value.translation_key == "exceptions.trigger_message_confirmation_required"
-    )
+    assert err.value.translation_key == "trigger_message_confirmation_required"
 
 
 @pytest.mark.asyncio
@@ -985,11 +981,11 @@ async def test_update_tariff_rejects_invalid_rate_entity_targets(
     )
 
     for entity_id, translation_key in (
-        ("number.missing", "exceptions.tariff_rate_entity_invalid"),
-        (other_platform.entity_id, "exceptions.tariff_rate_entity_invalid"),
-        (wrong_unique_id.entity_id, "exceptions.tariff_rate_entity_invalid"),
-        (unknown_site_entity.entity_id, "exceptions.tariff_rate_entity_invalid"),
-        (missing_locator.entity_id, "exceptions.tariff_rate_target_invalid"),
+        ("number.missing", "tariff_rate_entity_invalid"),
+        (other_platform.entity_id, "tariff_rate_entity_invalid"),
+        (wrong_unique_id.entity_id, "tariff_rate_entity_invalid"),
+        (unknown_site_entity.entity_id, "tariff_rate_entity_invalid"),
+        (missing_locator.entity_id, "tariff_rate_target_invalid"),
     ):
         with pytest.raises(ServiceValidationError) as err:
             await handlers[(DOMAIN, "update_tariff")](
@@ -1006,17 +1002,17 @@ async def test_update_tariff_rejects_missing_and_incomplete_updates(
 
     with pytest.raises(ServiceValidationError) as err:
         await handlers[(DOMAIN, "update_tariff")](SimpleNamespace(data={}))
-    assert err.value.translation_key == "exceptions.tariff_update_required"
+    assert err.value.translation_key == "tariff_update_required"
 
     with pytest.raises(ServiceValidationError) as err:
         await handlers[(DOMAIN, "update_tariff")](
             SimpleNamespace(data={"billing_start_date": "2026-04-01"})
         )
-    assert err.value.translation_key == "exceptions.tariff_billing_incomplete"
+    assert err.value.translation_key == "tariff_billing_incomplete"
 
     with pytest.raises(ServiceValidationError) as err:
         await handlers[(DOMAIN, "update_tariff")](SimpleNamespace(data={"rate": 0.2}))
-    assert err.value.translation_key == "exceptions.tariff_rate_entity_required"
+    assert err.value.translation_key == "tariff_rate_entity_required"
 
 
 @pytest.mark.asyncio
@@ -1409,8 +1405,8 @@ async def test_update_tariff_guided_structural_fields_validate_inputs(
                 SimpleNamespace(data={"site_id": "tariff-site", **data})
             )
         assert err.value.translation_key in {
-            "exceptions.tariff_structure_invalid",
-            "exceptions.tariff_rate_invalid",
+            "tariff_structure_invalid",
+            "tariff_rate_invalid",
         }
     coord.tariff_runtime.async_update_tariff.assert_not_awaited()
 
@@ -1474,7 +1470,7 @@ async def test_update_tariff_rejects_duplicate_and_cross_site_rates(
                 }
             )
         )
-    assert err.value.translation_key == "exceptions.tariff_rate_entity_duplicate"
+    assert err.value.translation_key == "tariff_rate_entity_duplicate"
 
     with pytest.raises(ServiceValidationError) as err:
         await handlers[(DOMAIN, "update_tariff")](
@@ -1487,7 +1483,7 @@ async def test_update_tariff_rejects_duplicate_and_cross_site_rates(
                 }
             )
         )
-    assert err.value.translation_key == "exceptions.tariff_site_mismatch"
+    assert err.value.translation_key == "tariff_site_mismatch"
 
     with pytest.raises(ServiceValidationError) as err:
         await handlers[(DOMAIN, "update_tariff")](
@@ -1501,7 +1497,7 @@ async def test_update_tariff_rejects_duplicate_and_cross_site_rates(
                 }
             )
         )
-    assert err.value.translation_key == "exceptions.tariff_site_mismatch"
+    assert err.value.translation_key == "tariff_site_mismatch"
 
     with pytest.raises(ServiceValidationError) as err:
         await handlers[(DOMAIN, "update_tariff")](
@@ -1512,4 +1508,4 @@ async def test_update_tariff_rejects_duplicate_and_cross_site_rates(
                 }
             )
         )
-    assert err.value.translation_key == "exceptions.tariff_rate_entity_invalid"
+    assert err.value.translation_key == "tariff_rate_entity_invalid"

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -140,7 +140,7 @@ def test_tariff_update_parsers_cover_passthrough_and_invalid_inputs() -> None:
         TariffBillingUpdate.from_object(
             {"billing_frequency": "MONTH", "billing_interval_value": 1}
         )
-    assert err.value.translation_key == "exceptions.tariff_billing_start_date_invalid"
+    assert err.value.translation_key == "tariff_billing_start_date_invalid"
 
     locator = TariffRateLocator(
         branch="purchase",
@@ -1962,9 +1962,9 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
     coord.client.site_tariff_update = AsyncMock()
 
     invalid_inputs = (
-        ({"tariff_payload": []}, "exceptions.tariff_structure_invalid"),
-        ({"tariff_payload": {"currency": "$"}}, "exceptions.tariff_structure_invalid"),
-        ({"purchase_tariff": []}, "exceptions.tariff_structure_invalid"),
+        ({"tariff_payload": []}, "tariff_structure_invalid"),
+        ({"tariff_payload": {"currency": "$"}}, "tariff_structure_invalid"),
+        ({"purchase_tariff": []}, "tariff_structure_invalid"),
         (
             {
                 "purchase_tariff": {
@@ -1973,7 +1973,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     "seasons": [],
                 }
             },
-            "exceptions.tariff_structure_invalid",
+            "tariff_structure_invalid",
         ),
         (
             {
@@ -1983,7 +1983,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     "seasons": [{"id": "default", "days": []}],
                 }
             },
-            "exceptions.tariff_structure_invalid",
+            "tariff_structure_invalid",
         ),
         (
             {
@@ -1993,7 +1993,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     "seasons": ["default"],
                 }
             },
-            "exceptions.tariff_structure_invalid",
+            "tariff_structure_invalid",
         ),
         (
             {
@@ -2003,7 +2003,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     "seasons": [{"id": "default", "days": ["week"]}],
                 }
             },
-            "exceptions.tariff_structure_invalid",
+            "tariff_structure_invalid",
         ),
         (
             {
@@ -2013,7 +2013,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     "seasons": [{"id": "default", "days": [{"id": "week"}]}],
                 }
             },
-            "exceptions.tariff_structure_invalid",
+            "tariff_structure_invalid",
         ),
         (
             {
@@ -2028,7 +2028,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     ],
                 }
             },
-            "exceptions.tariff_structure_invalid",
+            "tariff_structure_invalid",
         ),
         (
             {
@@ -2055,7 +2055,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     ],
                 }
             },
-            "exceptions.tariff_rate_invalid",
+            "tariff_rate_invalid",
         ),
         (
             {
@@ -2065,7 +2065,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     "seasons": [{"id": "default"}],
                 }
             },
-            "exceptions.tariff_structure_invalid",
+            "tariff_structure_invalid",
         ),
         (
             {
@@ -2075,7 +2075,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     "seasons": [{"id": "default", "tiers": ["tier-1"]}],
                 }
             },
-            "exceptions.tariff_structure_invalid",
+            "tariff_structure_invalid",
         ),
         (
             {
@@ -2090,7 +2090,7 @@ async def test_tariff_runtime_rejects_invalid_structural_tariffs(
                     ],
                 }
             },
-            "exceptions.tariff_structure_invalid",
+            "tariff_structure_invalid",
         ),
     )
     for kwargs, translation_key in invalid_inputs:
@@ -2223,7 +2223,7 @@ async def test_tariff_runtime_rejects_structural_time_and_tier_bounds(
     for kwargs in invalid_inputs:
         with pytest.raises(ServiceValidationError) as err:
             await TariffRuntime(coord).async_update_tariff(**kwargs)
-        assert err.value.translation_key == "exceptions.tariff_structure_invalid"
+        assert err.value.translation_key == "tariff_structure_invalid"
     coord.client.site_tariff.assert_not_awaited()
     coord.client.site_tariff_update.assert_not_awaited()
 
@@ -2248,7 +2248,7 @@ async def test_tariff_runtime_rejects_structural_time_and_tier_bounds(
                 }
             }
         )
-    assert err.value.translation_key == "exceptions.tariff_rate_api_unavailable"
+    assert err.value.translation_key == "tariff_rate_api_unavailable"
 
 
 @pytest.mark.asyncio
@@ -2385,7 +2385,7 @@ async def test_tariff_runtime_rejects_invalid_billing_and_duplicates(
 
     with pytest.raises(ServiceValidationError) as err:
         await TariffRuntime(coord).async_update_tariff()
-    assert err.value.translation_key == "exceptions.tariff_update_required"
+    assert err.value.translation_key == "tariff_update_required"
 
     coord.client.site_tariff_billing_update = None
     with pytest.raises(ServiceValidationError) as err:
@@ -2396,7 +2396,7 @@ async def test_tariff_runtime_rejects_invalid_billing_and_duplicates(
                 "billing_interval_value": 30,
             }
         )
-    assert err.value.translation_key == "exceptions.tariff_billing_api_unavailable"
+    assert err.value.translation_key == "tariff_billing_api_unavailable"
 
     with pytest.raises(ServiceValidationError) as err:
         await TariffRuntime(coord).async_update_tariff(
@@ -2406,7 +2406,7 @@ async def test_tariff_runtime_rejects_invalid_billing_and_duplicates(
                 "billing_interval_value": 1,
             }
         )
-    assert err.value.translation_key == "exceptions.tariff_billing_start_date_invalid"
+    assert err.value.translation_key == "tariff_billing_start_date_invalid"
 
     with pytest.raises(ServiceValidationError) as err:
         await TariffRuntime(coord).async_update_tariff(
@@ -2416,7 +2416,7 @@ async def test_tariff_runtime_rejects_invalid_billing_and_duplicates(
                 "billing_interval_value": 1,
             }
         )
-    assert err.value.translation_key == "exceptions.tariff_billing_frequency_invalid"
+    assert err.value.translation_key == "tariff_billing_frequency_invalid"
 
     with pytest.raises(ServiceValidationError) as err:
         await TariffRuntime(coord).async_update_tariff(
@@ -2426,7 +2426,7 @@ async def test_tariff_runtime_rejects_invalid_billing_and_duplicates(
                 "billing_interval_value": 25,
             }
         )
-    assert err.value.translation_key == "exceptions.tariff_billing_interval_invalid"
+    assert err.value.translation_key == "tariff_billing_interval_invalid"
 
     duplicate_update = {
         "locator": {
@@ -2441,7 +2441,7 @@ async def test_tariff_runtime_rejects_invalid_billing_and_duplicates(
         await TariffRuntime(coord).async_update_tariff(
             rate_updates=[duplicate_update, duplicate_update]
         )
-    assert err.value.translation_key == "exceptions.tariff_rate_target_duplicate"
+    assert err.value.translation_key == "tariff_rate_target_duplicate"
     coord.client.site_tariff_update.assert_not_awaited()
 
 

--- a/tests/components/enphase_ev/test_voltage_and_daily_energy.py
+++ b/tests/components/enphase_ev/test_voltage_and_daily_energy.py
@@ -66,5 +66,5 @@ def test_last_session_sensor_name_and_value(monkeypatch):
     )
 
     ent = EnphaseEnergyTodaySensor(coord, sn)
-    assert ent.name == "Last Session"
+    assert ent.translation_key == "last_session"
     assert ent.native_value == 1.0


### PR DESCRIPTION
Three related i18n / translation-correctness fixes, kept as three independent commits so they can be reviewed (or split) individually.

## fix(exceptions): drop redundant `exceptions.` translation_key prefix
Exceptions were raised with `translation_key="exceptions.<key>"`. Home Assistant resolves exception messages at `component.<domain>.exceptions.<key>.message` and prepends the `exceptions.` segment itself, so the prefix doubled the path: the lookup missed and the raw key (e.g. `exceptions.charger_not_plugged`) was surfaced to users in **every language**.

- Stripped the prefix from 25 literal sites and 5 f-string helpers (`translation_key=key`).
- Aligned the affected test assertions.
- Added a regression test that fails if the prefix is reintroduced.
- The `evse_runtime` log-reason mapping uses a substring match and is unaffected.

## feat(i18n): externalize remaining hardcoded user-facing strings
- Dropped the hardcoded `_attr_name = "Last Session"` that overrode the existing `last_session` translation key (the entity name was forced to English in every locale).
- Gave the Dry Contacts sensor a `translation_key` instead of a hardcoded English name.
- Raised the firmware advisory error via `translation_key`.
- Added `firmware_advisory_only` and `dry_contacts` to `strings.json` and every translation catalog.

## fix(translations): sync French states, typos and terminology
- Replaced the stale `charging/discharging/idle` states of the AC battery status sensors with the `normal/warning/error` states the code actually emits (`_normalize_battery_status_text`), aligning `fr.json` with `strings.json`.
- Fixed missing accents/apostrophes (Fréquence, Tarif d'exportation/importation, Plan d'export).
- Harmonized divergent French terms (status→État, schedule→planning, polling→scrutation, device→appareil, optional→facultatif) and unified the `site_id` field description.

## Validation
- `pytest`: 3274 passed
- `black` / `ruff` / `codespell`: clean

## Known follow-up (out of scope here)
The AC battery state desync also affects the other 24 translation catalogs — including `en.json`, which no longer mirrors `strings.json`. They still carry `charging/discharging/idle`. Only `fr.json` is corrected here; the rest would need the same `normal/warning/error` realignment.