### PR TITLE
Move service action text to translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🔧 Improvements
 - Added semantic device classes to IQ EV Charger plugged-in and charging binary sensors so Home Assistant automation triggers and conditions can recognize their purpose.
+- Moved service action display text fully into Home Assistant translations.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/services.yaml
+++ b/custom_components/enphase_ev/services.yaml
@@ -1,7 +1,5 @@
 
 start_charging:
-  name: Start Charging
-  description: Start charging on the Enphase Energy charger
   target:
     entity:
       integration: enphase_ev
@@ -26,15 +24,12 @@ start_charging:
               step: 1
 
 stop_charging:
-  name: Stop Charging
-  description: Stop charging on the Enphase Energy charger
   target:
     entity:
       integration: enphase_ev
       domain: button
 
 trigger_message:
-  name: Trigger OCPP Message
   target:
     entity:
       integration: enphase_ev
@@ -56,8 +51,6 @@ trigger_message:
       collapsed: true
       fields:
         confirm_advanced:
-          name: Confirm Advanced Trigger
-          description: Required for advanced OCPP trigger messages that may prompt charger diagnostics, firmware, or boot notifications.
           required: false
           selector:
             boolean:
@@ -70,8 +63,6 @@ trigger_message:
           example: "1234567"
 
 clear_reauth_issue:
-  name: Clear Reauth Issue
-  description: Manually clear the integration's reauthentication issue notification
   target:
     entity:
       integration: enphase_ev
@@ -91,8 +82,6 @@ clear_reauth_issue:
       example: "1234567"
 
 try_reauth_now:
-  name: Try Reauth Now
-  description: Use stored credentials to try Enphase reauthentication immediately
   target:
     entity:
       integration: enphase_ev
@@ -112,8 +101,6 @@ try_reauth_now:
       example: "1234567"
 
 clear_hems_auth_backoff:
-  name: Clear HEMS Auth Backoff
-  description: Clear the temporary HEMS/Heat Pump auth backoff without performing password login
   target:
     entity:
       integration: enphase_ev
@@ -132,8 +119,6 @@ clear_hems_auth_backoff:
           multiline: false
       example: "1234567"
 start_live_stream:
-  name: Start Live Stream
-  description: Request faster cloud status updates for a short period
   target:
     entity:
       integration: enphase_ev
@@ -149,8 +134,6 @@ start_live_stream:
           example: "1234567"
 
 stop_live_stream:
-  name: Stop Live Stream
-  description: Stop the cloud live stream request
   target:
     entity:
       integration: enphase_ev
@@ -166,8 +149,6 @@ stop_live_stream:
           example: "1234567"
 
 sync_schedules:
-  name: Sync Schedules
-  description: Refresh Enphase schedules from the cloud
   fields:
     device_id:
       required: false
@@ -177,8 +158,6 @@ sync_schedules:
           multiple: true
 
 force_refresh:
-  name: Force Refresh
-  description: Refresh battery schedule data from the Enphase cloud immediately
   target:
     entity:
       integration: enphase_ev
@@ -199,8 +178,6 @@ force_refresh:
               multiline: false
 
 update_tariff:
-  name: Update Tariff
-  description: Update Enphase billing-cycle details, guided tariff structures, and one or more existing import or export tariff rate values.
   target:
     entity:
       integration: enphase_ev
@@ -504,8 +481,6 @@ update_tariff:
               multiline: false
 
 add_schedule:
-  name: Add Battery Schedule
-  description: Create a battery schedule for CFG, DTG, or RBD
   target:
     entity:
       integration: enphase_ev
@@ -570,8 +545,6 @@ add_schedule:
               multiline: false
 
 update_schedule:
-  name: Update Battery Schedule
-  description: Update a battery schedule by schedule ID
   target:
     entity:
       integration: enphase_ev
@@ -645,8 +618,6 @@ update_schedule:
               multiline: false
 
 delete_schedule:
-  name: Delete Battery Schedule
-  description: Delete one or more battery schedules by schedule ID
   target:
     entity:
       integration: enphase_ev
@@ -682,8 +653,6 @@ delete_schedule:
               multiline: false
 
 validate_schedule:
-  name: Validate Battery Schedule
-  description: Validate battery schedule permissions and return the Enphase API response
   target:
     entity:
       integration: enphase_ev
@@ -712,8 +681,6 @@ validate_schedule:
               multiline: false
 
 request_grid_toggle_otp:
-  name: Request Grid Toggle OTP
-  description: Send a one-time code required for changing site grid mode.
   target:
     entity:
       integration: enphase_ev
@@ -729,8 +696,6 @@ request_grid_toggle_otp:
           example: "1234567"
 
 set_grid_mode:
-  name: Set Grid Mode
-  description: Change site grid mode using a one-time code.
   target:
     entity:
       integration: enphase_ev
@@ -758,32 +723,19 @@ set_grid_mode:
           example: "1234567"
 
 update_cfg_schedule:
-  name: Update CFG Schedule
-  description: >
-    Update the charge-from-grid schedule start time, end time, and/or
-    charge limit in a single atomic operation.  Only one API call is
-    made to the Enphase cloud, avoiding multiple pending-sync cycles.
-    At least one of start_time, end_time, or limit must be provided;
-    omitted values are preserved from the current schedule.
   target:
     entity:
       integration: enphase_ev
   fields:
     start_time:
-      name: Start Time
-      description: CFG schedule start time (HH:MM:SS).
       required: false
       selector:
         time:
     end_time:
-      name: End Time
-      description: CFG schedule end time (HH:MM:SS).
       required: false
       selector:
         time:
     limit:
-      name: Charge Limit
-      description: Maximum battery state of charge (%).
       required: false
       selector:
         number:
@@ -795,8 +747,6 @@ update_cfg_schedule:
       collapsed: true
       fields:
         site_id:
-          name: Site ID
-          description: Enphase site ID (optional, resolved from device target).
           required: false
           selector:
             text:

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -2439,6 +2439,11 @@
           "name": "Site ID",
           "description": "Enphase site ID (optional, resolved from device target)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Device",
           "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -2425,6 +2425,11 @@
           "name": "ID на обекта",
           "description": "Enphase ID на обекта (по избор; определя се от целевото устройство)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Разширени опции"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Разширени опции"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -2425,6 +2425,11 @@
           "name": "ID lokality",
           "description": "ID lokality Enphase (volitelné; určí se z cílového zařízení)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Pokročilé možnosti"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Pokročilé možnosti"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -2425,6 +2425,11 @@
           "name": "Site-id",
           "description": "Enphase-site-id (valgfrit; findes via målenheden)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Avancerede muligheder"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Avancerede muligheder"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -2425,6 +2425,11 @@
           "name": "Standort-ID",
           "description": "Enphase-Standort-ID (optional; wird aus dem Zielgerät ermittelt)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Erweiterte Optionen"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Gerät",
           "description": "Optionales Enphase-Gerät zur Auswahl des Standorts für Abrechnungs- oder Tarifstruktur-Updates."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Erweiterte Optionen"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -2425,6 +2425,11 @@
           "name": "ID τοποθεσίας",
           "description": "ID τοποθεσίας Enphase (προαιρετικό· επιλύεται από τη συσκευή στόχο)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Προηγμένες επιλογές"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Προηγμένες επιλογές"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -2425,6 +2425,11 @@
           "name": "Site ID",
           "description": "Enphase site ID (optional, resolved from device target)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Device",
           "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -2425,6 +2425,11 @@
           "name": "Site ID",
           "description": "Enphase site ID (optional, resolved from device target)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Device",
           "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -2425,6 +2425,11 @@
           "name": "Site ID",
           "description": "Enphase site ID (optional, resolved from device target)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Device",
           "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -2425,6 +2425,11 @@
           "name": "Site ID",
           "description": "Enphase site ID (optional, resolved from device target)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Device",
           "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -2425,6 +2425,11 @@
           "name": "Site ID",
           "description": "Enphase site ID (optional, resolved from device target)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Device",
           "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -2425,6 +2425,11 @@
           "name": "Site ID",
           "description": "Enphase site ID (optional, resolved from device target)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Device",
           "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -2425,6 +2425,11 @@
           "name": "ID del sitio",
           "description": "ID del sitio de Enphase (opcional; se resuelve desde el dispositivo de destino)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Dispositivo",
           "description": "Dispositivo Enphase opcional para elegir el sitio de las actualizaciones de facturación o estructura tarifaria."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -2425,6 +2425,11 @@
           "name": "Koha ID",
           "description": "Enphase koha ID (valikuline; leitakse sihtseadmest)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Täpsemad valikud"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Täpsemad valikud"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -2425,6 +2425,11 @@
           "name": "Sivuston tunnus",
           "description": "Enphase-sivuston tunnus (valinnainen; päätellään kohdelaitteesta)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Lisäasetukset"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Lisäasetukset"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -2425,6 +2425,11 @@
           "name": "ID du site",
           "description": "ID de site Enphase (facultatif ; résolu à partir de l'appareil cible)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Appareil",
           "description": "Appareil Enphase facultatif pour choisir le site des mises à jour de facturation ou de structure tarifaire."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -2425,6 +2425,11 @@
           "name": "Helyszín ID",
           "description": "Enphase helyszínazonosító (opcionális; a célkészülékből oldható fel)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Speciális beállítások"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Speciális beállítások"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -2425,6 +2425,11 @@
           "name": "ID sito",
           "description": "ID sito Enphase (facoltativo; risolto dal dispositivo di destinazione)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opzioni avanzate"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Dispositivo",
           "description": "Dispositivo Enphase opzionale per scegliere il sito degli aggiornamenti di fatturazione o struttura tariffaria."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opzioni avanzate"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -2425,6 +2425,11 @@
           "name": "Vietos ID",
           "description": "Enphase vietos ID (pasirinktinai; nustatomas iš tikslinio įrenginio)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Išplėstinės parinktys"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Išplėstinės parinktys"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -2425,6 +2425,11 @@
           "name": "Vietnes ID",
           "description": "Enphase vietnes ID (neobligāts; noteikts no mērķa ierīces)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Papildu opcijas"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Papildu opcijas"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -2425,6 +2425,11 @@
           "name": "Anleggs-ID",
           "description": "Enphase-anleggs-ID (valgfri; hentes fra målenheten)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Avanserte alternativer"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Avanserte alternativer"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -2425,6 +2425,11 @@
           "name": "Site-ID",
           "description": "Enphase-site-ID (optioneel; afgeleid van het doelapparaat)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Geavanceerde opties"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Geavanceerde opties"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -2425,6 +2425,11 @@
           "name": "ID lokalizacji",
           "description": "ID lokalizacji Enphase (opcjonalne; ustalane z urządzenia docelowego)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opcje zaawansowane"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opcje zaawansowane"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -2425,6 +2425,11 @@
           "name": "ID do site",
           "description": "ID do site Enphase (opcional; resolvido a partir do dispositivo de destino)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opções avançadas"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opções avançadas"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -2425,6 +2425,11 @@
           "name": "ID locație",
           "description": "ID locație Enphase (opțional; rezolvat din dispozitivul țintă)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opțiuni avansate"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Opțiuni avansate"
         }
       }
     },

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -2425,6 +2425,11 @@
           "name": "Plats-ID",
           "description": "Enphase plats-ID (valfritt; hämtas från målenheten)."
         }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Avancerade alternativ"
+        }
       }
     },
     "force_refresh": {
@@ -2727,6 +2732,11 @@
         "device_id": {
           "name": "Enphase-enhed",
           "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
+        }
+      },
+      "sections": {
+        "advanced": {
+          "name": "Avancerade alternativ"
         }
       }
     },

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -5,6 +5,10 @@ import json
 import pathlib
 import re
 
+import yaml
+
+ROOT = pathlib.Path(__file__).resolve().parents[3] / "custom_components" / "enphase_ev"
+
 
 def test_clear_reauth_issue_device_field_translated() -> None:
     """Ensure device selector metadata is translated for all locales."""
@@ -22,6 +26,36 @@ def test_clear_reauth_issue_device_field_translated() -> None:
         entry = fields["device_id"]
         assert entry.get("name"), f"{lang} device_id name empty"
         assert entry.get("description"), f"{lang} device_id description empty"
+
+
+def test_service_display_text_lives_in_translations() -> None:
+    """Ensure service action display text follows Home Assistant translation docs."""
+
+    services = yaml.safe_load((ROOT / "services.yaml").read_text(encoding="utf-8"))
+    strings = json.loads((ROOT / "strings.json").read_text(encoding="utf-8"))
+
+    for service_key, service_data in services.items():
+        assert "name" not in service_data, service_key
+        assert "description" not in service_data, service_key
+        service_strings = strings["services"][service_key]
+        assert service_strings["name"].strip(), service_key
+        assert service_strings["description"].strip(), service_key
+
+        for field_key, field_data in service_data.get("fields", {}).items():
+            if "fields" in field_data:
+                section_strings = service_strings["sections"][field_key]
+                assert section_strings["name"].strip(), f"{service_key}.{field_key}"
+                nested_fields = field_data["fields"]
+            else:
+                nested_fields = {field_key: field_data}
+            for nested_key, nested_data in nested_fields.items():
+                assert "name" not in nested_data, f"{service_key}.{nested_key}"
+                assert "description" not in nested_data, f"{service_key}.{nested_key}"
+                field_strings = service_strings["fields"][nested_key]
+                assert field_strings["name"].strip(), f"{service_key}.{nested_key}"
+                assert field_strings[
+                    "description"
+                ].strip(), f"{service_key}.{nested_key}"
 
 
 def test_try_reauth_now_strings_exist_for_all_locales() -> None:


### PR DESCRIPTION
## Summary

Move Enphase service action display text out of `services.yaml` and rely on `strings.json` plus locale translations, matching current Home Assistant service action guidance.

Add missing localized `advanced` section labels for `update_tariff` and `update_cfg_schedule`, and add a regression test that keeps service action display text in translations.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
git diff --check
```

Targeted coverage: not applicable; this PR does not touch integration Python modules.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots needed. This updates service action metadata and translations only.
