### PR TITLE
Fix heat pump inactive power smoothing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed Heat Pump power smoothing so offline/error HEMS states no longer carry forward stale running power estimates. (#715)
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -34,6 +34,7 @@ from .parsing_helpers import (
     heatpump_device_state,
     heatpump_member_device_type,
     heatpump_pairing_status,
+    heatpump_status_bucket,
     heatpump_status_text,
     parse_inverter_last_report,
     type_member_text,
@@ -62,6 +63,8 @@ _HEATPUMP_ACTIVE_SMOOTHING_MIN_WINDOW_S = 15 * 60.0
 _HEATPUMP_ACTIVE_SMOOTHING_MAX_WINDOW_S = 30 * 60.0
 _HEATPUMP_POWER_SEEDED_STALE_AFTER_S = 30 * 60.0
 _HEATPUMP_POWER_HOLD_STALE_ERRORS = {"seeded_waiting_for_delta", "repeated_sample"}
+_HEATPUMP_INACTIVE_RUNTIME_MODES = {"IDLE", "OFF", "STOPPED", "STANDBY"}
+_HEATPUMP_INACTIVE_STATUS_BUCKETS = {"error", "not_reporting"}
 _SITE_TODAY_HEATPUMP_TOTAL_KEYS = (
     "consumed_wh",
     "consumption_wh",
@@ -73,6 +76,10 @@ _SITE_TODAY_HEATPUMP_TOTAL_KEYS = (
     "value",
     "total",
 )
+
+
+def _heatpump_status_is_inactive(value: object) -> bool:
+    return heatpump_status_bucket(value) in _HEATPUMP_INACTIVE_STATUS_BUCKETS
 
 
 class HeatpumpRuntime:
@@ -1049,6 +1056,9 @@ class HeatpumpRuntime:
                 "device_state": (
                     heatpump_device_state(member) if isinstance(member, dict) else None
                 ),
+                "member_status": (
+                    heatpump_status_text(member) if isinstance(member, dict) else None
+                ),
                 "split_daily_energy_wh": split_daily_energy_wh,
                 "daily_solar_wh": daily_solar_wh,
                 "daily_battery_wh": daily_battery_wh,
@@ -1345,7 +1355,18 @@ class HeatpumpRuntime:
         device_uid = coerce_optional_text(snapshot.get("split_device_uid"))
         day_key = coerce_optional_text(snapshot.get("day_key"))
         runtime_mode = self._heatpump_runtime_mode(runtime_snapshot)
-        is_idle = runtime_mode in {"IDLE", "OFF", "STOPPED", "STANDBY"}
+        member = self._heatpump_member_for_uid(device_uid) if device_uid else None
+        member_status = (
+            heatpump_status_text(member)
+            if isinstance(member, dict)
+            else coerce_optional_text(snapshot.get("member_status"))
+        )
+        is_inactive_runtime = (
+            runtime_mode in _HEATPUMP_INACTIVE_RUNTIME_MODES
+            or _heatpump_status_is_inactive(runtime_mode)
+            or _heatpump_status_is_inactive(member_status)
+        )
+        is_active = not is_inactive_runtime
         current_energy_wh = coerce_optional_float(snapshot.get("daily_energy_wh"))
         current_split_energy_wh = coerce_optional_float(
             snapshot.get("split_daily_energy_wh")
@@ -1390,7 +1411,7 @@ class HeatpumpRuntime:
         power_source = "site_today_heatpump_delta"
 
         if current_energy_wh is None or current_sample_utc is None:
-            if is_idle:
+            if is_inactive_runtime:
                 accepted_value = 0.0
                 validation = "accepted_idle_without_delta"
             else:
@@ -1401,7 +1422,7 @@ class HeatpumpRuntime:
             or previous_sample_utc is None
             or previous_day_key != day_key
         ):
-            if is_idle:
+            if is_inactive_runtime:
                 accepted_value = 0.0
                 validation = "accepted_idle_seeded"
             else:
@@ -1411,7 +1432,7 @@ class HeatpumpRuntime:
             window_s = (current_sample_utc - previous_sample_utc).total_seconds()
             series_start_utc = previous_sample_utc
             if window_s <= 0:
-                if is_idle:
+                if is_inactive_runtime:
                     accepted_value = 0.0
                     validation = "accepted_idle_repeated_sample"
                 else:
@@ -1420,7 +1441,7 @@ class HeatpumpRuntime:
             else:
                 delta_wh = current_energy_wh - previous_energy_wh
                 if delta_wh < 0:
-                    if is_idle:
+                    if is_inactive_runtime:
                         accepted_value = 0.0
                         validation = "accepted_idle_reset"
                     else:
@@ -1429,20 +1450,25 @@ class HeatpumpRuntime:
                 elif delta_wh <= _HEATPUMP_POWER_MIN_DELTA_WH:
                     accepted_value = 0.0
                     validation = (
-                        "accepted_idle_zero" if is_idle else "accepted_zero_delta"
+                        "accepted_idle_zero"
+                        if is_inactive_runtime
+                        else "accepted_zero_delta"
                     )
                 else:
                     effective_window_s = (
                         window_s if window_s > 0 else _HEATPUMP_POWER_DEFAULT_WINDOW_S
                     )
                     candidate_value = (delta_wh * 3600.0) / effective_window_s
-                    if is_idle and candidate_value > _HEATPUMP_IDLE_POWER_MAX_W:
+                    if (
+                        is_inactive_runtime
+                        and candidate_value > _HEATPUMP_IDLE_POWER_MAX_W
+                    ):
                         accepted_value = candidate_value
                         validation = _HEATPUMP_IDLE_HIGH_DELTA_PENDING
                         idle_high_delta_pending = True
                     else:
                         accepted_value = candidate_value
-                        if is_idle:
+                        if is_inactive_runtime:
                             validation = "accepted_idle_delta"
 
         raw_value = accepted_value
@@ -1454,7 +1480,7 @@ class HeatpumpRuntime:
         display_validation = validation
         smoothed = False
         if (
-            is_idle
+            is_inactive_runtime
             and not rejected
             and current_energy_wh is not None
             and current_sample_utc is not None
@@ -1488,7 +1514,7 @@ class HeatpumpRuntime:
                 validation = "rejected_idle_high_delta"
                 display_validation = validation
         elif (
-            not is_idle
+            is_active
             and not rejected
             and current_energy_wh is not None
             and current_sample_utc is not None
@@ -1530,11 +1556,7 @@ class HeatpumpRuntime:
             "member_device_type": snapshot.get("member_device_type"),
             "pairing_status": snapshot.get("pairing_status"),
             "device_state": snapshot.get("device_state"),
-            "status": (
-                heatpump_status_text(self._heatpump_member_for_uid(device_uid))
-                if device_uid
-                else None
-            ),
+            "status": member_status,
             "recommended": self._heatpump_power_candidate_is_recommended(device_uid),
             "detail_count": 1 if current_split_energy_wh is not None else 0,
             "reported_detail_value": (

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -312,6 +312,91 @@ async def test_heatpump_power_holds_stale_running_repeated_site_sample(
 
 
 @pytest.mark.asyncio
+async def test_heatpump_power_uses_inventory_error_when_runtime_state_is_stale(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+    coord._devices_inventory_payload = {"curr_date_site": "2026-04-05"}  # noqa: SLF001
+    coord._battery_timezone = "UTC"  # noqa: SLF001
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "name": "Heat Pump",
+                        "statusText": "Error",
+                    }
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    now = time.monotonic()
+    runtime._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "heatpump_status": "RUNNING",
+    }
+    runtime._heatpump_runtime_state_last_success_mono = now - 5.0  # noqa: SLF001
+    runtime._heatpump_runtime_state_last_success_utc = datetime(  # noqa: SLF001
+        2026, 4, 5, 0, 15, tzinfo=timezone.utc
+    )
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-05",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 5, 0, 0, tzinfo=timezone.utc),
+        }
+    ]
+    coord.client._hems_site_supported = True  # noqa: SLF001
+    coord.client.hems_heatpump_state = AsyncMock(return_value=None)
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(150.0, timestamp="2026-04-05T00:20:00Z")
+    )
+    coord.client.hems_energy_consumption = AsyncMock(
+        return_value={
+            "type": "hems-device-details",
+            "timestamp": "2026-04-05T00:20:00Z",
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": "HP-1",
+                        "device_name": "Heat Pump",
+                        "consumption": [{"details": [150.0]}],
+                    }
+                ]
+            },
+        }
+    )
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        energy_wh=150.0,
+        timestamp="2026-04-05T00:15:00Z",
+        day_key="2026-04-05",
+        timezone_name="UTC",
+        device_name="Heat Pump",
+    )
+
+    await runtime._async_refresh_heatpump_power(force=True)  # noqa: SLF001
+
+    assert coord.heatpump_runtime_state_using_stale is True
+    assert coord.heatpump_power_w == pytest.approx(0.0)
+    assert coord.heatpump_power_last_error is None
+    selected = coord._heatpump_power_snapshot["selected_payload"]  # noqa: SLF001
+    assert selected["runtime_mode"] == "RUNNING"
+    assert selected["status"] == "Error"
+    assert selected["raw_validation"] == "accepted_idle_zero"
+    assert selected["power_validation"] == "accepted_idle_zero"
+    assert selected["smoothed"] is False
+
+
+@pytest.mark.asyncio
 async def test_heatpump_diagnostics_clears_livestream_when_circuit_active_without_fetcher(
     coordinator_factory,
 ) -> None:
@@ -723,6 +808,92 @@ def test_heatpump_power_summary_smooths_running_zero_from_history(
             site_interval_seconds=900.0,
         ),
         runtime_snapshot={"heatpump_status": "RUNNING"},
+    )
+
+    assert summary is not None
+    assert summary["raw_value_w"] == pytest.approx(0.0)
+    assert summary["raw_validation"] == "accepted_zero_delta"
+    assert summary["accepted_value_w"] == pytest.approx(15.0)
+    assert summary["power_window_seconds"] == pytest.approx(1200.0)
+    assert summary["power_validation"] == "smoothed_active_delta"
+    assert summary["smoothed"] is True
+
+
+@pytest.mark.parametrize(
+    "heatpump_status",
+    (
+        "OFFLINE",
+        "ERROR",
+        "FAULTED",
+        "CRITICAL",
+        "NOT_REPORTING",
+        "DISCONNECTED",
+    ),
+)
+def test_heatpump_power_summary_does_not_smooth_inactive_zero_from_history(
+    coordinator_factory, heatpump_status: str
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        }
+    ]
+    runtime._heatpump_daily_consumption_previous = (
+        _heatpump_daily_snapshot(  # noqa: SLF001
+            energy_wh=150.0,
+            timestamp="2026-04-02T00:15:00Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=150.0,
+            timestamp="2026-04-02T00:20:00Z",
+            site_interval_seconds=900.0,
+        ),
+        runtime_snapshot={"heatpump_status": heatpump_status},
+    )
+
+    assert summary is not None
+    assert summary["raw_value_w"] == pytest.approx(0.0)
+    assert summary["accepted_value_w"] == pytest.approx(0.0)
+    assert summary["raw_validation"] == "accepted_idle_zero"
+    assert summary["power_validation"] == "accepted_idle_zero"
+    assert summary["smoothed"] is False
+
+
+def test_heatpump_power_summary_smooths_unrecognized_runtime_zero_from_history(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        }
+    ]
+    runtime._heatpump_daily_consumption_previous = (
+        _heatpump_daily_snapshot(  # noqa: SLF001
+            energy_wh=105.0,
+            timestamp="2026-04-02T00:15:00Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=105.0,
+            timestamp="2026-04-02T00:20:00Z",
+            site_interval_seconds=900.0,
+        ),
+        runtime_snapshot={"heatpump_status": "UNKNOWN"},
     )
 
     assert summary is not None


### PR DESCRIPTION
## Summary

Fixes #715.

Prevents Heat Pump power smoothing from carrying stale running estimates forward when HEMS reports the heat pump as offline, errored, faulted, disconnected, or not reporting. The estimator now treats inactive runtime/status buckets as non-running and also considers current inventory status when the runtime endpoint is stale.

## Related Issues

- Fixes #715

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git config --global --add safe.directory /workspace && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/heatpump_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Results:

- `pytest tests/components/enphase_ev -q` under coverage: 3283 passed.
- `coverage report --include=custom_components/enphase_ev/heatpump_runtime.py --fail-under=100`: 100%.
- `pytest -q`: 3402 passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Issue diagnostics showed HEMS entering an offline/error state while the previous active energy history still produced nonzero smoothed Heat Pump power. This change keeps historical active smoothing for active/unknown runtime states, but suppresses it for inactive runtime or inventory statuses.
