### PR TITLE
Handle repeated EVSE start commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed IQ EV Charger start charging controls so repeated start requests while already charging do not surface Enphase endpoint 404 errors in Home Assistant, while explicit amp updates still reach Enphase.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -643,6 +643,14 @@ class EvseRuntime:
             data = (coord.data or {}).get(sn_str, {})
         except Exception:
             data = {}
+        if requested_amps is None and evse_power_is_actively_charging(
+            data.get("connector_status"),
+            data.get("charging"),
+            suspended_by_evse=data.get("suspended_by_evse", False),
+        ):
+            coord.set_desired_charging(sn_str, True)
+            coord.set_charging_expectation(sn_str, True, hold_for=hold_seconds)
+            return {"status": "already_charging"}
         if data.get("auth_required") is True:
             display = data.get("display_name") or data.get("name") or sn_str
             _LOGGER.warning(
@@ -735,6 +743,13 @@ class EvseRuntime:
                     coord._start_without_level_fallback = fallback_cache
                 fallback_cache[sn_str] = True
                 return result
+            if 400 <= err.status < 500:
+                raise ServiceValidationError(
+                    f"Start charging was rejected by Enphase (HTTP {err.status}).",
+                    translation_domain=DOMAIN,
+                    translation_key="start_charging_rejected",
+                    translation_placeholders={"status": str(err.status)},
+                ) from err
             raise
         if include_level is True and prefs.include_level is True:
             if isinstance(fallback_cache, dict):

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Cannot start charging because {name} requires authentication via the Enphase app or RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start charging was rejected by Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Grid control is unavailable for this site."
     },

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Зареждането не може да започне, защото {name} изисква удостоверяване чрез приложението Enphase или RFID."
     },
+    "start_charging_rejected": {
+      "message": "Стартирането на зареждането беше отхвърлено от Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Контролът на мрежата не е наличен за този сайт."
     },

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Nabíjení nelze zahájit, protože {name} vyžaduje ověření prostřednictvím aplikace Enphase nebo RFID."
     },
+    "start_charging_rejected": {
+      "message": "Spuštění nabíjení bylo službou Enphase odmítnuto (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Ovládání mřížky není pro tento web k dispozici."
     },

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Kan ikke starte opladningen, fordi {name} kræver godkendelse via Enphase-appen eller RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start af opladning blev afvist af Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Gitterstyring er ikke tilgængelig for dette websted."
     },

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Der Ladevorgang kann nicht gestartet werden, da {name} eine Authentifizierung über die Enphase-App oder RFID erfordert."
     },
+    "start_charging_rejected": {
+      "message": "Ladestart wurde von Enphase abgelehnt (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Die Rastersteuerung ist für diese Site nicht verfügbar."
     },

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Δεν είναι δυνατή η έναρξη της φόρτισης επειδή το {name} απαιτεί έλεγχο ταυτότητας μέσω της εφαρμογής Enphase ή RFID."
     },
+    "start_charging_rejected": {
+      "message": "Η έναρξη φόρτισης απορρίφθηκε από την Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Ο έλεγχος πλέγματος δεν είναι διαθέσιμος για αυτόν τον ιστότοπο."
     },

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Cannot start charging because {name} requires authentication via the Enphase app or RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start charging was rejected by Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Grid control is unavailable for this site."
     },

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Cannot start charging because {name} requires authentication via the Enphase app or RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start charging was rejected by Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Grid control is unavailable for this site."
     },

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Cannot start charging because {name} requires authentication via the Enphase app or RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start charging was rejected by Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Grid control is unavailable for this site."
     },

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Cannot start charging because {name} requires authentication via the Enphase app or RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start charging was rejected by Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Grid control is unavailable for this site."
     },

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Cannot start charging because {name} requires authentication via the Enphase app or RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start charging was rejected by Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Grid control is unavailable for this site."
     },

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Cannot start charging because {name} requires authentication via the Enphase app or RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start charging was rejected by Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Grid control is unavailable for this site."
     },

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "No se puede comenzar a cargar porque {name} requiere autenticación a través de la aplicación Enphase o RFID."
     },
+    "start_charging_rejected": {
+      "message": "Enphase rechazó el inicio de la carga (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "El control de red no está disponible para este sitio."
     },

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Laadimist ei saa alustada, kuna {name} nõuab autentimist rakenduse Enphase või RFID kaudu."
     },
+    "start_charging_rejected": {
+      "message": "Enphase lükkas laadimise alustamise tagasi (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Võrgu juhtimine pole sellel saidil saadaval."
     },

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Lataus ei onnistu, koska {name} vaatii todennuksen Enphase-sovelluksen tai RFID:n kautta."
     },
+    "start_charging_rejected": {
+      "message": "Enphase hylkäsi latauksen käynnistyksen (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Verkkoohjaus ei ole käytettävissä tälle sivustolle."
     },

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Impossible de démarrer le chargement car {name} nécessite une authentification via l'application Enphase ou RFID."
     },
+    "start_charging_rejected": {
+      "message": "Le démarrage de la charge a été rejeté par Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Le contrôle du réseau n'est pas disponible pour ce site."
     },

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "A töltés nem indítható el, mert a {name} hitelesítést igényel az Enphase alkalmazáson vagy az RFID-n keresztül."
     },
+    "start_charging_rejected": {
+      "message": "Az Enphase elutasította a töltés indítását (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "A rácsvezérlés nem érhető el ezen a webhelyen."
     },

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Impossibile avviare la ricarica perché {name} richiede l'autenticazione tramite l'app Enphase o RFID."
     },
+    "start_charging_rejected": {
+      "message": "L'avvio della ricarica è stato rifiutato da Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Il controllo della griglia non è disponibile per questo sito."
     },

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Negalima pradėti įkrauti, nes {name} reikalauja autentifikavimo naudojant „Enphase“ programą arba RFID."
     },
+    "start_charging_rejected": {
+      "message": "„Enphase“ atmetė įkrovimo paleidimą (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Šioje svetainėje tinklelio valdymas nepasiekiamas."
     },

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Nevar sākt uzlādi, jo {name} nepieciešama autentifikācija, izmantojot lietotni Enphase vai RFID."
     },
+    "start_charging_rejected": {
+      "message": "Enphase noraidīja uzlādes sākšanu (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Režģa vadība šai vietnei nav pieejama."
     },

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Kan ikke starte ladingen fordi {name} krever autentisering via Enphase-appen eller RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start av lading ble avvist av Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Rutenettkontroll er utilgjengelig for dette nettstedet."
     },

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Kan niet beginnen met opladen omdat {name} authenticatie via de Enphase-app of RFID vereist."
     },
+    "start_charging_rejected": {
+      "message": "Het starten van laden is geweigerd door Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Netbeheer is niet beschikbaar voor deze site."
     },

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Nie można rozpocząć ładowania, ponieważ {name} wymaga uwierzytelnienia za pomocą aplikacji Enphase lub RFID."
     },
+    "start_charging_rejected": {
+      "message": "Uruchomienie ładowania zostało odrzucone przez Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Sterowanie siecią jest niedostępne dla tej witryny."
     },

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Não é possível iniciar a cobrança porque {name} requer autenticação por meio do aplicativo Enphase ou RFID."
     },
+    "start_charging_rejected": {
+      "message": "O início da carga foi rejeitado pela Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "O controle de grade não está disponível para este site."
     },

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Nu se poate începe încărcarea deoarece {name} necesită autentificare prin aplicația Enphase sau RFID."
     },
+    "start_charging_rejected": {
+      "message": "Pornirea încărcării a fost respinsă de Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Controlul rețelei nu este disponibil pentru acest site."
     },

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -88,6 +88,9 @@
     "auth_required": {
       "message": "Det går inte att börja ladda eftersom {name} kräver autentisering via Enphase-appen eller RFID."
     },
+    "start_charging_rejected": {
+      "message": "Start av laddning avvisades av Enphase (HTTP {status})."
+    },
     "grid_control_unavailable": {
       "message": "Nätstyrning är inte tillgänglig för den här anläggningen."
     },

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -448,6 +448,76 @@ async def test_evse_runtime_start_stop_and_auto_resume_use_coordinator_hooks(
 
 
 @pytest.mark.asyncio
+async def test_evse_runtime_start_charging_noops_when_already_charging(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    coord.data = {
+        "EV1": {
+            "plugged": True,
+            "connector_status": "CHARGING",
+            "charging": True,
+            "charge_mode_pref": "MANUAL_CHARGING",
+        }
+    }
+    coord.require_plugged = MagicMock()
+    coord.pick_start_amps = MagicMock(return_value=28)
+    coord.set_desired_charging = MagicMock()
+    coord.set_charging_expectation = MagicMock()
+    coord.client.start_charging = AsyncMock()
+
+    result = await runtime.async_start_charging("EV1")
+
+    assert result == {"status": "already_charging"}
+    coord.require_plugged.assert_called_once_with("EV1")
+    coord.client.start_charging.assert_not_awaited()
+    coord.pick_start_amps.assert_not_called()
+    coord.set_desired_charging.assert_called_once_with("EV1", True)
+    coord.set_charging_expectation.assert_called_once_with(
+        "EV1",
+        True,
+        hold_for=90.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_start_charging_sends_explicit_amps_when_already_charging(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    coord.data = {
+        "EV1": {
+            "plugged": True,
+            "connector_status": "CHARGING",
+            "charging": True,
+            "charge_mode_pref": "MANUAL_CHARGING",
+        }
+    }
+    coord.require_plugged = MagicMock()
+    coord.pick_start_amps = MagicMock(return_value=24)
+    coord.set_last_set_amps = MagicMock()
+    coord.set_desired_charging = MagicMock()
+    coord.set_charging_expectation = MagicMock()
+    coord.kick_fast = MagicMock()
+    coord.async_start_streaming = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
+    coord.client.start_charging = AsyncMock(return_value={"status": "ok"})
+
+    await runtime.async_start_charging("EV1", requested_amps=24)
+
+    coord.client.start_charging.assert_awaited_once_with(
+        "EV1",
+        24,
+        1,
+        include_level=True,
+        strict_preference=True,
+    )
+    coord.set_last_set_amps.assert_called_once_with("EV1", 24)
+
+
+@pytest.mark.asyncio
 async def test_evse_runtime_start_charging_invalid_level_falls_back_and_caches(
     coordinator_factory,
 ) -> None:
@@ -606,6 +676,36 @@ async def test_evse_runtime_start_charging_reraises_non_fallback_errors(
     with pytest.raises(aiohttp.ClientResponseError):
         await runtime.async_start_charging("EV1")
 
+    coord.client.start_charging.assert_awaited_once_with(
+        "EV1",
+        28,
+        1,
+        include_level=True,
+        strict_preference=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_start_charging_maps_client_errors_to_validation(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    coord.data = {"EV1": {"plugged": True, "charge_mode_pref": "MANUAL_CHARGING"}}
+    coord.pick_start_amps = MagicMock(return_value=28)
+    coord.require_plugged = MagicMock()
+    coord.client.start_charging = AsyncMock(
+        side_effect=_client_response_error(
+            404,
+            message="HTTP error from Enphase endpoint (status=404)",
+        )
+    )
+
+    with pytest.raises(ServiceValidationError) as err:
+        await runtime.async_start_charging("EV1")
+
+    assert err.value.translation_key == "start_charging_rejected"
+    assert err.value.translation_placeholders == {"status": "404"}
     coord.client.start_charging.assert_awaited_once_with(
         "EV1",
         28,

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -629,6 +629,7 @@ def test_externalized_i18n_strings_localized_for_non_english_locales() -> None:
     )
     en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
     paths = [
+        "exceptions.start_charging_rejected.message",
         "exceptions.firmware_advisory_only.message",
         "entity.sensor.dry_contacts.name",
     ]
@@ -680,6 +681,7 @@ def test_translated_user_facing_errors_require_translation_keys() -> None:
     audited_files = [
         "ac_battery_runtime.py",
         "battery_runtime.py",
+        "evse_runtime.py",
         "select.py",
         "services.py",
         "switch.py",


### PR DESCRIPTION
## Summary

Fixes IQ EV Charger start controls so pressing Start while the charger is already actively charging is treated as a benign no-op instead of calling Enphase again and surfacing a 404 through Home Assistant's websocket API.

The change also preserves explicit amp updates during active charging, converts remaining 4xx start-command rejections into a translated `ServiceValidationError`, updates all locale files for the new exception message, and adds regression coverage for both paths.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml build ha-dev
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/evse_runtime.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/evse_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/config_flow.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Coverage result for touched module:

```text
custom_components/enphase_ev/evse_runtime.py    1214      0   100%
```

Full pytest result: `3417 passed`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Local Docker validation passed. GitHub Actions have not been reviewed yet because the PR was just opened.