### PR TITLE
Add service action icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🔧 Improvements
 - Added semantic device classes to IQ EV Charger plugged-in and charging binary sensors so Home Assistant automation triggers and conditions can recognize their purpose.
+- Added Home Assistant service action icons for Enphase actions in automation and script editors.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/icons.json
+++ b/custom_components/enphase_ev/icons.json
@@ -1,4 +1,60 @@
 {
+  "services": {
+    "add_schedule": {
+      "service": "mdi:calendar-plus"
+    },
+    "clear_hems_auth_backoff": {
+      "service": "mdi:lock-open"
+    },
+    "clear_reauth_issue": {
+      "service": "mdi:account-check"
+    },
+    "delete_schedule": {
+      "service": "mdi:calendar-remove"
+    },
+    "force_refresh": {
+      "service": "mdi:refresh"
+    },
+    "request_grid_toggle_otp": {
+      "service": "mdi:message-lock"
+    },
+    "set_grid_mode": {
+      "service": "mdi:transmission-tower"
+    },
+    "start_charging": {
+      "service": "mdi:play"
+    },
+    "start_live_stream": {
+      "service": "mdi:cloud-sync"
+    },
+    "stop_charging": {
+      "service": "mdi:stop"
+    },
+    "stop_live_stream": {
+      "service": "mdi:cloud-off-outline"
+    },
+    "sync_schedules": {
+      "service": "mdi:calendar-sync"
+    },
+    "trigger_message": {
+      "service": "mdi:message-text"
+    },
+    "try_reauth_now": {
+      "service": "mdi:account-key"
+    },
+    "update_cfg_schedule": {
+      "service": "mdi:calendar-edit"
+    },
+    "update_schedule": {
+      "service": "mdi:calendar-edit"
+    },
+    "update_tariff": {
+      "service": "mdi:cash-multiple"
+    },
+    "validate_schedule": {
+      "service": "mdi:calendar-check"
+    }
+  },
   "entity": {
     "binary_sensor": {
       "cloud_reachable": {

--- a/tests/components/enphase_ev/test_manifest.py
+++ b/tests/components/enphase_ev/test_manifest.py
@@ -1,6 +1,8 @@
 import json
 import pathlib
 
+import yaml
+
 MIN_HOME_ASSISTANT_VERSION = "2026.6.0"
 
 
@@ -66,3 +68,16 @@ def test_development_requirements_cover_minimum_homeassistant_version():
     assert hacs.get("homeassistant") == MIN_HOME_ASSISTANT_VERSION
     assert f"homeassistant>={MIN_HOME_ASSISTANT_VERSION}" in requirements_dev
     assert f"homeassistant=={MIN_HOME_ASSISTANT_VERSION}" in requirements_min_ha
+
+
+def test_service_actions_have_icons():
+    root = pathlib.Path(__file__).resolve().parents[3]
+    integration_dir = root / "custom_components" / "enphase_ev"
+
+    services = yaml.safe_load((integration_dir / "services.yaml").read_text())
+    icons = json.loads((integration_dir / "icons.json").read_text())
+
+    service_icons = icons.get("services", {})
+    assert set(service_icons) == set(services)
+    for service, icon_data in service_icons.items():
+        assert icon_data["service"].startswith("mdi:"), service


### PR DESCRIPTION
## Summary

Add Home Assistant service action icons for every Enphase service action so automation and script editors can show action-specific icons.

Add a manifest metadata regression test that keeps `icons.json` service entries aligned with `services.yaml`.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black tests/components/enphase_ev/test_manifest.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_manifest.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Targeted coverage: not applicable; this PR does not touch integration Python modules.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots needed. This updates service action metadata only.
