### PR TITLE
Add automation metadata for charger binary sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🔧 Improvements
-- None
+- Added semantic device classes to IQ EV Charger plugged-in and charging binary sensors so Home Assistant automation triggers and conditions can recognize their purpose.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -144,11 +144,15 @@ class _EVBoolSensor(EnphaseBaseEntity, BinarySensorEntity):
 
 
 class PluggedInBinarySensor(_EVBoolSensor):
+    _attr_device_class = BinarySensorDeviceClass.PLUG
+
     def __init__(self, coord: EnphaseCoordinator, sn: str):
         super().__init__(coord, sn, "plugged", "plugged_in")
 
 
 class ChargingBinarySensor(_EVBoolSensor):
+    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+
     def __init__(self, coord: EnphaseCoordinator, sn: str):
         super().__init__(coord, sn, "charging", "charging")
 

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -736,8 +736,10 @@ def test_ev_bool_sensors_reflect_coordinator_state(
 
     plugged = PluggedInBinarySensor(coord, RANDOM_SERIAL)
     assert plugged.is_on is False
+    assert plugged.device_class == BinarySensorDeviceClass.PLUG
 
     charging = ChargingBinarySensor(coord, RANDOM_SERIAL)
+    assert charging.device_class == BinarySensorDeviceClass.BATTERY_CHARGING
     assert charging.icon == "mdi:flash"
 
     coord.data[RANDOM_SERIAL]["charging"] = 0

--- a/tests/components/enphase_ev/test_schedule_sync.py
+++ b/tests/components/enphase_ev/test_schedule_sync.py
@@ -945,6 +945,7 @@ async def test_schedule_sync_remove_all_helpers_filters_registry_entries(
         device_id=None,
         area_id=None,
         labels=set(),
+        disabled_by=None,
     )
     ent_reg.entities["switch.other_platform"] = SimpleNamespace(
         id="switch.other_platform",
@@ -956,6 +957,7 @@ async def test_schedule_sync_remove_all_helpers_filters_registry_entries(
         device_id=None,
         area_id=None,
         labels=set(),
+        disabled_by=None,
     )
     ent_reg.entities["switch.bad_unique"] = SimpleNamespace(
         id="switch.bad_unique",
@@ -967,6 +969,7 @@ async def test_schedule_sync_remove_all_helpers_filters_registry_entries(
         device_id=None,
         area_id=None,
         labels=set(),
+        disabled_by=None,
     )
     ent_reg.entities["switch.mismatch_entry"] = SimpleNamespace(
         id="switch.mismatch_entry",
@@ -978,6 +981,7 @@ async def test_schedule_sync_remove_all_helpers_filters_registry_entries(
         device_id=None,
         area_id=None,
         labels=set(),
+        disabled_by=None,
     )
     ent_reg.entities["switch.parse_fail"] = SimpleNamespace(
         id="switch.parse_fail",
@@ -989,6 +993,7 @@ async def test_schedule_sync_remove_all_helpers_filters_registry_entries(
         device_id=None,
         area_id=None,
         labels=set(),
+        disabled_by=None,
     )
     ent_reg.entities["switch.unknown_serial"] = SimpleNamespace(
         id="switch.unknown_serial",
@@ -1000,6 +1005,7 @@ async def test_schedule_sync_remove_all_helpers_filters_registry_entries(
         device_id=None,
         area_id=None,
         labels=set(),
+        disabled_by=None,
     )
     ent_reg.entities["schedule.bad_unique"] = SimpleNamespace(
         id="schedule.bad_unique",
@@ -1011,6 +1017,7 @@ async def test_schedule_sync_remove_all_helpers_filters_registry_entries(
         device_id=None,
         area_id=None,
         labels=set(),
+        disabled_by=None,
     )
     ent_reg.entities["schedule.mismatch_entry"] = SimpleNamespace(
         id="schedule.mismatch_entry",
@@ -1022,6 +1029,7 @@ async def test_schedule_sync_remove_all_helpers_filters_registry_entries(
         device_id=None,
         area_id=None,
         labels=set(),
+        disabled_by=None,
     )
 
     await sync._remove_all_helpers()


### PR DESCRIPTION
## Summary

Add semantic Home Assistant device classes to the IQ EV Charger plugged-in and charging binary sensors so Home Assistant 2026.7 purpose-specific automation triggers and conditions can recognize their intent.

Also update a schedule-sync test registry fixture for current Home Assistant registry expectations.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Other: Automation metadata improvement.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/binary_sensor.py tests/components/enphase_ev/test_binary_sensor_module.py tests/components/enphase_ev/test_schedule_sync.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/binary_sensor.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots needed. This updates entity metadata only.
