### PR TITLE
Fix EV charger start and stop fallback handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Fixed Heat Pump power smoothing so offline/error HEMS states no longer carry forward stale running power estimates. (#715)
+- Fixed IQ EV Charger start and stop charging requests so transient Enphase service errors are not masked by legacy endpoint fallbacks, preventing Home Assistant from reporting a successful stop while charging continues. (#717)
+- Fixed duplicate reauthentication repair issues by relying on Home Assistant's native config-entry repair and clearing stale Enphase reauth repairs.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -4378,6 +4378,14 @@ class EnphaseEVClient:
                                     message=message,
                                     headers=r.headers,
                                 )
+                                response_error.enphase_routing_not_found = (
+                                    r.status == 404
+                                    and self._is_routing_not_found(body_text)
+                                )
+                                response_error.enphase_invalid_charge_level = (
+                                    r.status == 500
+                                    and self._is_invalid_charge_level_error(body_text)
+                                )
                                 if _is_scheduler_charging_mode_endpoint(endpoint):
                                     code, display = _scheduler_error_context_from_text(
                                         body_text
@@ -4897,6 +4905,8 @@ class EnphaseEVClient:
                 _record_variant(idx)
                 return result
             except aiohttp.ClientResponseError as e:
+                if e.status >= 500:
+                    raise
                 # 409/422 (and similar) often indicate not plugged in or not ready.
                 # Treat these as benign no-ops instead of surfacing as errors.
                 if e.status in (409, 422):
@@ -4991,6 +5001,41 @@ class EnphaseEVClient:
             ),
         ]
 
+    @staticmethod
+    def _is_routing_not_found(message: str | None) -> bool:
+        """Return True when a 404 is a routing miss rather than action state."""
+
+        if not message:
+            return False
+        text = message.strip()
+        lower = text.lower()
+        if "no static resource" in lower:
+            return True
+        try:
+            parsed = json.loads(text)
+        except (TypeError, ValueError):
+            return False
+        if not isinstance(parsed, dict):
+            return False
+        detail_parts = [
+            parsed.get("detail"),
+            parsed.get("title"),
+            parsed.get("message"),
+            parsed.get("error"),
+        ]
+        return any(
+            isinstance(part, str) and "no static resource" in part.lower()
+            for part in detail_parts
+        )
+
+    @staticmethod
+    def _is_invalid_charge_level_error(message: str | None) -> bool:
+        """Return True when a response reports an invalid charge level."""
+
+        if not message:
+            return False
+        return "invalid charge level" in message.lower()
+
     async def stop_charging(self, sn: str) -> dict:
         """Stop charging; try multiple endpoint variants."""
         candidates = self._stop_charging_candidates(sn)
@@ -5017,10 +5062,17 @@ class EnphaseEVClient:
                 self._stop_variant_idx = idx
                 return result
             except aiohttp.ClientResponseError as e:
+                if e.status >= 500:
+                    raise
+                if e.status == 404 and (
+                    getattr(e, "enphase_routing_not_found", False)
+                    or self._is_routing_not_found(e.message)
+                ):
+                    last_exc = e
+                    continue
                 # If charger is not plugged in or already stopped, some backends
                 # respond with 400/404/409. Treat these as benign no-ops.
                 if e.status in (400, 404, 409, 422):
-                    self._stop_variant_idx = idx  # cache the working path even if no-op
                     return {"status": "not_active"}
                 last_exc = e
                 continue

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -4466,8 +4466,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._auth_refresh_suspended_until_utc = suspended_until.astimezone(_tz.utc)
         self._persist_auth_refresh_suspension_state()
         diagnostics = getattr(self, "diagnostics", None)
-        if diagnostics is not None:
-            diagnostics.create_reauth_issue()
+        clear_reauth_issue = getattr(diagnostics, "clear_reauth_issue", None)
+        if callable(clear_reauth_issue):
+            clear_reauth_issue()
 
     def _clear_auth_repair_issues_on_success(self) -> None:
         """Clear auth repairs unless auto-refresh suspension should keep reauth visible."""
@@ -4859,8 +4860,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.diagnostics.create_auth_block_issue()
             raise self._auth_block_update_failed()
 
-        if self._unauth_errors >= 2:
-            self.diagnostics.create_reauth_issue()
+        self.diagnostics.clear_reauth_issue()
 
         raise ConfigEntryAuthFailed
 

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -716,7 +716,10 @@ class EvseRuntime:
                 and include_level is True
                 and not strict_preference
                 and err.status == 500
-                and "invalid charge level" in str(err.message or "").lower()
+                and (
+                    getattr(err, "enphase_invalid_charge_level", False)
+                    or "invalid charge level" in str(err.message or "").lower()
+                )
             ):
                 # Some chargers reject starts with a charge level when no explicit
                 # setpoint was requested, but accept the same command without it.

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -4450,6 +4450,7 @@ Fallback variants observed:
 - No body (uses last stored level)
 - The implementation caches working variants, with separate preferences for requests that should include or omit the charging level.
 - Backend `409`/`422` or parsed "not plugged" errors are normalized to `{ "status": "not_ready" }`; "already in charging state" is normalized to `{ "status": "already_charging" }`.
+- Transient backend `5xx` responses are raised immediately instead of falling through to method, path, or payload fallbacks. The EVSE runtime still retries without a charge-level payload when a `500` response explicitly reports an invalid charge level and no explicit setpoint was requested.
 
 Typical response:
 ```json
@@ -4464,7 +4465,11 @@ Fallbacks: `POST`, singular path `/ev_charger/`.
 ```json
 { "status": "accepted" }
 ```
-Implementation note: backend `400`, `404`, `409`, or `422` responses are treated as benign no-op `{ "status": "not_active" }`, and the working variant is cached.
+Implementation notes:
+- Successful responses cache the working variant.
+- Backend `400`, semantic `404`, `409`, or `422` responses are treated as benign no-op `{ "status": "not_active" }` but do not cache the variant.
+- Routing `404` responses with `No static resource` in the response text or JSON problem details are treated as route failures so fallback variants can still be tried.
+- Transient backend `5xx` responses are raised immediately instead of falling through to method or path fallbacks.
 
 ### 3.3 Trigger OCPP Message
 ```

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3303,6 +3303,20 @@ async def test_start_charging_not_ready_on_409() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_charging_raises_503_without_trying_fallback() -> None:
+    client = _make_client()
+    error = _make_cre(503, '{"errorMessageCode":"iqevc_ms-10007"}')
+    client._json = AsyncMock(side_effect=error)
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client.start_charging("SN", 32, connector_id=1)
+
+    assert err.value is error
+    assert client._json.await_count == 1
+    assert client._start_variant_idx is None
+
+
+@pytest.mark.asyncio
 async def test_start_charging_interprets_errors() -> None:
     body = {
         "error": {
@@ -3602,13 +3616,167 @@ async def test_stop_charging_handles_noop_status() -> None:
     client._json = AsyncMock(side_effect=[_make_cre(404), {"status": "ok"}])
     out = await client.stop_charging("SN")
     assert out == {"status": "not_active"}
-    assert client._stop_variant_idx == 0
+    assert client._stop_variant_idx is None
+
+
+@pytest.mark.asyncio
+async def test_control_candidates_keep_legacy_singular_fallbacks() -> None:
+    client = _make_client()
+
+    start_urls = [
+        url for _method, url, _payload in client._start_charging_candidates("SN", 32, 1)
+    ]
+    stop_urls = [
+        url for _method, url, _payload in client._stop_charging_candidates("SN")
+    ]
+
+    assert any("/ev_chargers/" in url for url in start_urls)
+    assert any("/ev_charger/" in url for url in start_urls)
+    assert any("/ev_chargers/" in url for url in stop_urls)
+    assert any("/ev_charger/" in url for url in stop_urls)
+
+
+@pytest.mark.asyncio
+async def test_stop_charging_raises_503_without_trying_fallback() -> None:
+    client = _make_client()
+    error = _make_cre(503, '{"errorMessageCode":"iqevc_ms-10007"}')
+    client._json = AsyncMock(side_effect=error)
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client.stop_charging("SN")
+
+    assert err.value is error
+    assert client._json.await_count == 1
+    assert client._stop_variant_idx is None
+
+
+@pytest.mark.asyncio
+async def test_stop_charging_routing_404_is_not_noop(monkeypatch) -> None:
+    client = _make_client()
+    monkeypatch.setattr(
+        client,
+        "_stop_charging_candidates",
+        lambda _sn: [
+            ("POST", "https://example.test/ev_charger/SN/stop_charging", None)
+        ],
+    )
+    error = _make_cre(404, '{"type":"about:blank","detail":"No static resource"}')
+    client._json = AsyncMock(side_effect=error)
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client.stop_charging("SN")
+
+    assert err.value is error
+    assert client._stop_variant_idx is None
+
+
+@pytest.mark.asyncio
+async def test_stop_charging_about_blank_404_with_spacing_is_not_noop(
+    monkeypatch,
+) -> None:
+    client = _make_client()
+    monkeypatch.setattr(
+        client,
+        "_stop_charging_candidates",
+        lambda _sn: [("POST", "https://example.test/stop_charging", None)],
+    )
+    error = _make_cre(404, '{ "type": "about:blank", "detail": "No static resource" }')
+    client._json = AsyncMock(side_effect=error)
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client.stop_charging("SN")
+
+    assert err.value is error
+    assert client._stop_variant_idx is None
+
+
+@pytest.mark.asyncio
+async def test_stop_charging_semantic_404_remains_noop() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=[
+            _make_cre(
+                404,
+                '{"type":"about:blank","title":"Not Found","detail":"charger is not active"}',
+            )
+        ]
+    )
+
+    out = await client.stop_charging("SN")
+
+    assert out == {"status": "not_active"}
+    assert client._stop_variant_idx is None
+
+
+@pytest.mark.asyncio
+async def test_stop_charging_routing_404_falls_back_to_legacy_singular() -> None:
+    client = _make_client()
+    error = _make_cre(404, '{"type":"about:blank","detail":"No static resource"}')
+    client._json = AsyncMock(side_effect=[error, _make_cre(405), {"status": "ok"}])
+
+    out = await client.stop_charging("SN")
+
+    assert out == {"status": "ok"}
+    assert client._json.await_count == 3
+    args, _kwargs = client._json.await_args
+    assert "/ev_charger/" in args[1]
+    assert client._stop_variant_idx == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_charging_routing_404_from_json_response_uses_derived_flag() -> None:
+    session = _FakeSession(
+        [
+            _FakeResponse(
+                status=404,
+                json_body={},
+                text_body='{ "type": "about:blank", "detail": "No static resource" }',
+            ),
+            _FakeResponse(status=405, json_body={}, text_body="method not allowed"),
+            _FakeResponse(status=200, json_body={"status": "ok"}),
+        ]
+    )
+    client = _make_client(session)
+
+    out = await client.stop_charging("SN")
+
+    assert out == {"status": "ok"}
+    assert len(session.calls) == 3
+    assert "/ev_charger/" in session.calls[-1][1]
+    assert client._stop_variant_idx == 2
+
+
+@pytest.mark.asyncio
+async def test_start_charging_invalid_level_500_from_json_response_sets_flag() -> None:
+    session = _FakeSession(
+        [
+            _FakeResponse(
+                status=500,
+                json_body={},
+                text_body='{"error":{"displayMessage":"Invalid charge level","code":"500"}}',
+            ),
+        ]
+    )
+    client = _make_client(session)
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client.start_charging("SN", 32)
+
+    assert getattr(err.value, "enphase_invalid_charge_level", False) is True
+    assert len(session.calls) == 1
+
+
+def test_stop_charging_routing_404_helper_handles_empty_message() -> None:
+    assert not api.EnphaseEVClient._is_routing_not_found(None)
+    assert not api.EnphaseEVClient._is_routing_not_found("")
+    assert not api.EnphaseEVClient._is_invalid_charge_level_error(None)
+    assert not api.EnphaseEVClient._is_invalid_charge_level_error("")
 
 
 @pytest.mark.asyncio
 async def test_stop_charging_raises_last_exception() -> None:
     client = _make_client()
-    client._json = AsyncMock(side_effect=[_make_cre(500)] * 3)
+    client._json = AsyncMock(side_effect=[_make_cre(405)] * 3)
     with pytest.raises(aiohttp.ClientResponseError):
         await client.stop_charging("SN")
 

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -3927,7 +3927,10 @@ async def test_handle_client_unauthorized_paths(
     coord._unauth_errors = 1
     with pytest.raises(coord_mod.ConfigEntryAuthFailed):
         await coord._handle_client_unauthorized()
-    assert any(issue[1] == "reauth_required" for issue in mock_issue_registry.created)
+    assert not any(
+        issue[1] == "reauth_required" for issue in mock_issue_registry.created
+    )
+    assert any(issue[1] == "reauth_required" for issue in mock_issue_registry.deleted)
 
 
 def test_persist_tokens_updates_entry(coordinator_factory, config_entry):

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2235,18 +2235,13 @@ async def test_handle_client_unauthorized_failure(monkeypatch, hass):
     with pytest.raises(ConfigEntryAuthFailed):
         await coord._handle_client_unauthorized()
 
-    assert deleted == ["too_many_active_sessions"]
+    assert deleted == [
+        "reauth_required",
+        "auth_blocked",
+        "too_many_active_sessions",
+    ]
     assert coord._unauth_errors >= 2
-    issue_id, payload = created[-1]
-    assert issue_id == "reauth_required"
-    placeholders = payload["translation_placeholders"]
-    assert placeholders["site_id"] == coord.site_id
-    assert placeholders["site_name"] == "Garage Site"
-    assert placeholders["last_status"] == "401"
-    assert placeholders["last_error"] == "unauthorized"
-    metrics = payload["data"]["site_metrics"]
-    assert metrics["site_name"] == "Garage Site"
-    assert metrics["last_error"] == "unauthorized"
+    assert created == []
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -1419,6 +1419,26 @@ def test_auth_refresh_suspended_active_clears_expired_window(hass, monkeypatch):
     coord._persist_auth_refresh_suspension_state.assert_called_once_with()
 
 
+def test_note_auth_refresh_suspended_clears_custom_reauth_issue(hass):
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    coord = _attach_evse_runtime(EnphaseCoordinator.__new__(EnphaseCoordinator))
+    coord.hass = hass
+    coord._persist_auth_refresh_suspension_state = MagicMock()
+    coord.diagnostics = SimpleNamespace(
+        clear_reauth_issue=MagicMock(),
+        create_reauth_issue=MagicMock(),
+    )
+    suspended_until = datetime.now(timezone.utc) + timedelta(hours=1)
+
+    coord._note_auth_refresh_suspended(suspended_until=suspended_until)
+
+    assert coord._auth_refresh_suspended_until_utc == suspended_until
+    coord._persist_auth_refresh_suspension_state.assert_called_once_with()
+    coord.diagnostics.clear_reauth_issue.assert_called_once_with()
+    coord.diagnostics.create_reauth_issue.assert_not_called()
+
+
 def test_clear_auth_repair_issues_on_success_clears_reauth_when_not_suspended(hass):
     from custom_components.enphase_ev.coordinator import EnphaseCoordinator
 
@@ -1486,7 +1506,10 @@ async def test_attempt_auto_refresh_suspends_after_repeated_rejections(
     coord._auth_refresh_suspended_until_utc = None
     coord.client = SimpleNamespace(update_credentials=MagicMock())
     coord._persist_tokens = MagicMock()
-    coord.diagnostics = SimpleNamespace(create_reauth_issue=MagicMock())
+    coord.diagnostics = SimpleNamespace(
+        clear_reauth_issue=MagicMock(),
+        create_reauth_issue=MagicMock(),
+    )
 
     calls = 0
 
@@ -1513,7 +1536,8 @@ async def test_attempt_auto_refresh_suspends_after_repeated_rejections(
     assert coord._auth_refresh_rejected_until is None
     assert coord._auth_refresh_rejected_ends_utc is None
     assert coord._auth_refresh_suspended_until_utc is not None
-    coord.diagnostics.create_reauth_issue.assert_called_once_with()
+    coord.diagnostics.clear_reauth_issue.assert_called_once_with()
+    coord.diagnostics.create_reauth_issue.assert_not_called()
 
     assert await coord._attempt_auto_refresh() is False
     assert calls == AUTH_REFRESH_REJECTED_SUSPEND_THRESHOLD
@@ -1578,7 +1602,10 @@ def test_note_auth_refresh_rejected_threshold_handles_utcnow_error(monkeypatch, 
     coord._auth_refresh_rejected_ends_utc = datetime.now(timezone.utc) + timedelta(
         seconds=60
     )
-    coord.diagnostics = SimpleNamespace(create_reauth_issue=MagicMock())
+    coord.diagnostics = SimpleNamespace(
+        clear_reauth_issue=MagicMock(),
+        create_reauth_issue=MagicMock(),
+    )
 
     monkeypatch.setattr(
         arr_mod.dt_util,
@@ -1592,7 +1619,8 @@ def test_note_auth_refresh_rejected_threshold_handles_utcnow_error(monkeypatch, 
     assert coord._auth_refresh_rejected_until is None
     assert coord._auth_refresh_rejected_ends_utc is None
     assert coord._auth_refresh_suspended_until_utc is not None
-    coord.diagnostics.create_reauth_issue.assert_called_once_with()
+    coord.diagnostics.clear_reauth_issue.assert_called_once_with()
+    coord.diagnostics.create_reauth_issue.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -2234,7 +2262,7 @@ async def test_handle_client_unauthorized_creates_issue_after_failures(
         await coord._handle_client_unauthorized()
 
     assert coord._unauth_errors == 2
-    assert created and created[0][0][2] == "reauth_required"
+    assert created == []
 
 
 def test_blocked_auth_failure_message_handles_missing_timestamp():

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -492,6 +492,42 @@ async def test_evse_runtime_start_charging_invalid_level_falls_back_and_caches(
 
 
 @pytest.mark.asyncio
+async def test_evse_runtime_start_charging_invalid_level_flag_falls_back(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    coord.data = {"EV1": {"plugged": True, "charge_mode_pref": "MANUAL_CHARGING"}}
+    coord.pick_start_amps = MagicMock(return_value=28)
+    coord.set_last_set_amps = MagicMock()
+    coord.set_desired_charging = MagicMock()
+    coord.set_charging_expectation = MagicMock()
+    coord.kick_fast = MagicMock()
+    coord.async_start_streaming = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
+    coord.require_plugged = MagicMock()
+    invalid_level_error = _client_response_error(
+        500,
+        message="HTTP error from Enphase endpoint (status=500, body_length=61)",
+    )
+    invalid_level_error.enphase_invalid_charge_level = True
+    coord.client.start_charging = AsyncMock(
+        side_effect=[invalid_level_error, {"status": "ok"}]
+    )
+
+    await runtime.async_start_charging("EV1")
+
+    assert coord.client.start_charging.await_args_list[1] == call(
+        "EV1",
+        28,
+        1,
+        include_level=False,
+        strict_preference=True,
+    )
+    assert coord._start_without_level_fallback == {"EV1": True}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_evse_runtime_start_charging_uses_cached_no_level_fallback(
     coordinator_factory,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #717.

- Fast-fail IQ EV Charger start/stop requests on transient Enphase 5xx responses instead of falling through to legacy endpoint variants.
- Keep legacy singular `ev_charger` endpoint fallbacks for routing misses and older charger deployments.
- Avoid caching benign stop no-op responses so future stop calls can still exercise the correct endpoint.
- Use Home Assistant's native config-entry reauth repair for credential expiry and clear stale custom Enphase reauth repairs to avoid duplicate repair issues.
- Document the observed start/stop API behavior and update the changelog.

## Related Issues

- Fixes #717

## Type of change

- [x] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_edge_cases.py tests/components/enphase_ev/test_evse_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger:/Users/james/Documents/GitHub/ha-enphase-ev-charger ha-dev bash -lc "git status --short >/tmp/git-ok && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/evse_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
```

Results:

- `black`: passed, 8 files unchanged
- `ruff check .`: passed
- `pre-commit run --all-files`: passed (`black`, `ruff`, `codespell`)
- Coverage: `3295 passed`, 100% for `custom_components/enphase_ev/api.py`, `custom_components/enphase_ev/coordinator.py`, and `custom_components/enphase_ev/evse_runtime.py`
- Full pytest: `3414 passed`
- Quality scale: platinum OK

Manual validation:

- Retested against a plugged-in IQ EV Charger. Direct integration API start returned success and cloud status reported `charging: true` after 15 seconds. Stop returned success and Home Assistant ended at `Charging: Off`, `Connector Status: SUSPENDED_EVSE`, `Plugged In: On`, `Power: 0 W`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The `pre-commit` Docker command mounts the host Git metadata path because this checkout is a Git worktree and the container otherwise cannot resolve `.git/worktrees/...`.
