### PR TITLE
Handle active Storm Guard state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed Storm Guard entities becoming unavailable while Enphase reports the active storm state during a weather alert.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -3675,7 +3675,7 @@ class BatteryRuntime:
             normalized = value.strip().lower()
             if normalized in ("enabled", "disabled"):
                 return normalized
-            if normalized in ("true", "1", "yes", "y", "on"):
+            if normalized in ("true", "1", "yes", "y", "on", "active"):
                 return "enabled"
             if normalized in ("false", "0", "no", "n", "off"):
                 return "disabled"

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -5134,7 +5134,7 @@ async def test_battery_runtime_refresh_storm_guard_profile_caches_and_handles_ba
     coord.hass.config = BadConfig()
     coord.client.storm_guard_profile = AsyncMock(
         side_effect=[
-            {"data": {"stormGuardState": "enabled", "evseStormEnabled": False}},
+            {"data": {"stormGuardState": "active", "evseStormEnabled": False}},
             {"data": {"stormGuardState": "disabled", "evseStormEnabled": True}},
         ]
     )
@@ -5450,6 +5450,7 @@ def test_battery_runtime_storm_alert_and_guard_helper_edge_paths(
     assert runtime.normalize_storm_guard_state(True) == "enabled"
     assert runtime.normalize_storm_guard_state(0) == "disabled"
     assert runtime.normalize_storm_guard_state(" yes ") == "enabled"
+    assert runtime.normalize_storm_guard_state("active") == "enabled"
     assert runtime.normalize_storm_guard_state("off") == "disabled"
     assert runtime.storm_alert_status_is_inactive(None) is False
     assert runtime.storm_alert_is_active({"active": True}) is True

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -3753,7 +3753,7 @@ async def test_first_refresh_populates_storm_guard_state_before_entities(
         async def storm_guard_profile(self, **_kwargs):
             return {
                 "data": {
-                    "stormGuardState": "enabled",
+                    "stormGuardState": "active",
                     "evseStormEnabled": True,
                 }
             }


### PR DESCRIPTION
## Summary

Fixes Storm Guard entities becoming unavailable while Enphase reports `stormGuardState: "active"` during an active weather alert.

Root cause: the integration normalized `enabled`/`disabled` and common boolean-like strings, but did not recognize Enphase's active storm state. The switch then saw a null Storm Guard state and marked the entity unavailable.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime_settings.py::test_battery_runtime_refresh_storm_guard_profile_caches_and_handles_bad_locale tests/components/enphase_ev/test_battery_runtime_settings.py::test_battery_runtime_storm_alert_and_guard_helper_edge_paths tests/components/enphase_ev/test_coordinator_behavior.py::test_first_refresh_populates_storm_guard_state_before_entities"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

`pre-commit` required mounting the host Git metadata because this Codex checkout is a Git worktree and Docker otherwise sees an absolute `.git` pointer that is not mounted.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Observed diagnostic payload included `stormGuardState: "active"` while Storm Guard and storm alert endpoint health were supported and successful. The state now normalizes to the switch's enabled/on state so the entity remains available during an active storm alert.
