### PR TITLE
Remove retired Enphase devices from registries

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -38,6 +38,21 @@ from .entity_cleanup import (
 from .log_redaction import redact_identifier, redact_site_id, redact_text
 from .runtime_data import EnphaseConfigEntry, EnphaseRuntimeData, get_runtime_data
 from .runtime_helpers import coerce_optional_text as _clean_optional_text
+from .serial_discovery import (
+    active_serial_registry_identifiers,
+)
+from .serial_entity_metadata import (
+    AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
+    AC_BATTERY_RETIRED_UNIQUE_SUFFIXES,
+    BATTERY_ENTITY_UNIQUE_SUFFIXES,
+    BATTERY_RETIRED_UNIQUE_SUFFIXES,
+    CHARGER_BINARY_SENSOR_UNIQUE_SUFFIXES,
+    CHARGER_SENSOR_UNIQUE_SUFFIXES,
+    ac_battery_entity_serial_from_unique_id,
+    battery_entity_serial_from_unique_id,
+    charger_entity_serial_from_unique_id,
+    inverter_entity_serial_from_unique_id,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,6 +100,10 @@ _SITE_ENERGY_ENTITY_UNIQUE_ID_SUFFIXES: tuple[str, ...] = (
     "battery_discharge",
     "battery_power",
 )
+_CHARGER_ENTITY_UNIQUE_ID_SUFFIXES_BY_DOMAIN: dict[str, tuple[str, ...]] = {
+    "binary_sensor": CHARGER_BINARY_SENSOR_UNIQUE_SUFFIXES,
+    "sensor": CHARGER_SENSOR_UNIQUE_SUFFIXES,
+}
 _CLOUD_ENTITY_UNIQUE_ID_SUFFIXES_BY_DOMAIN: dict[str, tuple[str, ...]] = {
     "binary_sensor": ("cloud_reachable",),
     "sensor": (
@@ -404,11 +423,232 @@ def _sync_charger_devices(
         dev_reg.async_get_or_create(**kwargs)
 
 
+def _serial_entity_group_from_unique_id(
+    unique_id: object,
+    *,
+    domain: str,
+    site_id: object,
+) -> tuple[str, str] | None:
+    """Return the serial-backed entity group and serial for a unique ID."""
+
+    try:
+        site_text = str(site_id).strip()
+    except Exception:  # noqa: BLE001
+        site_text = ""
+    if domain == "binary_sensor":
+        serial = charger_entity_serial_from_unique_id(
+            unique_id,
+            _CHARGER_ENTITY_UNIQUE_ID_SUFFIXES_BY_DOMAIN["binary_sensor"],
+        )
+        return ("charger", serial) if serial is not None else None
+    if domain != "sensor":
+        return None
+
+    charger_serial = charger_entity_serial_from_unique_id(
+        unique_id,
+        _CHARGER_ENTITY_UNIQUE_ID_SUFFIXES_BY_DOMAIN["sensor"],
+    )
+    if charger_serial is not None:
+        return ("charger", charger_serial)
+    if site_text:
+        battery_serial = battery_entity_serial_from_unique_id(
+            unique_id,
+            site_id=site_text,
+            suffixes=(
+                *BATTERY_ENTITY_UNIQUE_SUFFIXES,
+                *BATTERY_RETIRED_UNIQUE_SUFFIXES,
+            ),
+        )
+        if battery_serial is not None:
+            return ("battery", battery_serial)
+
+        ac_battery_serial = ac_battery_entity_serial_from_unique_id(
+            unique_id,
+            site_id=site_text,
+            suffixes=(
+                *AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
+                *AC_BATTERY_RETIRED_UNIQUE_SUFFIXES,
+            ),
+        )
+        if ac_battery_serial is not None:
+            return ("ac_battery", ac_battery_serial)
+
+    inverter_serial = inverter_entity_serial_from_unique_id(unique_id)
+    if inverter_serial is not None:
+        return ("inverter", inverter_serial)
+    return None
+
+
+def _prune_inactive_serial_entities(
+    hass: HomeAssistant,
+    entry: EnphaseConfigEntry,
+    coord,
+    site_id: object,
+) -> int:
+    """Remove owned serial-backed entities no longer present in active discovery."""
+
+    if er is None or not bool(getattr(coord, "_devices_inventory_ready", False)):
+        return 0
+    try:
+        ent_reg = er.async_get(hass)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug(
+            "Skipping inactive serial entity cleanup for site %s: %s",
+            redact_site_id(site_id),
+            redact_text(err, site_ids=(site_id,)),
+        )
+        return 0
+    active_serials_by_group = active_serial_registry_identifiers(coord)
+    entry_id = getattr(entry, "entry_id", None)
+    removed = 0
+    for reg_entry in iter_entity_registry_entries(ent_reg):
+        entry_domain = getattr(reg_entry, "domain", None)
+        if entry_domain is None:
+            entity_id = getattr(reg_entry, "entity_id", "")
+            entry_domain = (
+                entity_id.partition(".")[0] if isinstance(entity_id, str) else ""
+            )
+        if not is_owned_entity(reg_entry, entry_id, entry_domain):
+            continue
+        group_and_serial = _serial_entity_group_from_unique_id(
+            getattr(reg_entry, "unique_id", None),
+            domain=entry_domain,
+            site_id=site_id,
+        )
+        if group_and_serial is None:
+            continue
+        group, serial = group_and_serial
+        active_serials = active_serials_by_group.get(group)
+        if active_serials is None:
+            continue
+        if serial in active_serials:
+            continue
+        entity_id = getattr(reg_entry, "entity_id", None)
+        if not entity_id:
+            continue
+        try:
+            ent_reg.async_remove(entity_id)
+            removed += 1
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Failed removing inactive serial entity %s for site %s: %s",
+                redact_identifier(entity_id),
+                redact_site_id(site_id),
+                redact_text(err, site_ids=(site_id,), identifiers=(serial, entity_id)),
+            )
+    if removed:
+        _LOGGER.debug(
+            "Removed %s inactive serial entities for site %s",
+            removed,
+            redact_site_id(site_id),
+        )
+    return removed
+
+
+def _remove_empty_inactive_serial_devices(
+    hass: HomeAssistant,
+    entry: EnphaseConfigEntry,
+    coord,
+    dev_reg,
+    site_id: object,
+) -> int:
+    """Remove empty serial devices no longer present in active inventory."""
+
+    if er is None or not bool(getattr(coord, "_devices_inventory_ready", False)):
+        return 0
+    try:
+        ent_reg = er.async_get(hass)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug(
+            "Skipping inactive serial device cleanup for site %s: %s",
+            redact_site_id(site_id),
+            redact_text(err, site_ids=(site_id,)),
+        )
+        return 0
+    remove_device = getattr(dev_reg, "async_remove_device", None)
+    if not callable(remove_device):
+        return 0
+
+    active_serials_by_group = active_serial_registry_identifiers(coord)
+    if any(serials is None for serials in active_serials_by_group.values()):
+        return 0
+    active_serials: set[str] = set()
+    for serials in active_serials_by_group.values():
+        active_serials.update(serials or set())
+    entry_id = getattr(entry, "entry_id", None)
+    removed = 0
+    for device in iter_device_registry_entries(dev_reg):
+        config_entries = getattr(device, "config_entries", None)
+        if config_entries is not None and entry_id not in config_entries:
+            continue
+        identifiers = getattr(device, "identifiers", None)
+        if not identifiers:
+            continue
+        inactive_serials: list[str] = []
+        has_active_serial = False
+        for ident_domain, ident_value in identifiers:
+            if ident_domain != DOMAIN:
+                continue
+            try:
+                ident_text = str(ident_value).strip()
+            except Exception:  # noqa: BLE001
+                continue
+            if (
+                not ident_text
+                or ident_text.startswith("type:")
+                or ident_text.startswith("site:")
+            ):
+                continue
+            if ident_text in active_serials:
+                has_active_serial = True
+                break
+            inactive_serials.append(ident_text)
+        if has_active_serial or not inactive_serials:
+            continue
+        device_id = getattr(device, "id", None)
+        if not device_id:
+            continue
+        remaining_entries = entries_for_device(ent_reg, device_id)
+        if remaining_entries:
+            _LOGGER.debug(
+                "Keeping inactive serial device %s for site %s; %s entities remain",
+                redact_identifier(inactive_serials[0]),
+                redact_site_id(site_id),
+                len(remaining_entries),
+            )
+            continue
+        try:
+            remove_device(device_id)
+            removed += 1
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Failed removing inactive serial device %s for site %s: %s",
+                redact_identifier(inactive_serials[0]),
+                redact_site_id(site_id),
+                redact_text(err, site_ids=(site_id,), identifiers=inactive_serials),
+            )
+    if removed:
+        _LOGGER.debug(
+            "Removed %s inactive serial devices for site %s",
+            removed,
+            redact_site_id(site_id),
+        )
+    return removed
+
+
 def _sync_registry_devices(
-    entry: EnphaseConfigEntry, coord, dev_reg, site_id: object
+    entry: EnphaseConfigEntry,
+    coord,
+    dev_reg,
+    site_id: object,
+    *,
+    hass: HomeAssistant | None = None,
 ) -> None:
     type_devices = _sync_type_devices(entry, coord, dev_reg, site_id)
     _sync_charger_devices(entry, coord, dev_reg, site_id, type_devices)
+    if hass is not None:
+        _prune_inactive_serial_entities(hass, entry, coord, site_id)
+        _remove_empty_inactive_serial_devices(hass, entry, coord, dev_reg, site_id)
 
 
 def _registry_type_metadata_signature(coord) -> tuple[tuple[object, ...], ...]:
@@ -1270,7 +1510,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
 
     site_id = entry.data.get("site_id")
     dev_reg = dr.async_get(hass)
-    _sync_registry_devices(entry, coord, dev_reg, site_id)
+    _sync_registry_devices(entry, coord, dev_reg, site_id, hass=hass)
     _remove_legacy_site_device(hass, entry, coord, dev_reg, site_id)
     _remove_evse_type_device_and_entities(hass, entry, dev_reg, site_id)
     _migrate_orphaned_update_entities_to_type_devices(hass, entry, site_id)
@@ -1283,10 +1523,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
         try:
             current_signature = _registry_metadata_signature(coord)
             if current_signature != last_registry_signature:
-                _sync_registry_devices(entry, coord, dev_reg, site_id)
+                _sync_registry_devices(entry, coord, dev_reg, site_id, hass=hass)
                 _remove_evse_type_device_and_entities(hass, entry, dev_reg, site_id)
                 _migrate_orphaned_update_entities_to_type_devices(hass, entry, site_id)
                 last_registry_signature = current_signature
+            else:
+                _prune_inactive_serial_entities(hass, entry, coord, site_id)
+                _remove_empty_inactive_serial_devices(
+                    hass, entry, coord, dev_reg, site_id
+                )
             _remove_legacy_site_device(hass, entry, coord, dev_reg, site_id)
             _complete_startup_migrations_if_ready(hass, entry, coord, dev_reg, site_id)
         except Exception as err:  # noqa: BLE001
@@ -1327,6 +1572,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
             hass.async_create_task(coro, name=name)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _prune_inactive_serial_entities(hass, entry, coord, site_id)
+    _remove_empty_inactive_serial_devices(hass, entry, coord, dev_reg, site_id)
 
     # Start background work only after entities have been forwarded so restored
     # topology can create entities first and warmup can fill in live state later.

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -15,21 +15,43 @@ from .const import DOMAIN
 from .coordinator import EnphaseCoordinator
 from .device_info_helpers import _cloud_device_info
 from .entity import EnphaseBaseEntity
+from .entity_cleanup import prune_managed_entities
 from .runtime_helpers import (
     inventory_type_available as _type_available,
     inventory_type_device_info as _type_device_info,
 )
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
+from .serial_discovery import active_charger_serials_for_cleanup
+from .serial_entity_metadata import (
+    CHARGER_BINARY_SENSOR_UNIQUE_SUFFIXES,
+    HISTORICAL_CHARGER_BINARY_SENSOR_UNIQUE_SUFFIXES,
+    charger_entity_unique_ids,
+)
 from .sensor import (
     _heatpump_runtime_device_uid,
     _heatpump_runtime_snapshot,
 )
 
 PARALLEL_UPDATES = 0
-HISTORICAL_CHARGER_BINARY_SENSOR_UNIQUE_SUFFIXES: tuple[str, ...] = (
-    "_commissioned",
-    "_charger_problem",
-)
+
+
+def _charger_binary_sensor_unique_ids(serials: set[str]) -> set[str]:
+    return {
+        unique_id
+        for serial in serials
+        for unique_id in charger_entity_unique_ids(
+            serial, CHARGER_BINARY_SENSOR_UNIQUE_SUFFIXES
+        )
+    }
+
+
+def _is_managed_charger_binary_sensor(unique_id: str) -> bool:
+    site_prefix = f"{DOMAIN}_site_"
+    if unique_id.startswith(site_prefix):
+        return False
+    return unique_id.startswith(f"{DOMAIN}_") and unique_id.endswith(
+        CHARGER_BINARY_SENSOR_UNIQUE_SUFFIXES
+    )
 
 
 async def async_setup_entry(
@@ -104,6 +126,18 @@ async def async_setup_entry(
             heatpump_sg_ready_entity_added = True
         elif inventory_ready and not heatpump_runtime_available:
             _async_remove_site_binary_entity("heat_pump_sg_ready_active")
+        active_charger_serials = active_charger_serials_for_cleanup(coord)
+        if active_charger_serials is not None:
+            prune_managed_entities(
+                ent_reg,
+                entry.entry_id,
+                domain="binary_sensor",
+                active_unique_ids=_charger_binary_sensor_unique_ids(
+                    active_charger_serials
+                ),
+                is_managed=_is_managed_charger_binary_sensor,
+            )
+            known_serials.intersection_update(active_charger_serials)
         serials = [sn for sn in coord.iter_serials() if sn and sn not in known_serials]
         if not serials:
             return

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -414,6 +414,24 @@ def _coerce_int_list(value: object) -> list[int] | None:
     return parsed or None
 
 
+def _mapping_or_empty(value: object) -> dict:
+    """Return a mapping payload, or an empty mapping for malformed nested data."""
+
+    return value if isinstance(value, dict) else {}
+
+
+def _first_mapping_or_empty(value: object) -> dict:
+    """Return the first mapping from a nested list/dict payload."""
+
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, list) and value:
+        first = value[0]
+        if isinstance(first, dict):
+            return first
+    return {}
+
+
 def _power_as_float(raw: object) -> float | None:
     try:
         return float(raw)
@@ -2664,6 +2682,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         context: RefreshPipelineContext,
     ) -> dict:
         phase_timings = context.phase_timings
+        self._status_charger_data_authoritative = False
+        self._status_charger_data_serials = None
         self._backoff_until = None
         self._clear_backoff_timer()
         self._clear_auth_repair_issues_on_success()
@@ -2828,6 +2848,22 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         await asyncio.gather(task, return_exceptions=True)
         context.first_refresh_followups_task = None
 
+    def _evse_status_refresh_enabled(self) -> bool:
+        """Return True when this entry should continue polling EVSE status."""
+
+        if self.site_only:
+            return False
+        if self.serials:
+            return True
+        selected = getattr(self, "_selected_type_keys", None)
+        if isinstance(selected, (set, list, tuple)) and selected:
+            return any(normalize_type_key(key) == "iqevse" for key in selected)
+        if getattr(self, "_configured_serials", None):
+            return True
+        if getattr(self, "_restored_evse_serial_order", None):
+            return True
+        return bool(getattr(self, "_status_charger_data_authoritative", False))
+
     def _first_refresh_storm_guard_followups_needed(self) -> bool:
         if getattr(self, "_battery_has_encharge", None) is False:
             return False
@@ -2946,7 +2982,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.diagnostics.create_auth_block_issue()
             raise self._auth_block_update_failed()
 
-        if self.site_only or not self.serials:
+        if not self._evse_status_refresh_enabled():
             return await self._async_run_site_only_refresh_pipeline(context)
 
         # Handle backoff window
@@ -2960,12 +2996,27 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if first_refresh:
             self._start_first_refresh_followups(context)
         status_refresh_succeeded = False
+        status_charger_data_authoritative = False
+        status_charger_data_serials: list[str] | None = None
         try:
             status_start = time.monotonic()
             data = await self.client.status()
             phase_timings["status_s"] = round(time.monotonic() - status_start, 3)
             if isinstance(data, dict):
                 self._status_payload_cache = dict(data)
+                raw_charger_data = data.get("evChargerData")
+                if isinstance(raw_charger_data, list):
+                    status_charger_data_serials = []
+                    status_charger_data_authoritative = True
+                    for charger in raw_charger_data:
+                        if not isinstance(charger, dict):
+                            status_charger_data_authoritative = False
+                            break
+                        serial = str(charger.get("sn") or "").strip()
+                        if not serial:
+                            status_charger_data_authoritative = False
+                            break
+                        status_charger_data_serials.append(serial)
             self._mark_payload_endpoint_success(
                 "status",
                 success_mono=time.monotonic(),
@@ -3014,6 +3065,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 )
                 phase_timings["status_s"] = round(time.monotonic() - status_start, 3)
                 data = {"evChargerData": [], "ts": None}
+                status_charger_data_authoritative = False
             self._unauth_errors = 0
             self._payload_errors = 0
             self._network_errors = 0
@@ -3202,6 +3254,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     retry_after=backoff,
                 )
         finally:
+            self._status_charger_data_authoritative = (
+                status_charger_data_authoritative
+                and not bool(getattr(self, "payload_using_stale", False))
+            )
+            self._status_charger_data_serials = (
+                list(dict.fromkeys(status_charger_data_serials or []))
+                if self._status_charger_data_authoritative
+                else None
+            )
             if not status_refresh_succeeded:
                 await self._async_cancel_first_refresh_followups(context)
             self.latency_ms = int((time.monotonic() - t0) * 1000)
@@ -3212,12 +3273,17 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         prev_data = self.data if isinstance(self.data, dict) else {}
         self._has_successful_refresh = True
         out: dict[str, dict] = {}
-        arr = data.get("evChargerData") or []
+        raw_charger_data = data.get("evChargerData")
+        arr = (
+            [charger for charger in raw_charger_data if isinstance(charger, dict)]
+            if isinstance(raw_charger_data, list)
+            else []
+        )
         data_ts = data.get("ts")
         records: list[tuple[str, dict]] = []
         charge_mode_candidates: list[str] = []
         for obj in arr:
-            sn = str(obj.get("sn") or "")
+            sn = str(obj.get("sn") or "").strip()
             if not sn:
                 continue
             self._ensure_serial_tracked(sn)
@@ -3267,7 +3333,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return None, "unknown"
 
         for sn, obj in records:
-            conn0 = (obj.get("connectors") or [{}])[0]
+            conn0 = _first_mapping_or_empty(obj.get("connectors"))
             previous_entry = None
             if isinstance(self.data, dict):
                 previous_entry = self.data.get(sn)
@@ -3311,9 +3377,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     self.set_last_set_amps(sn, int(charging_level))
                 except Exception:
                     pass
-            sch = obj.get("sch_d") or {}
-            sch_info0 = (sch.get("info") or [{}])[0]
-            sess = obj.get("session_d") or {}
+            sch = _mapping_or_empty(obj.get("sch_d"))
+            sch_info0 = _first_mapping_or_empty(sch.get("info"))
+            sess = _mapping_or_empty(obj.get("session_d"))
             smart_ev = obj.get("smartEV")
             if not isinstance(smart_ev, dict):
                 smart_ev = {}
@@ -3428,7 +3494,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 obj.get("chargeMode"),
                 obj.get("chargingMode"),
                 obj.get("charge_mode"),
-                (obj.get("sch_d") or {}).get("mode"),
+                sch.get("mode"),
             ):
                 charge_mode = self._normalize_effective_charge_mode(
                     charge_mode_candidate
@@ -4131,7 +4197,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             background_by_day.setdefault((day_key, max_cache_age), []).append(sn)
         # Prune after day-keys are known so historical session-day entries in use
         # by current chargers are retained for normal TTL behavior.
-        self._prune_runtime_caches(active_serials=out.keys(), keep_day_keys=day_locals)
+        if bool(getattr(self, "_status_charger_data_authoritative", False)):
+            self._prune_runtime_caches(
+                active_serials=out.keys(), keep_day_keys=day_locals
+            )
 
         async def _async_fetch_immediate_session_updates(
             day_key: str,
@@ -6671,6 +6740,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         """Return charger serials in a stable order for entity setup."""
         if getattr(self, "site_only", False):
             return []
+        active_inventory_serials = self._active_inventory_evse_serials()
+        if active_inventory_serials is not None:
+            return active_inventory_serials
         ordered: list[str] = []
         serial_order = getattr(self, "_serial_order", None)
         known_serials = getattr(self, "serials", None)
@@ -6684,6 +6756,57 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             ordered.extend(str(sn) for sn in source.keys())
         # Deduplicate while preserving order
         return [sn for sn in dict.fromkeys(ordered) if sn]
+
+    def _active_inventory_evse_serials(self) -> list[str] | None:
+        """Return active EVSE serials once inventory has authoritatively loaded."""
+
+        if not bool(getattr(self, "_devices_inventory_ready", False)):
+            return None
+
+        status_serials: list[str] | None = None
+        if bool(getattr(self, "_status_charger_data_authoritative", False)):
+            cached_serials = getattr(self, "_status_charger_data_serials", None)
+            if isinstance(cached_serials, list):
+                status_serials = [str(sn) for sn in cached_serials if sn]
+            else:
+                source = self.data if isinstance(self.data, dict) else {}
+                status_serials = [str(sn) for sn in source if sn]
+            return status_serials
+        try:
+            bucket = self.inventory_view.type_bucket("iqevse")
+        except Exception:  # noqa: BLE001
+            return status_serials
+        if not isinstance(bucket, dict):
+            return status_serials
+        members = bucket.get("devices")
+        if not isinstance(members, list):
+            return status_serials
+        serials: list[str] = []
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            for key in ("serial_number", "serial", "serialNumber", "device_sn"):
+                raw_serial = member.get(key)
+                if raw_serial is None:
+                    continue
+                try:
+                    serial = str(raw_serial).strip()
+                except Exception:  # noqa: BLE001
+                    continue
+                if serial:
+                    serials.append(serial)
+                    break
+        if serials:
+            return [serial for serial in dict.fromkeys(serials) if serial]
+        if "count" not in bucket:
+            return status_serials
+        try:
+            count = int(bucket.get("count"))
+        except (TypeError, ValueError):
+            return status_serials
+        if count == 0:
+            return status_serials or []
+        return status_serials
 
     def iter_battery_serials(self) -> list[str]:
         """Return active battery identities in a stable order."""

--- a/custom_components/enphase_ev/discovery_snapshot.py
+++ b/custom_components/enphase_ev/discovery_snapshot.py
@@ -234,6 +234,7 @@ class DiscoverySnapshotManager:
 
         serial_order = snapshot.get("serial_order")
         if isinstance(serial_order, list):
+            restored_serials: list[str] = []
             for serial in serial_order:
                 if serial is None:
                     continue
@@ -242,7 +243,12 @@ class DiscoverySnapshotManager:
                 except Exception:  # noqa: BLE001
                     continue
                 if text:
-                    self.coordinator._ensure_serial_tracked(text)
+                    restored_serials.append(text)
+            restored_serials = list(dict.fromkeys(restored_serials))
+            self.coordinator._restored_evse_serial_order = restored_serials
+            if restored_serials:
+                self.coordinator._serial_order = list(restored_serials)
+                self.coordinator.serials = set(restored_serials)
 
         grouped = snapshot.get("type_device_buckets")
         ordered = snapshot.get("type_device_order")

--- a/custom_components/enphase_ev/entity_cleanup.py
+++ b/custom_components/enphase_ev/entity_cleanup.py
@@ -45,17 +45,25 @@ def iter_device_registry_entries(dev_reg) -> list[object]:
 
 def entries_for_device(ent_reg, device_id: str) -> list[object]:
     """Return entity registry entries attached to the given device."""
+    entries: list[object] = []
+    seen_entity_ids: set[object] = set()
     entries_for_device_func = getattr(er, "async_entries_for_device", None)
     if callable(entries_for_device_func):
         try:
-            return list(entries_for_device_func(ent_reg, device_id))
+            for entry in entries_for_device_func(ent_reg, device_id):
+                entries.append(entry)
+                seen_entity_ids.add(getattr(entry, "entity_id", id(entry)))
         except Exception:  # noqa: BLE001
             pass
-    return [
-        entry
-        for entry in iter_entity_registry_entries(ent_reg)
-        if getattr(entry, "device_id", None) == device_id
-    ]
+    for entry in iter_entity_registry_entries(ent_reg):
+        if getattr(entry, "device_id", None) != device_id:
+            continue
+        entity_id = getattr(entry, "entity_id", id(entry))
+        if entity_id in seen_entity_ids:
+            continue
+        entries.append(entry)
+        seen_entity_ids.add(entity_id)
+    return entries
 
 
 def is_owned_entity(

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -372,9 +372,10 @@ class EvseRuntime:
     def prune_serial_runtime_state(self, active_serials: Iterable[str]) -> set[str]:
         coord = self.coordinator
         keep_serials = self.normalize_serials(active_serials)
-        keep_serials.update(
-            self.normalize_serials(getattr(coord, "_configured_serials", ()))
-        )
+        if not bool(getattr(coord, "_devices_inventory_ready", False)):
+            keep_serials.update(
+                self.normalize_serials(getattr(coord, "_configured_serials", ()))
+            )
         if isinstance(getattr(coord, "serials", None), set):
             coord.serials.intersection_update(keep_serials)
         else:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -68,6 +68,12 @@ from .runtime_helpers import (
     inventory_type_device_info as _type_device_info,
     normalize_evse_session_energy,
 )
+from .serial_discovery import (
+    active_ac_battery_serials_for_cleanup,
+    active_battery_serials_for_cleanup,
+    active_charger_serials_for_cleanup,
+    active_inverter_serials_for_cleanup,
+)
 from .sensor_registry import (
     AC_BATTERY_ENTITY_UNIQUE_SUFFIXES as AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
     AC_BATTERY_RETIRED_UNIQUE_SUFFIXES as AC_BATTERY_RETIRED_UNIQUE_SUFFIXES,
@@ -120,6 +126,30 @@ _battery_last_reported_snapshot = _battery_helpers.battery_last_reported_snapsho
 _battery_optional_bool = _battery_helpers.battery_optional_bool
 _battery_parse_timestamp = _battery_helpers.battery_parse_timestamp
 _battery_snapshot_last_reported = _battery_helpers.battery_snapshot_last_reported
+
+
+def _ac_battery_status_fallback_serials_for_setup(
+    coord: EnphaseCoordinator,
+) -> set[str] | None:
+    """Return AC Battery serials seeded by battery status for non-destructive setup."""
+
+    if not ac_battery_entities_available(coord):
+        return None
+    details = getattr(coord, "ac_battery_status_summary", None)
+    if (
+        not isinstance(details, dict)
+        or details.get("status_source") != "battery_status"
+    ):
+        return None
+    iter_ac_batteries = getattr(coord, "iter_ac_battery_serials", None)
+    if not callable(iter_ac_batteries):
+        return None
+    try:
+        return {
+            serial for sn in iter_ac_batteries() if sn and (serial := str(sn).strip())
+        }
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _type_label(coord: EnphaseCoordinator, type_key: str) -> str | None:
@@ -795,6 +825,14 @@ async def async_setup_entry(
 
     @callback
     def _async_sync_chargers() -> None:
+        active_charger_serials = active_charger_serials_for_cleanup(coord)
+        if active_charger_serials is not None:
+            registry_setup.prune_removed_charger_sensor_entities(active_charger_serials)
+            registry_setup.remove_missing_charger_entities(active_charger_serials)
+            known_serials.intersection_update(active_charger_serials)
+            registry_setup.known_charger_serials.intersection_update(
+                active_charger_serials
+            )
         serials = [sn for sn in coord.iter_serials() if sn and sn not in known_serials]
         per_serial_entities = []
         site_has_battery = _site_has_battery(coord)
@@ -830,20 +868,15 @@ async def async_setup_entry(
             async_add_entities(per_serial_entities, update_before_add=False)
         if serials:
             known_serials.update(serials)
+            registry_setup.known_charger_serials.update(serials)
 
     @callback
     def _async_sync_batteries() -> None:
-        site_has_battery = _site_has_battery(coord)
-        if not site_has_battery or not _type_available(coord, "encharge"):
-            current_serials: list[str] = []
-        else:
-            iter_batteries = getattr(coord, "iter_battery_serials", None)
-            current_serials = (
-                [sn for sn in iter_batteries() if sn]
-                if callable(iter_batteries)
-                else []
-            )
-        current_set = set(current_serials)
+        active_battery_serials = active_battery_serials_for_cleanup(coord)
+        if active_battery_serials is None:
+            return
+        current_serials = sorted(active_battery_serials)
+        current_set = active_battery_serials
 
         registry_setup.prune_battery_registry_once(current_set)
         registry_setup.remove_missing_battery_entities(current_set)
@@ -869,19 +902,20 @@ async def async_setup_entry(
 
     @callback
     def _async_sync_ac_batteries() -> None:
-        if not ac_battery_entities_available(coord):
-            current_serials: list[str] = []
-        else:
-            iter_ac_batteries = getattr(coord, "iter_ac_battery_serials", None)
-            current_serials = (
-                [sn for sn in iter_ac_batteries() if sn]
-                if callable(iter_ac_batteries)
-                else []
+        active_ac_battery_serials = active_ac_battery_serials_for_cleanup(coord)
+        cleanup_authoritative = active_ac_battery_serials is not None
+        if active_ac_battery_serials is None:
+            active_ac_battery_serials = _ac_battery_status_fallback_serials_for_setup(
+                coord
             )
-        current_set = set(current_serials)
+            if active_ac_battery_serials is None:
+                return
+        current_serials = sorted(active_ac_battery_serials)
+        current_set = active_ac_battery_serials
 
-        registry_setup.prune_ac_battery_registry_once(current_set)
-        registry_setup.remove_missing_ac_battery_entities(current_set)
+        if cleanup_authoritative:
+            registry_setup.prune_ac_battery_registry_once(current_set)
+            registry_setup.remove_missing_ac_battery_entities(current_set)
 
         serials = [
             sn
@@ -906,10 +940,11 @@ async def async_setup_entry(
 
     @callback
     def _async_sync_inverters() -> None:
-        current_serials = [
-            sn for sn in getattr(coord, "iter_inverter_serials", lambda: [])() if sn
-        ]
-        current_set = set(current_serials)
+        active_inverter_serials = active_inverter_serials_for_cleanup(coord)
+        if active_inverter_serials is None:
+            return
+        current_serials = sorted(active_inverter_serials)
+        current_set = active_inverter_serials
 
         registry_setup.prune_inverter_registry_once(current_set)
         registry_setup.remove_missing_inverter_entities(current_set)
@@ -937,16 +972,16 @@ async def async_setup_entry(
         current_type_keys = {
             key for key in coord.inventory_view.iter_type_keys() if key
         }
-        current_battery_serials = {
-            sn for sn in getattr(coord, "iter_battery_serials", lambda: [])() if sn
-        }
-        current_ac_battery_serials = {
-            sn for sn in getattr(coord, "iter_ac_battery_serials", lambda: [])() if sn
-        }
-        current_charger_serials = {sn for sn in coord.iter_serials() if sn}
-        current_inverter_serials = {
-            sn for sn in getattr(coord, "iter_inverter_serials", lambda: [])() if sn
-        }
+        current_battery_serials = active_battery_serials_for_cleanup(coord)
+        current_ac_battery_serials = active_ac_battery_serials_for_cleanup(coord)
+        if current_ac_battery_serials is None:
+            current_ac_battery_serials = _ac_battery_status_fallback_serials_for_setup(
+                coord
+            )
+        current_charger_serials = active_charger_serials_for_cleanup(coord)
+        if current_charger_serials is None:
+            current_charger_serials = {sn for sn in coord.iter_serials() if sn}
+        current_inverter_serials = active_inverter_serials_for_cleanup(coord)
 
         _async_sync_site_entities()
         _async_sync_type_inventory()

--- a/custom_components/enphase_ev/sensor_registry.py
+++ b/custom_components/enphase_ev/sensor_registry.py
@@ -8,44 +8,23 @@ from typing import Any
 from .const import DOMAIN
 from .device_types import is_dry_contact_type_key
 from .runtime_helpers import coerce_optional_text as _clean_text
-
-BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
-    "_charge_level",
-    "_status",
-    "_health",
-    "_cycle_count",
-)
-BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = (
-    "_last_reported",
-    "_last_reported_at",
-)
-AC_BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
-    "_charge_level",
-    "_status",
-    "_power",
-    "_operating_mode",
-    "_cycle_count",
-    "_last_reported",
-)
-AC_BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = ("_last_reported_at",)
-HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES: tuple[str, ...] = (
-    "_connector_reason",
-    "_session_miles",
-    "_plg_in_at",
-    "_plg_out_at",
-    "_schedule_type",
-    "_schedule_start",
-    "_schedule_end",
-    "_session_kwh",
-    "_charging_level",
-    "_session_duration",
-    "_phase_mode",
-    "_max_current",
-    "_min_amp",
-    "_max_amp",
-    "_connection",
-    "_reporting_interval",
-    "_ip_address",
+from .serial_entity_metadata import (
+    AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
+    AC_BATTERY_RETIRED_UNIQUE_SUFFIXES,
+    BATTERY_ENTITY_UNIQUE_SUFFIXES,
+    BATTERY_RETIRED_UNIQUE_SUFFIXES,
+    CHARGER_SENSOR_UNIQUE_SUFFIXES,
+    HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES,
+    ac_battery_entity_serial_from_unique_id,
+    battery_entity_serial_from_unique_id,
+    charger_entity_serial_from_unique_id,
+    charger_entity_unique_id,
+    charger_entity_unique_ids,
+    inverter_entity_unique_id,
+    site_ac_battery_entity_unique_id,
+    site_ac_battery_entity_unique_ids,
+    site_battery_entity_unique_id,
+    site_battery_entity_unique_ids,
 )
 
 
@@ -61,6 +40,7 @@ class EnphaseSensorRegistrySetup:
         self.known_site_entity_keys: set[str] = set()
         self.known_type_keys: set[str] = set()
         self.known_gateway_iq_router_keys: set[str] = set()
+        self.known_charger_serials: set[str] = set()
         self.known_battery_serials: set[str] = set()
         self.known_ac_battery_serials: set[str] = set()
         self.known_inverter_serials: set[str] = set()
@@ -87,50 +67,46 @@ class EnphaseSensorRegistrySetup:
     def battery_sensor_unique_id(self, serial: str, suffix: str) -> str:
         """Return the unique ID for a per-storage-battery sensor."""
 
-        return f"{DOMAIN}_site_{self._site_id}_battery_{serial}{suffix}"
+        return site_battery_entity_unique_id(self._site_id, serial, suffix)
 
     def battery_sensor_unique_ids(self, serial: str) -> tuple[str, ...]:
         """Return active unique IDs for a per-storage-battery sensor set."""
 
-        return tuple(
-            self.battery_sensor_unique_id(serial, suffix)
-            for suffix in BATTERY_ENTITY_UNIQUE_SUFFIXES
+        return site_battery_entity_unique_ids(
+            self._site_id, serial, BATTERY_ENTITY_UNIQUE_SUFFIXES
         )
 
     def battery_retired_sensor_unique_ids(self, serial: str) -> tuple[str, ...]:
         """Return retired unique IDs for a per-storage-battery sensor set."""
 
-        return tuple(
-            self.battery_sensor_unique_id(serial, suffix)
-            for suffix in BATTERY_RETIRED_UNIQUE_SUFFIXES
+        return site_battery_entity_unique_ids(
+            self._site_id, serial, BATTERY_RETIRED_UNIQUE_SUFFIXES
         )
 
     def ac_battery_sensor_unique_id(self, serial: str, suffix: str) -> str:
         """Return the unique ID for a per-AC-battery sensor."""
 
-        return f"{DOMAIN}_site_{self._site_id}_ac_battery_{serial}{suffix}"
+        return site_ac_battery_entity_unique_id(self._site_id, serial, suffix)
 
     def ac_battery_sensor_unique_ids(self, serial: str) -> tuple[str, ...]:
         """Return active unique IDs for a per-AC-battery sensor set."""
 
-        return tuple(
-            self.ac_battery_sensor_unique_id(serial, suffix)
-            for suffix in AC_BATTERY_ENTITY_UNIQUE_SUFFIXES
+        return site_ac_battery_entity_unique_ids(
+            self._site_id, serial, AC_BATTERY_ENTITY_UNIQUE_SUFFIXES
         )
 
     def ac_battery_retired_sensor_unique_ids(self, serial: str) -> tuple[str, ...]:
         """Return retired unique IDs for a per-AC-battery sensor set."""
 
-        return tuple(
-            self.ac_battery_sensor_unique_id(serial, suffix)
-            for suffix in AC_BATTERY_RETIRED_UNIQUE_SUFFIXES
+        return site_ac_battery_entity_unique_ids(
+            self._site_id, serial, AC_BATTERY_RETIRED_UNIQUE_SUFFIXES
         )
 
     @staticmethod
     def inverter_lifetime_sensor_unique_id(serial: str) -> str:
         """Return the unique ID for a microinverter lifetime energy sensor."""
 
-        return f"{DOMAIN}_inverter_{serial}_lifetime_energy"
+        return inverter_entity_unique_id(serial)
 
     def remove_site_sensor_entity(self, key: str) -> None:
         """Remove a site-level sensor entity by setup key."""
@@ -283,6 +259,45 @@ class EnphaseSensorRegistrySetup:
                 continue
             self._ent_reg.async_remove(reg_entry.entity_id)
 
+    def charger_sensor_unique_id(self, serial: str, suffix: str) -> str:
+        """Return the unique ID for a per-charger sensor."""
+
+        return charger_entity_unique_id(serial, suffix)
+
+    def charger_sensor_unique_ids(self, serial: str) -> tuple[str, ...]:
+        """Return active unique IDs for a per-charger sensor set."""
+
+        return charger_entity_unique_ids(serial, CHARGER_SENSOR_UNIQUE_SUFFIXES)
+
+    def charger_serial_from_unique_id(self, unique_id: object) -> str | None:
+        """Return a charger serial parsed from a known per-charger unique ID."""
+
+        return charger_entity_serial_from_unique_id(
+            unique_id, CHARGER_SENSOR_UNIQUE_SUFFIXES
+        )
+
+    def prune_removed_charger_sensor_entities(self, current_set: set[str]) -> None:
+        """Remove per-charger sensors no longer present in active discovery."""
+
+        for reg_entry in list(self._entity_registry_values()):
+            if not self._registry_entry_matches_sensor(reg_entry):
+                continue
+            unique_id = getattr(reg_entry, "unique_id", None)
+            serial = self.charger_serial_from_unique_id(unique_id)
+            if serial is None or serial in current_set:
+                continue
+            self._ent_reg.async_remove(reg_entry.entity_id)
+            self.known_charger_serials.discard(serial)
+
+    def remove_missing_charger_entities(self, current_set: set[str]) -> None:
+        """Remove known charger entities no longer in the current set."""
+
+        self._remove_missing_serial_entities(
+            self.known_charger_serials,
+            current_set,
+            self.charger_sensor_unique_ids,
+        )
+
     def prune_removed_site_entities(self) -> None:
         """Remove legacy site-level sensor entities that no longer exist."""
 
@@ -329,18 +344,14 @@ class EnphaseSensorRegistrySetup:
     def remove_missing_battery_entities(self, current_set: set[str]) -> None:
         """Remove known storage battery entities no longer in the current set."""
 
-        removed_serials = self.known_battery_serials - current_set
-        for serial in removed_serials:
-            for unique_id in (
+        self._remove_missing_serial_entities(
+            self.known_battery_serials,
+            current_set,
+            lambda serial: (
                 *self.battery_sensor_unique_ids(serial),
                 *self.battery_retired_sensor_unique_ids(serial),
-            ):
-                entity_id = self._async_get_sensor_entity_id(unique_id)
-                if entity_id is not None:
-                    self._ent_reg.async_remove(entity_id)
-            self.known_battery_serials.discard(serial)
-
-        self.known_battery_serials.intersection_update(current_set)
+            ),
+        )
 
     def prune_ac_battery_registry_once(self, current_set: set[str]) -> None:
         """Prune stale AC battery registry entries after startup."""
@@ -370,18 +381,14 @@ class EnphaseSensorRegistrySetup:
     def remove_missing_ac_battery_entities(self, current_set: set[str]) -> None:
         """Remove known AC battery entities no longer in the current set."""
 
-        removed_serials = self.known_ac_battery_serials - current_set
-        for serial in removed_serials:
-            for unique_id in (
+        self._remove_missing_serial_entities(
+            self.known_ac_battery_serials,
+            current_set,
+            lambda serial: (
                 *self.ac_battery_sensor_unique_ids(serial),
                 *self.ac_battery_retired_sensor_unique_ids(serial),
-            ):
-                entity_id = self._async_get_sensor_entity_id(unique_id)
-                if entity_id is not None:
-                    self._ent_reg.async_remove(entity_id)
-            self.known_ac_battery_serials.discard(serial)
-
-        self.known_ac_battery_serials.intersection_update(current_set)
+            ),
+        )
 
     def prune_inverter_registry_once(self, current_set: set[str]) -> None:
         """Prune stale inverter registry entries after startup."""
@@ -410,67 +417,35 @@ class EnphaseSensorRegistrySetup:
     def remove_missing_inverter_entities(self, current_set: set[str]) -> None:
         """Remove known inverter entities no longer in the current set."""
 
-        removed_serials = self.known_inverter_serials - current_set
-        for serial in removed_serials:
-            entity_id = self._async_get_sensor_entity_id(
-                self.inverter_lifetime_sensor_unique_id(serial)
-            )
-            if entity_id is not None:
-                self._ent_reg.async_remove(entity_id)
-            self.known_inverter_serials.discard(serial)
-
-        self.known_inverter_serials.intersection_update(current_set)
+        self._remove_missing_serial_entities(
+            self.known_inverter_serials,
+            current_set,
+            lambda serial: (self.inverter_lifetime_sensor_unique_id(serial),),
+        )
 
     def battery_serial_from_unique_id(self, unique_id: object) -> str | None:
         """Return a battery serial parsed from a known per-battery unique ID."""
 
-        if not isinstance(unique_id, str):
-            return None
-        unique_prefix = f"{DOMAIN}_site_{self._site_id}_battery_"
-        if not unique_id.startswith(unique_prefix):
-            return None
-        if unique_id in {
-            f"{DOMAIN}_site_{self._site_id}_battery_overall_status",
-            f"{DOMAIN}_site_{self._site_id}_battery_last_reported",
-        }:
-            return None
-        for suffix in (
-            *BATTERY_ENTITY_UNIQUE_SUFFIXES,
-            *BATTERY_RETIRED_UNIQUE_SUFFIXES,
-        ):
-            if not unique_id.endswith(suffix):
-                continue
-            serial = unique_id[len(unique_prefix) : -len(suffix)]
-            if serial:
-                return serial
-            return None
-        return None
+        return battery_entity_serial_from_unique_id(
+            unique_id,
+            site_id=self._site_id,
+            suffixes=(
+                *BATTERY_ENTITY_UNIQUE_SUFFIXES,
+                *BATTERY_RETIRED_UNIQUE_SUFFIXES,
+            ),
+        )
 
     def ac_battery_serial_from_unique_id(self, unique_id: object) -> str | None:
         """Return an AC battery serial parsed from a known unique ID."""
 
-        if not isinstance(unique_id, str):
-            return None
-        unique_prefix = f"{DOMAIN}_site_{self._site_id}_ac_battery_"
-        if not unique_id.startswith(unique_prefix):
-            return None
-        if unique_id in {
-            f"{DOMAIN}_site_{self._site_id}_ac_battery_overall_status",
-            f"{DOMAIN}_site_{self._site_id}_ac_battery_last_reported",
-            f"{DOMAIN}_site_{self._site_id}_ac_battery_power",
-        }:
-            return None
-        for suffix in (
-            *AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
-            *AC_BATTERY_RETIRED_UNIQUE_SUFFIXES,
-        ):
-            if not unique_id.endswith(suffix):
-                continue
-            serial = unique_id[len(unique_prefix) : -len(suffix)]
-            if serial:
-                return serial
-            return None
-        return None
+        return ac_battery_entity_serial_from_unique_id(
+            unique_id,
+            site_id=self._site_id,
+            suffixes=(
+                *AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
+                *AC_BATTERY_RETIRED_UNIQUE_SUFFIXES,
+            ),
+        )
 
     def _gateway_iq_router_key_from_unique_id(self, unique_id: object) -> str | None:
         key = _clean_text(unique_id)
@@ -508,3 +483,21 @@ class EnphaseSensorRegistrySetup:
         if not callable(get_entity_id):
             return None
         return get_entity_id("sensor", DOMAIN, unique_id)
+
+    def _remove_missing_serial_entities(
+        self,
+        known_serials: set[str],
+        current_set: set[str],
+        unique_ids_for_serial,
+    ) -> None:
+        """Remove entities for serials that disappeared from active discovery."""
+
+        removed_serials = known_serials - current_set
+        for serial in removed_serials:
+            for unique_id in unique_ids_for_serial(serial):
+                entity_id = self._async_get_sensor_entity_id(unique_id)
+                if entity_id is not None:
+                    self._ent_reg.async_remove(entity_id)
+            known_serials.discard(serial)
+
+        known_serials.intersection_update(current_set)

--- a/custom_components/enphase_ev/serial_discovery.py
+++ b/custom_components/enphase_ev/serial_discovery.py
@@ -1,0 +1,199 @@
+"""Authoritative active serial discovery helpers for registry cleanup."""
+
+from __future__ import annotations
+
+from .device_types import normalize_type_key
+
+
+def inventory_type_available_for_cleanup(coord, type_key: str) -> bool | None:
+    """Return inventory type availability, or None when the inventory view is unknown."""
+
+    inventory_view = getattr(coord, "inventory_view", None)
+    has_type_for_entities = getattr(inventory_view, "has_type_for_entities", None)
+    if not callable(has_type_for_entities):
+        return None
+    try:
+        return bool(has_type_for_entities(type_key))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def inventory_type_selected_for_cleanup(coord, type_key: str) -> bool:
+    """Return whether a device type is selected for this entry."""
+
+    normalized = normalize_type_key(type_key)
+    if not normalized:
+        return False
+    selected = getattr(coord, "_selected_type_keys", None)
+    if selected is None or not selected:
+        return True
+    try:
+        return normalized in {normalize_type_key(key) for key in selected}
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def inventory_type_bucket_for_cleanup(coord, type_key: str) -> dict[str, object] | None:
+    """Return the inventory bucket when the devices inventory exposed it."""
+
+    normalized = normalize_type_key(type_key)
+    if not normalized:
+        return None
+    inventory_view = getattr(coord, "inventory_view", None)
+    type_bucket = getattr(inventory_view, "type_bucket", None)
+    if callable(type_bucket):
+        try:
+            bucket = type_bucket(normalized)
+        except Exception:  # noqa: BLE001
+            bucket = None
+        if isinstance(bucket, dict):
+            return bucket
+    buckets = getattr(coord, "_type_device_buckets", None)
+    if not isinstance(buckets, dict):
+        return None
+    bucket = buckets.get(normalized)
+    return bucket if isinstance(bucket, dict) else None
+
+
+def inventory_type_bucket_empty_for_cleanup(coord, type_key: str) -> bool:
+    """Return True when inventory explicitly exposed an empty bucket."""
+
+    bucket = inventory_type_bucket_for_cleanup(coord, type_key)
+    if not isinstance(bucket, dict):
+        return False
+    members = bucket.get("devices")
+    if not isinstance(members, list) or members:
+        return False
+    if "count" not in bucket:
+        return False
+    try:
+        count = int(bucket.get("count"))
+    except (TypeError, ValueError):
+        return False
+    return count == 0
+
+
+def inventory_type_known_absent_for_cleanup(coord, type_key: str) -> bool:
+    """Return True when non-status discovery can safely prove absence."""
+
+    return not inventory_type_selected_for_cleanup(
+        coord, type_key
+    ) or inventory_type_bucket_empty_for_cleanup(coord, type_key)
+
+
+def serials_from_getter(getter) -> set[str] | None:
+    """Return cleaned serials from a callable getter, or None on failure."""
+
+    if not callable(getter):
+        return None
+    try:
+        return {serial for sn in getter() if sn and (serial := str(sn).strip())}
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def active_charger_serials_for_cleanup(coord) -> set[str] | None:
+    """Return active EVSE serials when EVSE inventory is authoritative."""
+
+    if not bool(getattr(coord, "_devices_inventory_ready", False)):
+        return None
+    active_inventory = getattr(coord, "_active_inventory_evse_serials", None)
+    if callable(active_inventory):
+        try:
+            serials = active_inventory()
+        except Exception:  # noqa: BLE001
+            return None
+        if serials is None:
+            return None
+        return {serial for sn in serials if sn and (serial := str(sn).strip())}
+    return serials_from_getter(getattr(coord, "iter_serials", None))
+
+
+def active_battery_serials_for_cleanup(coord) -> set[str] | None:
+    """Return active storage battery serials when battery status is authoritative."""
+
+    if not bool(getattr(coord, "_devices_inventory_ready", False)):
+        return None
+    battery_type_available = inventory_type_available_for_cleanup(coord, "encharge")
+    if getattr(coord, "_battery_has_encharge", None) is False:
+        return set()
+    if battery_type_available is False:
+        if inventory_type_known_absent_for_cleanup(coord, "encharge"):
+            return set()
+        if isinstance(getattr(coord, "_battery_status_payload", None), dict):
+            return serials_from_getter(getattr(coord, "iter_battery_serials", None))
+        return None
+    if battery_type_available is True and not isinstance(
+        getattr(coord, "_battery_status_payload", None), dict
+    ):
+        return None
+    return serials_from_getter(getattr(coord, "iter_battery_serials", None))
+
+
+def active_ac_battery_serials_for_cleanup(coord) -> set[str] | None:
+    """Return active AC Battery serials when AC Battery discovery is authoritative."""
+
+    if not bool(getattr(coord, "_devices_inventory_ready", False)):
+        return None
+    ac_capability = getattr(coord, "battery_has_acb", None)
+    if ac_capability is False:
+        return set()
+    ac_type_available = inventory_type_available_for_cleanup(coord, "ac_battery")
+    if ac_type_available is False:
+        if inventory_type_known_absent_for_cleanup(coord, "ac_battery"):
+            return set()
+        if isinstance(getattr(coord, "_ac_battery_devices_payload", None), dict):
+            return serials_from_getter(getattr(coord, "iter_ac_battery_serials", None))
+        return None
+    if ac_type_available is True and ac_capability is not True:
+        return None
+    if ac_type_available is True and not isinstance(
+        getattr(coord, "_ac_battery_devices_payload", None), dict
+    ):
+        return None
+    return serials_from_getter(getattr(coord, "iter_ac_battery_serials", None))
+
+
+def active_inverter_serials_for_cleanup(coord) -> set[str] | None:
+    """Return active inverter serials when inverter inventory is authoritative."""
+
+    if not bool(getattr(coord, "_devices_inventory_ready", False)):
+        return None
+    if not bool(getattr(coord, "include_inverters", True)):
+        return set()
+    inverter_type_available = inventory_type_available_for_cleanup(
+        coord, "microinverter"
+    )
+    if inverter_type_available is False:
+        if inventory_type_known_absent_for_cleanup(coord, "microinverter"):
+            return set()
+        if isinstance(getattr(coord, "_inverters_inventory_payload", None), dict):
+            return serials_from_getter(getattr(coord, "iter_inverter_serials", None))
+        return None
+    if inverter_type_available is True and not isinstance(
+        getattr(coord, "_inverters_inventory_payload", None), dict
+    ):
+        return None
+    return serials_from_getter(getattr(coord, "iter_inverter_serials", None))
+
+
+def active_serial_registry_identifiers(coord) -> dict[str, set[str] | None]:
+    """Return active serial identifiers by serial-backed device family."""
+
+    return {
+        "charger": active_charger_serials_for_cleanup(coord),
+        "battery": active_battery_serials_for_cleanup(coord),
+        "ac_battery": active_ac_battery_serials_for_cleanup(coord),
+        "inverter": active_inverter_serials_for_cleanup(coord),
+    }
+
+
+def all_active_serial_registry_identifiers(coord) -> set[str]:
+    """Return active serial identifiers across supported serial device families."""
+
+    active: set[str] = set()
+    for serials in active_serial_registry_identifiers(coord).values():
+        if serials is None:
+            continue
+        active.update(serials)
+    return active

--- a/custom_components/enphase_ev/serial_entity_metadata.py
+++ b/custom_components/enphase_ev/serial_entity_metadata.py
@@ -1,0 +1,223 @@
+"""Shared unique-ID metadata for serial-backed Enphase entities."""
+
+from __future__ import annotations
+
+from .const import DOMAIN
+
+CHARGER_BINARY_SENSOR_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_plugged",
+    "_charging",
+    "_connected",
+)
+HISTORICAL_CHARGER_BINARY_SENSOR_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_commissioned",
+    "_charger_problem",
+)
+CHARGER_SENSOR_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_energy_today",
+    "_connector_status",
+    "_electrical_phase",
+    "_power",
+    "_charge_level",
+    "_charging_amps",
+    "_last_reported",
+    "_last_rpt",
+    "_charge_mode",
+    "_authentication",
+    "_charger_authentication",
+    "_status",
+    "_lifetime_energy",
+    "_lifetime_kwh",
+    "_storm_guard_state",
+)
+HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_connector_reason",
+    "_session_miles",
+    "_plg_in_at",
+    "_plg_out_at",
+    "_schedule_type",
+    "_schedule_start",
+    "_schedule_end",
+    "_session_kwh",
+    "_charging_level",
+    "_session_duration",
+    "_phase_mode",
+    "_max_current",
+    "_min_amp",
+    "_max_amp",
+    "_connection",
+    "_reporting_interval",
+    "_ip_address",
+)
+BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_charge_level",
+    "_status",
+    "_health",
+    "_cycle_count",
+)
+BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_last_reported",
+    "_last_reported_at",
+)
+AC_BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_charge_level",
+    "_status",
+    "_power",
+    "_operating_mode",
+    "_cycle_count",
+    "_last_reported",
+)
+AC_BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = ("_last_reported_at",)
+INVERTER_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = ("_lifetime_energy",)
+
+
+def charger_entity_unique_id(serial: str, suffix: str) -> str:
+    """Return a per-charger unique ID."""
+
+    return f"{DOMAIN}_{serial}{suffix}"
+
+
+def charger_entity_unique_ids(
+    serial: str,
+    suffixes: tuple[str, ...] = CHARGER_SENSOR_UNIQUE_SUFFIXES,
+) -> tuple[str, ...]:
+    """Return per-charger unique IDs for suffixes."""
+
+    return tuple(charger_entity_unique_id(serial, suffix) for suffix in suffixes)
+
+
+def site_battery_entity_unique_id(site_id: str, serial: str, suffix: str) -> str:
+    """Return a per-storage-battery unique ID."""
+
+    return f"{DOMAIN}_site_{site_id}_battery_{serial}{suffix}"
+
+
+def site_battery_entity_unique_ids(
+    site_id: str,
+    serial: str,
+    suffixes: tuple[str, ...] = BATTERY_ENTITY_UNIQUE_SUFFIXES,
+) -> tuple[str, ...]:
+    """Return per-storage-battery unique IDs for suffixes."""
+
+    return tuple(
+        site_battery_entity_unique_id(site_id, serial, suffix) for suffix in suffixes
+    )
+
+
+def site_ac_battery_entity_unique_id(site_id: str, serial: str, suffix: str) -> str:
+    """Return a per-AC-battery unique ID."""
+
+    return f"{DOMAIN}_site_{site_id}_ac_battery_{serial}{suffix}"
+
+
+def site_ac_battery_entity_unique_ids(
+    site_id: str,
+    serial: str,
+    suffixes: tuple[str, ...] = AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
+) -> tuple[str, ...]:
+    """Return per-AC-battery unique IDs for suffixes."""
+
+    return tuple(
+        site_ac_battery_entity_unique_id(site_id, serial, suffix) for suffix in suffixes
+    )
+
+
+def inverter_entity_unique_id(serial: str) -> str:
+    """Return a microinverter unique ID."""
+
+    return f"{DOMAIN}_inverter_{serial}_lifetime_energy"
+
+
+def charger_entity_serial_from_unique_id(
+    unique_id: object,
+    suffixes: tuple[str, ...],
+) -> str | None:
+    """Return a bare charger serial from a managed per-charger unique ID."""
+
+    if not isinstance(unique_id, str):
+        return None
+    unique_prefix = f"{DOMAIN}_"
+    if not unique_id.startswith(unique_prefix):
+        return None
+    if unique_id.startswith(f"{DOMAIN}_site_") or unique_id.startswith(
+        f"{DOMAIN}_inverter_"
+    ):
+        return None
+    for suffix in sorted(suffixes, key=len, reverse=True):
+        if not unique_id.endswith(suffix):
+            continue
+        serial = unique_id[len(unique_prefix) : -len(suffix)]
+        return serial or None
+    return None
+
+
+def prefixed_serial_from_unique_id(
+    unique_id: object,
+    *,
+    prefix: str,
+    suffixes: tuple[str, ...],
+    blocked_unique_ids: set[str] | None = None,
+) -> str | None:
+    """Return a serial from a namespaced unique ID."""
+
+    if not isinstance(unique_id, str) or not unique_id.startswith(prefix):
+        return None
+    if blocked_unique_ids and unique_id in blocked_unique_ids:
+        return None
+    for suffix in sorted(suffixes, key=len, reverse=True):
+        if not unique_id.endswith(suffix):
+            continue
+        serial = unique_id[len(prefix) : -len(suffix)]
+        return serial or None
+    return None
+
+
+def battery_entity_serial_from_unique_id(
+    unique_id: object,
+    *,
+    site_id: str,
+    suffixes: tuple[str, ...],
+) -> str | None:
+    """Return a storage battery serial parsed from a managed unique ID."""
+
+    prefix = f"{DOMAIN}_site_{site_id}_battery_"
+    return prefixed_serial_from_unique_id(
+        unique_id,
+        prefix=prefix,
+        suffixes=suffixes,
+        blocked_unique_ids={
+            f"{DOMAIN}_site_{site_id}_battery_overall_status",
+            f"{DOMAIN}_site_{site_id}_battery_last_reported",
+        },
+    )
+
+
+def ac_battery_entity_serial_from_unique_id(
+    unique_id: object,
+    *,
+    site_id: str,
+    suffixes: tuple[str, ...],
+) -> str | None:
+    """Return an AC Battery serial parsed from a managed unique ID."""
+
+    prefix = f"{DOMAIN}_site_{site_id}_ac_battery_"
+    return prefixed_serial_from_unique_id(
+        unique_id,
+        prefix=prefix,
+        suffixes=suffixes,
+        blocked_unique_ids={
+            f"{DOMAIN}_site_{site_id}_ac_battery_overall_status",
+            f"{DOMAIN}_site_{site_id}_ac_battery_last_reported",
+            f"{DOMAIN}_site_{site_id}_ac_battery_power",
+        },
+    )
+
+
+def inverter_entity_serial_from_unique_id(unique_id: object) -> str | None:
+    """Return an inverter serial parsed from a managed unique ID."""
+
+    return prefixed_serial_from_unique_id(
+        unique_id,
+        prefix=f"{DOMAIN}_inverter_",
+        suffixes=INVERTER_ENTITY_UNIQUE_SUFFIXES,
+    )

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -20,6 +20,7 @@ class DiscoveryState:
     _warmup_task: Any = None
     _warmup_in_progress: bool = False
     _warmup_last_error: str | None = None
+    _restored_evse_serial_order: list[str] = field(default_factory=list)
     _restored_site_energy_channels: set[str] = field(default_factory=set)
     _restored_gateway_iq_energy_router_records: PayloadRecords = field(
         default_factory=list
@@ -155,6 +156,8 @@ class RefreshHealthState:
     _warmup_phase_timings: dict[str, float] = field(default_factory=dict)
     _refresh_performance_history: list[dict[str, object]] = field(default_factory=list)
     _has_successful_refresh: bool = False
+    _status_charger_data_authoritative: bool = False
+    _status_charger_data_serials: list[str] | None = None
     _session_history_cache_shim: dict[tuple[str, str], tuple[float, list[dict]]] = (
         field(default_factory=dict)
     )

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -35,6 +35,7 @@ from .runtime_helpers import (
     inventory_type_device_info as _type_device_info,
 )
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
+from .serial_discovery import active_charger_serials_for_cleanup
 
 PARALLEL_UPDATES = 0
 
@@ -78,16 +79,26 @@ async def async_setup_entry(
 
     @callback
     def _async_sync_charger_updates() -> None:
+        active_serials = active_charger_serials_for_cleanup(coord)
         current_serials = (
-            set(_charger_serials(coord)) if _type_available(coord, "iqevse") else set()
+            active_serials
+            if active_serials is not None
+            else (
+                set(_charger_serials(coord))
+                if _type_available(coord, "iqevse")
+                else set()
+            )
         )
-        _async_prune_removed_charger_updates(
-            entry=entry,
-            ent_reg=ent_reg,
-            current_serials=current_serials,
-            known_serials=known_serials,
-        )
-        if not current_serials and not _type_available(coord, "iqevse"):
+        if active_serials is not None:
+            _async_prune_removed_charger_updates(
+                entry=entry,
+                ent_reg=ent_reg,
+                current_serials=current_serials,
+                known_serials=known_serials,
+            )
+        if not current_serials and (
+            active_serials is None and not _type_available(coord, "iqevse")
+        ):
             return
         known_serials.intersection_update(current_serials)
         serials = [sn for sn in current_serials if sn and sn not in known_serials]

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -93,6 +93,19 @@ async def test_async_setup_entry_syncs_binary_sensors(
         "commissioned": False,
     }
     coord._ensure_serial_tracked(new_serial)
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "iqevse": {
+                "type_label": "EV Chargers",
+                "count": 2,
+                "devices": [
+                    {"serial_number": RANDOM_SERIAL},
+                    {"serial_number": new_serial},
+                ],
+            }
+        },
+        ["iqevse"],
+    )
 
     sync_cb()
     assert len(added) == 7
@@ -152,6 +165,96 @@ async def test_async_setup_entry_prunes_historical_charger_binary_sensor_entitie
     assert fake_registry.async_remove.call_count == 2
     fake_registry.async_remove.assert_any_call("binary_sensor.old_commissioned")
     fake_registry.async_remove.assert_any_call("binary_sensor.old_problem")
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_prunes_removed_charger_binary_sensor_entities(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=["EVKEEP"])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    fake_registry = SimpleNamespace(
+        entities={
+            "binary_sensor.old_plugged": SimpleNamespace(
+                entity_id="binary_sensor.old_plugged",
+                domain="binary_sensor",
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_EVOLD_plugged",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "binary_sensor.keep_connected": SimpleNamespace(
+                entity_id="binary_sensor.keep_connected",
+                domain="binary_sensor",
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_EVKEEP_connected",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "binary_sensor.keep_site_status": SimpleNamespace(
+                entity_id="binary_sensor.keep_site_status",
+                domain="binary_sensor",
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_site_{coord.site_id}_connected",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "binary_sensor.ignore_wrong_entry": SimpleNamespace(
+                entity_id="binary_sensor.ignore_wrong_entry",
+                domain="binary_sensor",
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_EVOTHER_plugged",
+                config_entry_id="other-entry",
+            ),
+        },
+        async_remove=MagicMock(),
+        async_get_entity_id=MagicMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.binary_sensor.er.async_get",
+        lambda _hass: fake_registry,
+    )
+    monkeypatch.setattr(
+        coord, "async_add_topology_listener", lambda callback: _stub_listener()
+    )
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+
+    fake_registry.async_remove.assert_called_once_with("binary_sensor.old_plugged")
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_waits_for_authoritative_charger_inventory_before_binary_prune(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=["EVKEEP"])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._active_inventory_evse_serials = lambda: None  # type: ignore[method-assign]
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    fake_registry = SimpleNamespace(
+        entities={
+            "binary_sensor.old_plugged": SimpleNamespace(
+                entity_id="binary_sensor.old_plugged",
+                domain="binary_sensor",
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_EVOLD_plugged",
+                config_entry_id=config_entry.entry_id,
+            ),
+        },
+        async_remove=MagicMock(),
+        async_get_entity_id=MagicMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.binary_sensor.er.async_get",
+        lambda _hass: fake_registry,
+    )
+    monkeypatch.setattr(
+        coord, "async_add_topology_listener", lambda callback: _stub_listener()
+    )
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+
+    fake_registry.async_remove.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_buttons_and_fast.py
+++ b/tests/components/enphase_ev/test_buttons_and_fast.py
@@ -506,6 +506,19 @@ async def test_button_platform_async_setup_entry_filters_known_serials(
 
     coord._ensure_serial_tracked("6666")
     coord.data["6666"] = {"sn": "6666", "name": "Aux Charger"}
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "iqevse": {
+                "type_label": "EV Chargers",
+                "count": 2,
+                "devices": [
+                    {"serial_number": "5555"},
+                    {"serial_number": "6666"},
+                ],
+            }
+        },
+        ["iqevse"],
+    )
     listeners[0]()
 
     assert len(added) == 1

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -1296,6 +1296,217 @@ def test_prune_runtime_caches_removes_stale_serial_state(coordinator_factory):
     coord.session_history.prune.assert_called_once()
 
 
+def test_prune_runtime_caches_drops_configured_retired_serial_after_inventory_ready(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=["EV1", "EV2"])
+    coord._configured_serials = {"EV1", "EV2"}  # noqa: SLF001
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord.serials = {"EV1", "EV2"}
+    coord._serial_order = ["EV1", "EV2"]  # noqa: SLF001
+    coord.last_set_amps = {"EV1": 16, "EV2": 32}
+
+    coord._prune_runtime_caches(  # noqa: SLF001
+        active_serials={"EV1"},
+        keep_day_keys={"2020-01-02"},
+    )
+
+    assert coord.serials == {"EV1"}
+    assert coord._serial_order == ["EV1"]  # noqa: SLF001
+    assert coord.last_set_amps == {"EV1": 16}
+
+
+def test_iter_serials_uses_authoritative_active_inventory(coordinator_factory):
+    coord = coordinator_factory(serials=["EV1", "EV2"])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._type_device_buckets = {  # noqa: SLF001
+        "iqevse": {
+            "count": 3,
+            "devices": [
+                {"serial_number": "EV1"},
+                {"serialNumber": "EV1"},
+                {"serial": "EV3"},
+            ],
+        }
+    }
+    coord._type_device_order = ["iqevse"]  # noqa: SLF001
+    coord.data = {"EV2": {"status": "stale"}}
+
+    assert coord.iter_serials() == ["EV1", "EV3"]
+
+    coord._type_device_buckets = {"iqevse": {"count": 0, "devices": []}}  # noqa: SLF001
+    coord._type_device_order = []  # noqa: SLF001
+
+    assert coord.iter_serials() == []
+
+
+def test_iter_serials_waits_with_empty_non_authoritative_status_when_evse_bucket_missing(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=["OLD"])
+    coord.discovery_snapshot.apply({"serial_order": ["NEW", "NEW"]})
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._status_charger_data_authoritative = False  # noqa: SLF001
+    coord.data = {}
+    coord._type_device_buckets = {  # noqa: SLF001
+        "envoy": {
+            "count": 1,
+            "devices": [{"serial_number": "GW-1"}],
+        }
+    }
+    coord._type_device_order = ["envoy"]  # noqa: SLF001
+
+    assert coord._active_inventory_evse_serials() is None  # noqa: SLF001
+    assert coord.iter_serials() == ["NEW"]
+    assert coord.serials == {"NEW"}
+
+
+def test_iter_serials_drops_restored_snapshot_when_empty_status_is_authoritative(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=["OLD"])
+    coord.discovery_snapshot.apply({"serial_order": ["NEW", "NEW"]})
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._status_charger_data_authoritative = True  # noqa: SLF001
+    coord.data = {}
+    coord._type_device_buckets = {  # noqa: SLF001
+        "envoy": {
+            "count": 1,
+            "devices": [{"serial_number": "GW-1"}],
+        }
+    }
+    coord._type_device_order = ["envoy"]  # noqa: SLF001
+
+    assert coord.iter_serials() == []
+
+
+def test_iter_serials_uses_fresh_status_when_evse_bucket_missing(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=["OLD"])
+    coord.discovery_snapshot.apply({"serial_order": ["RESTORED"]})
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._status_charger_data_authoritative = True  # noqa: SLF001
+    coord.payload_using_stale = False
+    coord.data = {"ACTIVE": {"sn": "ACTIVE"}}
+    coord._type_device_buckets = {  # noqa: SLF001
+        "envoy": {
+            "count": 1,
+            "devices": [{"serial_number": "GW-1"}],
+        }
+    }
+    coord._type_device_order = ["envoy"]  # noqa: SLF001
+
+    assert coord.iter_serials() == ["ACTIVE"]
+
+
+def test_iter_serials_prefers_fresh_status_over_stale_evse_bucket(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=["OLD"])
+    coord.discovery_snapshot.apply({"serial_order": ["OLD", "ACTIVE"]})
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._status_charger_data_authoritative = True  # noqa: SLF001
+    coord.payload_using_stale = False
+    coord.data = {"ACTIVE": {"sn": "ACTIVE"}}
+    coord._type_device_buckets = {  # noqa: SLF001
+        "iqevse": {
+            "count": 2,
+            "devices": [
+                {"serial_number": "OLD"},
+                {"serial_number": "ACTIVE"},
+            ],
+        }
+    }
+    coord._type_device_order = ["iqevse"]  # noqa: SLF001
+
+    assert coord._active_inventory_evse_serials() == ["ACTIVE"]  # noqa: SLF001
+    assert coord.iter_serials() == ["ACTIVE"]
+
+
+def test_iter_serials_waits_when_only_stale_status_is_available(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=["OLD"])
+    coord.discovery_snapshot.apply({"serial_order": ["RESTORED"]})
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.payload_using_stale = True
+    coord.data = {"STALE": {"sn": "STALE"}}
+    coord._type_device_buckets = {  # noqa: SLF001
+        "envoy": {
+            "count": 1,
+            "devices": [{"serial_number": "GW-1"}],
+        }
+    }
+    coord._type_device_order = ["envoy"]  # noqa: SLF001
+
+    assert coord._active_inventory_evse_serials() is None  # noqa: SLF001
+    assert coord.iter_serials() == ["RESTORED", "STALE"]
+
+
+def test_iter_serials_uses_restored_snapshot_when_inventory_view_raises(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=["OLD"])
+    coord.discovery_snapshot.apply({"serial_order": ["NEW"]})
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord.inventory_view = SimpleNamespace(
+        type_bucket=lambda _type_key: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+
+    assert coord.iter_serials() == ["NEW", "OLD"]
+
+
+def test_iter_serials_handles_malformed_authoritative_inventory(coordinator_factory):
+    coord = coordinator_factory(serials=["EV1"])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord.inventory_view = SimpleNamespace(
+        type_bucket=lambda _type_key: {"count": 1, "devices": "bad"}
+    )
+
+    assert coord.iter_serials() == ["EV1"]
+
+    coord.inventory_view = SimpleNamespace(
+        type_bucket=lambda _type_key: {"devices": []}
+    )
+
+    assert coord.iter_serials() == ["EV1"]
+
+    class BadSerial:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    class BadCount:
+        def __int__(self) -> int:
+            raise TypeError("boom")
+
+        def __str__(self) -> str:
+            raise TypeError("boom")
+
+    coord.inventory_view = SimpleNamespace(
+        type_bucket=lambda _type_key: {
+            "count": BadCount(),
+            "devices": [
+                "not-a-dict",
+                {"serial_number": BadSerial()},
+            ],
+        }
+    )
+
+    assert coord.iter_serials() == ["EV1"]
+
+    coord.inventory_view = SimpleNamespace(
+        type_bucket=lambda _type_key: {"count": 0, "devices": []}
+    )
+
+    assert coord.iter_serials() == []
+
+
 def test_cleanup_runtime_state_clears_session_history(coordinator_factory):
     coord = coordinator_factory(serials=["EV1"])
     clear = MagicMock()
@@ -2827,6 +3038,7 @@ def test_amp_helpers_and_expectation_management(coordinator_factory, monkeypatch
 
     coord.serials = None
     coord._serial_order = None
+    coord._devices_inventory_ready = False
     assert coord._ensure_serial_tracked("  EV2  ") is True
     assert "EV2" in coord.iter_serials()
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1613,10 +1613,11 @@ async def test_update_skips_status_when_site_only(hass, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_update_skips_status_when_no_serials(hass, monkeypatch):
+async def test_update_skips_status_when_no_evse_context(hass, monkeypatch):
     coord = _make_coordinator(hass, monkeypatch)
     coord.serials = set()
     coord._serial_order = []
+    coord._configured_serials = set()  # noqa: SLF001
 
     client = SimpleNamespace(
         status=AsyncMock(side_effect=AssertionError("should not call status"))
@@ -1629,6 +1630,38 @@ async def test_update_skips_status_when_no_serials(hass, monkeypatch):
     assert client.status.await_count == 0
     assert coord.last_success_utc is not None
     assert coord._has_successful_refresh is True
+
+
+@pytest.mark.asyncio
+async def test_update_keeps_status_when_configured_evse_serials_are_pruned(
+    hass, monkeypatch
+):
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.serials = set()
+    coord._serial_order = []  # noqa: SLF001
+    coord.client.status = AsyncMock(return_value={"evChargerData": [], "ts": 0})
+
+    result = await coord._async_update_data()  # noqa: SLF001
+
+    assert result == {}
+    coord.client.status.assert_awaited_once()
+    assert coord._status_charger_data_authoritative is True  # noqa: SLF001
+    assert coord.iter_serials() == []
+
+
+def test_evse_status_refresh_enabled_without_active_serials(hass, monkeypatch):
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.serials = set()
+    coord._serial_order = []  # noqa: SLF001
+    coord._configured_serials = set()  # noqa: SLF001
+    coord._selected_type_keys = {"iqevse"}  # noqa: SLF001
+
+    assert coord._evse_status_refresh_enabled() is True  # noqa: SLF001
+
+    coord._selected_type_keys = None  # noqa: SLF001
+    coord._restored_evse_serial_order = ["RESTORED"]  # noqa: SLF001
+
+    assert coord._evse_status_refresh_enabled() is True  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -3536,6 +3569,212 @@ async def test_first_refresh_soft_fails_optional_evse_status_endpoint(
     assert coord.data == {}
     assert coord._has_successful_refresh is True  # noqa: SLF001
     assert coord.payload_using_stale is False
+    assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"data": {"chargers": ["bad-entry"]}},
+        {"evChargerData": {"sn": "bad-entry"}},
+        {"evChargerData": ["bad-entry"]},
+        {"evChargerData": [{}]},
+        {"evChargerData": [{"name": "bad-entry"}]},
+    ],
+)
+async def test_first_refresh_malformed_raw_status_is_not_cleanup_authoritative(
+    hass, monkeypatch, payload
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.discovery_snapshot.apply({"serial_order": ["RESTORED"]})
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[method-assign]
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._type_device_buckets = {  # noqa: SLF001
+        "envoy": {
+            "count": 1,
+            "devices": [{"serial_number": "GW-1"}],
+        }
+    }
+    coord._type_device_order = ["envoy"]  # noqa: SLF001
+    coord.client.status = AsyncMock(return_value=payload)
+
+    data = await coord._async_update_data()  # noqa: SLF001
+    coord.data = data
+
+    assert data == {}
+    assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+    assert coord._status_charger_data_serials is None  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() is None  # noqa: SLF001
+    assert coord.iter_serials() == ["RESTORED"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_malformed_nested_status_row_keeps_cleanup_authority(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.discovery_snapshot.apply({"serial_order": ["RESTORED", "ACTIVE"]})
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[method-assign]
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._type_device_buckets = {  # noqa: SLF001
+        "iqevse": {
+            "count": 2,
+            "devices": [
+                {"serial_number": "RESTORED"},
+                {"serial_number": "ACTIVE"},
+            ],
+        }
+    }
+    coord._type_device_order = ["iqevse"]  # noqa: SLF001
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "ACTIVE",
+                    "connectors": "bad-connectors",
+                    "sch_d": {"info": {"type": "scheduled"}},
+                    "session_d": "bad-session",
+                }
+            ],
+            "ts": 0,
+        }
+    )
+
+    data = await coord._async_update_data()  # noqa: SLF001
+    coord.data = data
+
+    assert list(data) == ["ACTIVE"]
+    assert coord._status_charger_data_authoritative is True  # noqa: SLF001
+    assert coord._status_charger_data_serials == ["ACTIVE"]  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() == ["ACTIVE"]  # noqa: SLF001
+    assert data["ACTIVE"]["connector_reason"] is None
+    assert data["ACTIVE"]["schedule_status"] is None
+    assert data["ACTIVE"]["schedule_type"] == "scheduled"
+    assert data["ACTIVE"]["session_energy_raw"] is None
+
+
+@pytest.mark.asyncio
+async def test_first_refresh_empty_evchargerdata_is_cleanup_authoritative(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.discovery_snapshot.apply({"serial_order": ["RESTORED"]})
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[method-assign]
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._type_device_buckets = {  # noqa: SLF001
+        "envoy": {
+            "count": 1,
+            "devices": [{"serial_number": "GW-1"}],
+        }
+    }
+    coord._type_device_order = ["envoy"]  # noqa: SLF001
+    coord.client.status = AsyncMock(return_value={"evChargerData": [], "ts": 0})
+
+    data = await coord._async_update_data()  # noqa: SLF001
+    coord.data = data
+
+    assert data == {}
+    assert coord._status_charger_data_authoritative is True  # noqa: SLF001
+    assert coord._status_charger_data_serials == []  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() == []  # noqa: SLF001
+    assert coord.iter_serials() == []
+
+
+@pytest.mark.asyncio
+async def test_empty_evchargerdata_keeps_status_refresh_after_serials_pruned(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.discovery_snapshot.apply({"serial_order": ["RESTORED"]})
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[method-assign]
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._type_device_buckets = {  # noqa: SLF001
+        "iqevse": {
+            "count": 1,
+            "devices": [{"serial_number": "RESTORED"}],
+        }
+    }
+    coord._type_device_order = ["iqevse"]  # noqa: SLF001
+    coord.client.status = AsyncMock(return_value={"evChargerData": [], "ts": 0})
+
+    data = await coord._async_update_data()  # noqa: SLF001
+    coord.data = data
+
+    assert data == {}
+    assert coord.serials == set()
+    assert coord.iter_serials() == []
+
+    coord.client.status.reset_mock()
+
+    data = await coord._async_update_data()  # noqa: SLF001
+    coord.data = data
+
+    assert data == {}
+    coord.client.status.assert_awaited_once()
+    assert coord._status_charger_data_authoritative is True  # noqa: SLF001
+    assert coord._status_charger_data_serials == []  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() == []  # noqa: SLF001
+    assert coord.iter_serials() == []
+
+
+@pytest.mark.asyncio
+async def test_refresh_topology_uses_fresh_status_serial_cache_before_data_assignment(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.data = {
+        "OLD": {"sn": "OLD"},
+        "ACTIVE": {"sn": "ACTIVE"},
+    }
+    coord.discovery_snapshot.apply({"serial_order": ["OLD", "ACTIVE"]})
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[method-assign]
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._type_device_buckets = {  # noqa: SLF001
+        "iqevse": {
+            "count": 2,
+            "devices": [
+                {"serial_number": "OLD"},
+                {"serial_number": "ACTIVE"},
+            ],
+        }
+    }
+    coord._type_device_order = ["iqevse"]  # noqa: SLF001
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "ACTIVE",
+                    "connectors": [{}],
+                }
+            ],
+            "ts": 0,
+        }
+    )
+    coord._async_resolve_post_status_evse_enrichments = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+        return_value=({}, {}, {}, {})
+    )
+    observed_active_serials: list[list[str] | None] = []
+    observed_data_serials: list[set[str]] = []
+
+    def _finish_refresh_pipeline(_context) -> None:
+        observed_active_serials.append(
+            coord._active_inventory_evse_serials()
+        )  # noqa: SLF001
+        observed_data_serials.append(set(coord.data))
+
+    coord._finish_refresh_pipeline = Mock(  # type: ignore[method-assign]  # noqa: SLF001
+        side_effect=_finish_refresh_pipeline
+    )
+
+    data = await coord._async_update_data()  # noqa: SLF001
+
+    assert set(data) == {"ACTIVE"}
+    assert observed_data_serials == [{"OLD", "ACTIVE"}]
+    assert observed_active_serials == [["ACTIVE"]]
+    assert coord._status_charger_data_serials == ["ACTIVE"]  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -3938,7 +4177,10 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
         }
     )
 
-    ensure_serial.assert_called_once_with("REST-1")
+    ensure_serial.assert_not_called()
+    assert coord._restored_evse_serial_order == ["REST-1"]  # noqa: SLF001
+    assert coord._serial_order == ["REST-1"]  # noqa: SLF001
+    assert coord.serials == {"REST-1"}
     set_buckets.assert_called_once()
     assert set_buckets.call_args.kwargs["authoritative"] is False
     assert coord._battery_storage_order == ["BAT-1"]  # noqa: SLF001

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -1637,6 +1637,7 @@ def test_ensure_serial_tracked_invalid_inputs(coordinator_factory):
 def test_iter_serials_falls_back_to_sorted(coordinator_factory):
     coord = coordinator_factory()
     coord._serial_order = []
+    coord._devices_inventory_ready = False
     coord.serials = {"B", "A"}
     ordered = coord.iter_serials()
     assert ordered[:2] == ["A", "B"]

--- a/tests/components/enphase_ev/test_entity_cleanup.py
+++ b/tests/components/enphase_ev/test_entity_cleanup.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from custom_components.enphase_ev.entity_cleanup import (
+    entries_for_device,
     is_owned_entity,
     iter_entity_registry_entries,
     prune_managed_entities,
@@ -32,6 +33,31 @@ def test_iter_entity_registry_entries_handles_edge_shapes() -> None:
         )
         == []
     )
+
+
+def test_entries_for_device_scans_registry_when_ha_helper_returns_empty(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.entity_cleanup.er.async_entries_for_device",
+        lambda _ent_reg, _device_id: [],
+    )
+    ent_reg = SimpleNamespace(
+        entities={
+            "sensor.attached": SimpleNamespace(
+                entity_id="sensor.attached",
+                device_id="device-1",
+            ),
+            "sensor.other": SimpleNamespace(
+                entity_id="sensor.other",
+                device_id="device-2",
+            ),
+        }
+    )
+
+    entries = entries_for_device(ent_reg, "device-1")
+
+    assert [entry.entity_id for entry in entries] == ["sensor.attached"]
 
 
 def test_is_owned_entity_filters_domain_platform_and_entry() -> None:

--- a/tests/components/enphase_ev/test_registry_cleanup.py
+++ b/tests/components/enphase_ev/test_registry_cleanup.py
@@ -1,0 +1,950 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from custom_components.enphase_ev import (
+    DOMAIN,
+    _prune_inactive_serial_entities,
+    _remove_empty_inactive_serial_devices,
+    _serial_entity_group_from_unique_id,
+)
+from custom_components.enphase_ev.const import CONF_SITE_ID
+from custom_components.enphase_ev.serial_discovery import (
+    active_ac_battery_serials_for_cleanup,
+    active_battery_serials_for_cleanup,
+    active_charger_serials_for_cleanup,
+    active_inverter_serials_for_cleanup,
+    active_serial_registry_identifiers,
+    all_active_serial_registry_identifiers,
+    inventory_type_available_for_cleanup,
+    inventory_type_bucket_empty_for_cleanup,
+    inventory_type_bucket_for_cleanup,
+    inventory_type_selected_for_cleanup,
+    serials_from_getter,
+)
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
+from custom_components.enphase_ev.serial_entity_metadata import (
+    charger_entity_serial_from_unique_id,
+    prefixed_serial_from_unique_id,
+)
+
+
+@pytest.mark.asyncio
+async def test_remove_empty_inactive_serial_devices_keeps_devices_with_entities(
+    hass: HomeAssistant, config_entry
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    active_serial = RANDOM_SERIAL
+    inactive_serial = "EV-RETIRED"
+
+    active_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, active_serial)},
+        manufacturer="Enphase",
+        name="Active Charger",
+    )
+    inactive_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, inactive_serial)},
+        manufacturer="Enphase",
+        name="Retired Charger",
+    )
+    type_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"type:{site_id}:envoy")},
+        manufacturer="Enphase",
+        name="Gateway",
+    )
+    stale_entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_{inactive_serial}_status",
+        config_entry=config_entry,
+        device_id=inactive_device.id,
+    )
+    coord = SimpleNamespace(
+        _devices_inventory_ready=True,
+        _selected_type_keys={"iqevse"},
+        inventory_view=SimpleNamespace(has_type_for_entities=lambda _key: False),
+        iter_serials=lambda: [active_serial],
+        iter_battery_serials=lambda: [],
+        iter_ac_battery_serials=lambda: [],
+        iter_inverter_serials=lambda: [],
+    )
+
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord, dev_reg, site_id
+        )
+        == 0
+    )
+    assert dev_reg.async_get(inactive_device.id) is not None
+
+    ent_reg.async_remove(stale_entity.entity_id)
+
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord, dev_reg, site_id
+        )
+        == 1
+    )
+    assert dev_reg.async_get(active_device.id) is not None
+    assert dev_reg.async_get(inactive_device.id) is None
+    assert dev_reg.async_get(type_device.id) is not None
+
+
+@pytest.mark.asyncio
+async def test_remove_empty_inactive_serial_devices_preserves_active_supported_devices(
+    hass: HomeAssistant, config_entry
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+    active_battery = "BAT-ACTIVE"
+    active_inverter = "INV-ACTIVE"
+    inactive_battery = "BAT-RETIRED"
+
+    active_battery_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, active_battery)},
+        manufacturer="Enphase",
+        name="Active Battery",
+    )
+    active_inverter_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, active_inverter)},
+        manufacturer="Enphase",
+        name="Active Microinverter",
+    )
+    inactive_battery_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, inactive_battery)},
+        manufacturer="Enphase",
+        name="Retired Battery",
+    )
+    stale_entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_battery_{inactive_battery}_status",
+        config_entry=config_entry,
+        device_id=inactive_battery_device.id,
+    )
+    coord = SimpleNamespace(
+        _devices_inventory_ready=True,
+        _selected_type_keys={"encharge", "microinverter"},
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda key: key in {"encharge", "microinverter"}
+        ),
+        _battery_status_payload={},
+        include_inverters=True,
+        _inverters_inventory_payload={},
+        iter_serials=lambda: [],
+        iter_battery_serials=lambda: [active_battery],
+        iter_ac_battery_serials=lambda: [],
+        iter_inverter_serials=lambda: [active_inverter],
+    )
+
+    assert all_active_serial_registry_identifiers(coord) == {
+        active_battery,
+        active_inverter,
+    }
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord, dev_reg, site_id
+        )
+        == 0
+    )
+
+    ent_reg.async_remove(stale_entity.entity_id)
+
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord, dev_reg, site_id
+        )
+        == 1
+    )
+    assert dev_reg.async_get(active_battery_device.id) is not None
+    assert dev_reg.async_get(active_inverter_device.id) is not None
+    assert dev_reg.async_get(inactive_battery_device.id) is None
+
+
+@pytest.mark.asyncio
+async def test_prune_inactive_serial_entities_removes_retired_charger_entities(
+    hass: HomeAssistant, config_entry
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    ent_reg = er.async_get(hass)
+    active_serial = RANDOM_SERIAL
+    inactive_serial = "EV-RETIRED"
+    active_battery = "BAT-ACTIVE"
+    inactive_battery = "BAT-RETIRED"
+    active_ac_battery = "ACBAT-ACTIVE"
+    inactive_ac_battery = "ACBAT-RETIRED"
+    active_inverter = "INV-ACTIVE"
+    inactive_inverter = "INV-RETIRED"
+    coord = SimpleNamespace(
+        _devices_inventory_ready=True,
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda key: key
+            in {"encharge", "ac_battery", "microinverter"}
+        ),
+        _battery_status_payload={},
+        battery_has_acb=True,
+        _ac_battery_devices_payload={},
+        include_inverters=True,
+        _inverters_inventory_payload={},
+        iter_serials=lambda: [active_serial],
+        iter_battery_serials=lambda: [active_battery],
+        iter_ac_battery_serials=lambda: [active_ac_battery],
+        iter_inverter_serials=lambda: [active_inverter],
+    )
+
+    stale_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_{inactive_serial}_charging_amps",
+        config_entry=config_entry,
+    )
+    stale_binary = ent_reg.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{DOMAIN}_{inactive_serial}_connected",
+        config_entry=config_entry,
+    )
+    active_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_{active_serial}_last_rpt",
+        config_entry=config_entry,
+    )
+    active_connector_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_{active_serial}_connector_status",
+        config_entry=config_entry,
+    )
+    active_authentication_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_{active_serial}_charger_authentication",
+        config_entry=config_entry,
+    )
+    site_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_service_status",
+        config_entry=config_entry,
+    )
+    inverter_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_inverter_{active_inverter}_lifetime_energy",
+        config_entry=config_entry,
+    )
+    stale_battery_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_battery_{inactive_battery}_status",
+        config_entry=config_entry,
+    )
+    active_battery_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_battery_{active_battery}_status",
+        config_entry=config_entry,
+    )
+    stale_ac_battery_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_ac_battery_{inactive_ac_battery}_power",
+        config_entry=config_entry,
+    )
+    active_ac_battery_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_ac_battery_{active_ac_battery}_power",
+        config_entry=config_entry,
+    )
+    stale_inverter_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_inverter_{inactive_inverter}_lifetime_energy",
+        config_entry=config_entry,
+    )
+
+    assert _prune_inactive_serial_entities(hass, config_entry, coord, site_id) == 5
+
+    assert ent_reg.async_get(stale_sensor.entity_id) is None
+    assert ent_reg.async_get(stale_binary.entity_id) is None
+    assert ent_reg.async_get(stale_battery_sensor.entity_id) is None
+    assert ent_reg.async_get(stale_ac_battery_sensor.entity_id) is None
+    assert ent_reg.async_get(stale_inverter_sensor.entity_id) is None
+    assert ent_reg.async_get(active_sensor.entity_id) is not None
+    assert ent_reg.async_get(active_connector_sensor.entity_id) is not None
+    assert ent_reg.async_get(active_authentication_sensor.entity_id) is not None
+    assert ent_reg.async_get(active_battery_sensor.entity_id) is not None
+    assert ent_reg.async_get(active_ac_battery_sensor.entity_id) is not None
+    assert ent_reg.async_get(site_sensor.entity_id) is not None
+    assert ent_reg.async_get(inverter_sensor.entity_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_prune_inactive_serial_entities_skips_unknown_device_families(
+    hass: HomeAssistant, config_entry
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    ent_reg = er.async_get(hass)
+    inactive_serial = "EV-RETIRED"
+    inactive_battery = "BAT-UNKNOWN"
+    inactive_ac_battery = "ACBAT-UNKNOWN"
+    inactive_inverter = "INV-UNKNOWN"
+    coord = SimpleNamespace(
+        _devices_inventory_ready=True,
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda key: key
+            in {"encharge", "ac_battery", "microinverter"}
+        ),
+        battery_has_acb=True,
+        include_inverters=True,
+        _battery_status_payload=None,
+        _ac_battery_devices_payload=None,
+        _inverters_inventory_payload=None,
+        iter_serials=lambda: [RANDOM_SERIAL],
+        iter_battery_serials=lambda: [],
+        iter_ac_battery_serials=lambda: [],
+        iter_inverter_serials=lambda: [],
+    )
+
+    stale_charger_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_{inactive_serial}_charging_amps",
+        config_entry=config_entry,
+    )
+    stale_battery_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_battery_{inactive_battery}_status",
+        config_entry=config_entry,
+    )
+    stale_ac_battery_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_ac_battery_{inactive_ac_battery}_status",
+        config_entry=config_entry,
+    )
+    stale_inverter_sensor = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_inverter_{inactive_inverter}_lifetime_energy",
+        config_entry=config_entry,
+    )
+
+    assert active_serial_registry_identifiers(coord) == {
+        "charger": {RANDOM_SERIAL},
+        "battery": None,
+        "ac_battery": None,
+        "inverter": None,
+    }
+    assert _prune_inactive_serial_entities(hass, config_entry, coord, site_id) == 1
+
+    assert ent_reg.async_get(stale_charger_sensor.entity_id) is None
+    assert ent_reg.async_get(stale_battery_sensor.entity_id) is not None
+    assert ent_reg.async_get(stale_ac_battery_sensor.entity_id) is not None
+    assert ent_reg.async_get(stale_inverter_sensor.entity_id) is not None
+
+
+@pytest.mark.asyncio
+async def test_remove_empty_inactive_serial_devices_waits_for_authoritative_families(
+    hass: HomeAssistant, config_entry
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    dev_reg = dr.async_get(hass)
+    inactive_serial = "SERIAL-UNKNOWN-FAMILY"
+    inactive_device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, inactive_serial)},
+        manufacturer="Enphase",
+        name="Empty Serial Device",
+    )
+    coord = SimpleNamespace(
+        _devices_inventory_ready=True,
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda key: key
+            in {"encharge", "ac_battery", "microinverter"}
+        ),
+        battery_has_acb=True,
+        include_inverters=True,
+        _battery_status_payload=None,
+        _ac_battery_devices_payload=None,
+        _inverters_inventory_payload=None,
+        iter_serials=lambda: [],
+        iter_battery_serials=lambda: [],
+        iter_ac_battery_serials=lambda: [],
+        iter_inverter_serials=lambda: [],
+    )
+
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord, dev_reg, site_id
+        )
+        == 0
+    )
+    assert dev_reg.async_get(inactive_device.id) is not None
+
+
+def test_prune_inactive_serial_entities_handles_guard_paths(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    module = importlib.import_module("custom_components.enphase_ev")
+    coord_not_ready = SimpleNamespace(
+        _devices_inventory_ready=False,
+        iter_serials=lambda: [],
+    )
+
+    assert (
+        _prune_inactive_serial_entities(hass, config_entry, coord_not_ready, site_id)
+        == 0
+    )
+    assert charger_entity_serial_from_unique_id(None, ("_power",)) is None
+    assert charger_entity_serial_from_unique_id("other_EV_power", ("_power",)) is None
+    assert (
+        charger_entity_serial_from_unique_id(f"{DOMAIN}_EV_unknown", ("_power",))
+        is None
+    )
+
+    coord_ready = SimpleNamespace(
+        _devices_inventory_ready=True,
+        iter_serials=lambda: [],
+    )
+    original_er = module.er
+    monkeypatch.setattr(module, "er", None)
+    assert (
+        _prune_inactive_serial_entities(hass, config_entry, coord_ready, site_id) == 0
+    )
+    monkeypatch.setattr(module, "er", original_er)
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er.async_get",
+        lambda _hass: (_ for _ in ()).throw(RuntimeError("registry boom")),
+    )
+    assert (
+        _prune_inactive_serial_entities(hass, config_entry, coord_ready, site_id) == 0
+    )
+
+    removed: list[str] = []
+
+    class FakeRegistry:
+        entities = {
+            "light.skip": SimpleNamespace(
+                entity_id="light.skip",
+                domain="light",
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_EVOLD_power",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "sensor.wrong_entry": SimpleNamespace(
+                entity_id="sensor.wrong_entry",
+                domain="sensor",
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_EVOLD_power",
+                config_entry_id="other-entry",
+            ),
+            "sensor.no_entity_id": SimpleNamespace(
+                entity_id=None,
+                domain="sensor",
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_EVOLD_power",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "sensor.raise": SimpleNamespace(
+                entity_id="sensor.raise",
+                domain="sensor",
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_EVOLD_status",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "sensor.domain_from_entity": SimpleNamespace(
+                entity_id="sensor.domain_from_entity",
+                domain=None,
+                platform=DOMAIN,
+                unique_id=f"{DOMAIN}_EVOLD_charging_amps",
+                config_entry_id=config_entry.entry_id,
+            ),
+        }
+
+        def async_remove(self, entity_id):
+            if entity_id == "sensor.raise":
+                raise RuntimeError("remove boom")
+            removed.append(entity_id)
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er.async_get",
+        lambda _hass: FakeRegistry(),
+    )
+
+    assert (
+        _prune_inactive_serial_entities(hass, config_entry, coord_ready, site_id) == 1
+    )
+    assert removed == ["sensor.domain_from_entity"]
+
+
+def test_serial_registry_identifier_helpers_cover_edge_paths(config_entry) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+
+    class BadIter:
+        def __iter__(self):
+            raise RuntimeError("boom")
+
+    class BadSelected(tuple):
+        def __iter__(self):
+            raise RuntimeError("selected boom")
+
+    class BadSite:
+        def __str__(self) -> str:
+            raise RuntimeError("site boom")
+
+    class EmptyCoord:
+        pass
+
+    def _raise_type(_key):
+        raise RuntimeError("type boom")
+
+    assert inventory_type_available_for_cleanup(EmptyCoord(), "encharge") is None
+    assert (
+        inventory_type_available_for_cleanup(
+            SimpleNamespace(
+                inventory_view=SimpleNamespace(has_type_for_entities=_raise_type)
+            ),
+            "encharge",
+        )
+        is None
+    )
+    assert inventory_type_selected_for_cleanup(EmptyCoord(), " ") is False
+    assert (
+        inventory_type_selected_for_cleanup(
+            SimpleNamespace(_selected_type_keys=BadSelected(("encharge",))),
+            "encharge",
+        )
+        is True
+    )
+    assert inventory_type_bucket_for_cleanup(EmptyCoord(), " ") is None
+    assert (
+        inventory_type_bucket_empty_for_cleanup(
+            SimpleNamespace(_type_device_buckets={"encharge": {"devices": []}}),
+            "encharge",
+        )
+        is False
+    )
+    assert serials_from_getter(None) is None
+    assert active_serial_registry_identifiers(
+        SimpleNamespace(_devices_inventory_ready=False)
+    ) == {
+        "charger": None,
+        "battery": None,
+        "ac_battery": None,
+        "inverter": None,
+    }
+    assert (
+        active_serial_registry_identifiers(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                _active_inventory_evse_serials=lambda: (_ for _ in ()).throw(
+                    RuntimeError("evse boom")
+                ),
+            )
+        )["charger"]
+        is None
+    )
+    assert (
+        active_serial_registry_identifiers(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                _active_inventory_evse_serials=lambda: None,
+            )
+        )["charger"]
+        is None
+    )
+    assert (
+        active_serial_registry_identifiers(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda key: key == "ac_battery"
+                ),
+                battery_has_acb=False,
+                iter_serials=lambda: [],
+            )
+        )["ac_battery"]
+        == set()
+    )
+    assert (
+        active_serial_registry_identifiers(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                include_inverters=False,
+                iter_serials=lambda: [],
+            )
+        )["inverter"]
+        == set()
+    )
+    assert active_charger_serials_for_cleanup(
+        SimpleNamespace(_devices_inventory_ready=True, iter_serials=lambda: ["EV-1"])
+    ) == {"EV-1"}
+    assert active_battery_serials_for_cleanup(
+        SimpleNamespace(
+            _devices_inventory_ready=True,
+            inventory_view=SimpleNamespace(
+                has_type_for_entities=lambda key: key == "encharge"
+            ),
+            _battery_status_payload={},
+            iter_battery_serials=lambda: ["BAT-1"],
+        )
+    ) == {"BAT-1"}
+    assert (
+        active_battery_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False
+                ),
+                iter_battery_serials=lambda: ["BAT-STALE"],
+            )
+        )
+        is None
+    )
+    assert (
+        active_battery_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                _selected_type_keys={"iqevse"},
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False
+                ),
+                iter_battery_serials=lambda: ["BAT-STALE"],
+            )
+        )
+        == set()
+    )
+    assert (
+        active_battery_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False
+                ),
+                _battery_status_payload={},
+                iter_battery_serials=lambda: [],
+            )
+        )
+        == set()
+    )
+    assert (
+        active_battery_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                _selected_type_keys={"encharge"},
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False,
+                    type_bucket=lambda _key: {"count": "bad", "devices": []},
+                ),
+                iter_battery_serials=lambda: ["BAT-STALE"],
+            )
+        )
+        is None
+    )
+    assert (
+        active_battery_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                _selected_type_keys={"encharge"},
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False,
+                    type_bucket=lambda _key: {"count": 0, "devices": "bad"},
+                ),
+                iter_battery_serials=lambda: ["BAT-STALE"],
+            )
+        )
+        is None
+    )
+    assert (
+        active_battery_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                _selected_type_keys={"encharge"},
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False,
+                    type_bucket=lambda _key: {"count": 0, "devices": []},
+                ),
+                iter_battery_serials=lambda: ["BAT-STALE"],
+            )
+        )
+        == set()
+    )
+    assert active_ac_battery_serials_for_cleanup(
+        SimpleNamespace(
+            _devices_inventory_ready=True,
+            inventory_view=SimpleNamespace(
+                has_type_for_entities=lambda key: key == "ac_battery"
+            ),
+            battery_has_acb=True,
+            _ac_battery_devices_payload={},
+            iter_ac_battery_serials=lambda: ["ACBAT-1"],
+        )
+    ) == {"ACBAT-1"}
+    assert (
+        active_ac_battery_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False
+                ),
+                battery_has_acb=True,
+                iter_ac_battery_serials=lambda: ["ACBAT-STALE"],
+            )
+        )
+        is None
+    )
+    assert (
+        active_ac_battery_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                _selected_type_keys={"iqevse"},
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False
+                ),
+                battery_has_acb=True,
+                iter_ac_battery_serials=lambda: ["ACBAT-STALE"],
+            )
+        )
+        == set()
+    )
+    assert (
+        active_ac_battery_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False
+                ),
+                battery_has_acb=True,
+                _ac_battery_devices_payload={},
+                iter_ac_battery_serials=lambda: [],
+            )
+        )
+        == set()
+    )
+    assert active_inverter_serials_for_cleanup(
+        SimpleNamespace(
+            _devices_inventory_ready=True,
+            inventory_view=SimpleNamespace(
+                has_type_for_entities=lambda key: key == "microinverter"
+            ),
+            include_inverters=True,
+            _inverters_inventory_payload={},
+            iter_inverter_serials=lambda: ["INV-1"],
+        )
+    ) == {"INV-1"}
+    assert (
+        active_inverter_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False
+                ),
+                include_inverters=True,
+                iter_inverter_serials=lambda: ["INV-STALE"],
+            )
+        )
+        is None
+    )
+    assert (
+        active_inverter_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                _selected_type_keys={"iqevse"},
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False
+                ),
+                include_inverters=True,
+                iter_inverter_serials=lambda: ["INV-STALE"],
+            )
+        )
+        == set()
+    )
+    assert (
+        active_inverter_serials_for_cleanup(
+            SimpleNamespace(
+                _devices_inventory_ready=True,
+                inventory_view=SimpleNamespace(
+                    has_type_for_entities=lambda _key: False
+                ),
+                include_inverters=True,
+                _inverters_inventory_payload={},
+                iter_inverter_serials=lambda: [],
+            )
+        )
+        == set()
+    )
+
+    coord = SimpleNamespace(
+        _devices_inventory_ready=True,
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda key: key == "encharge"
+        ),
+        _battery_status_payload={},
+        iter_serials=lambda: BadIter(),
+        iter_battery_serials=lambda: [None, " BAT-1 "],
+        iter_ac_battery_serials=lambda: [],
+        iter_inverter_serials=lambda: [],
+    )
+
+    assert all_active_serial_registry_identifiers(coord) == {"BAT-1"}
+    assert (
+        prefixed_serial_from_unique_id(
+            f"{DOMAIN}_site_{site_id}_battery_overall_status",
+            prefix=f"{DOMAIN}_site_{site_id}_battery_",
+            suffixes=("_status",),
+            blocked_unique_ids={f"{DOMAIN}_site_{site_id}_battery_overall_status"},
+        )
+        is None
+    )
+    assert (
+        prefixed_serial_from_unique_id(
+            f"{DOMAIN}_site_{site_id}_battery_BAT-1_unknown",
+            prefix=f"{DOMAIN}_site_{site_id}_battery_",
+            suffixes=("_status",),
+        )
+        is None
+    )
+    assert (
+        _serial_entity_group_from_unique_id(
+            f"{DOMAIN}_site_{site_id}_battery_BAT-1_status",
+            domain="sensor",
+            site_id=BadSite(),
+        )
+        is None
+    )
+
+
+def test_remove_empty_inactive_serial_devices_handles_guard_paths(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    module = importlib.import_module("custom_components.enphase_ev")
+    coord_not_ready = SimpleNamespace(
+        _devices_inventory_ready=False,
+        iter_serials=lambda: [],
+    )
+    dev_reg = SimpleNamespace(async_remove_device=Mock())
+
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord_not_ready, dev_reg, "site-1"
+        )
+        == 0
+    )
+
+    original_er = module.er
+    monkeypatch.setattr(module, "er", None)
+    coord_ready = SimpleNamespace(
+        _devices_inventory_ready=True,
+        _selected_type_keys={"iqevse"},
+        inventory_view=SimpleNamespace(has_type_for_entities=lambda _key: False),
+        iter_serials=lambda: [],
+        iter_battery_serials=lambda: [],
+        iter_ac_battery_serials=lambda: [],
+        iter_inverter_serials=lambda: [],
+    )
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord_ready, dev_reg, "site-1"
+        )
+        == 0
+    )
+    monkeypatch.setattr(module, "er", original_er)
+
+    ent_reg = SimpleNamespace(entities={})
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er.async_get",
+        lambda _hass: ent_reg,
+    )
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass,
+            config_entry,
+            coord_ready,
+            SimpleNamespace(devices={}),
+            "site-1",
+        )
+        == 0
+    )
+
+    class BadIdentifier:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    devices = {
+        "foreign-entry": SimpleNamespace(
+            id="foreign-entry",
+            config_entries={"other-entry"},
+            identifiers={(DOMAIN, "EV-FOREIGN")},
+        ),
+        "no-identifiers": SimpleNamespace(
+            id="no-identifiers",
+            config_entries={config_entry.entry_id},
+            identifiers=set(),
+        ),
+        "other-domain": SimpleNamespace(
+            id="other-domain",
+            config_entries={config_entry.entry_id},
+            identifiers={("other", "EV-OTHER")},
+        ),
+        "bad-identifier": SimpleNamespace(
+            id="bad-identifier",
+            config_entries={config_entry.entry_id},
+            identifiers={(DOMAIN, BadIdentifier())},
+        ),
+        "no-id": SimpleNamespace(
+            id=None,
+            config_entries={config_entry.entry_id},
+            identifiers={(DOMAIN, "EV-NO-ID")},
+        ),
+        "remove-fails": SimpleNamespace(
+            id="remove-fails",
+            config_entries={config_entry.entry_id},
+            identifiers={(DOMAIN, "EV-REMOVE-FAILS")},
+        ),
+    }
+    dev_reg_failing_remove = SimpleNamespace(
+        devices=devices,
+        async_remove_device=lambda _device_id: (_ for _ in ()).throw(
+            RuntimeError("remove failed")
+        ),
+    )
+
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord_ready, dev_reg_failing_remove, "site-1"
+        )
+        == 0
+    )
+    monkeypatch.setattr(module, "er", original_er)
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er.async_get",
+        lambda _hass: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord_ready, dev_reg, "site-1"
+        )
+        == 0
+    )

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -746,6 +746,19 @@ async def test_select_platform_async_setup_entry_filters_known_serials(
 
     coord._ensure_serial_tracked("2222")
     coord.data["2222"] = {"sn": "2222", "name": "Driveway"}
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "iqevse": {
+                "type_label": "EV Chargers",
+                "count": 2,
+                "devices": [
+                    {"serial_number": "1111"},
+                    {"serial_number": "2222"},
+                ],
+            }
+        },
+        ["iqevse"],
+    )
     listeners[0]()
 
     assert len(added) == 1

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -52,6 +52,32 @@ def _mk_coord(sn: str, payload: dict[str, Any]) -> Any:
     return coord
 
 
+def _mark_battery_status_ready(coord: Any) -> None:
+    coord._battery_status_payload = {}  # noqa: SLF001
+
+
+def _mark_inverter_inventory_ready(coord: Any) -> None:
+    coord._inverters_inventory_payload = {}  # noqa: SLF001
+
+
+def test_ac_battery_status_fallback_serials_guard_paths() -> None:
+    coord = SimpleNamespace(
+        battery_has_acb=True,
+        inventory_view=SimpleNamespace(has_type_for_entities=lambda _key: True),
+        ac_battery_status_summary={"status_source": "battery_status"},
+    )
+
+    assert sensor_mod._ac_battery_status_fallback_serials_for_setup(coord) is None
+
+    class BadSerial:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    coord.iter_ac_battery_serials = lambda: [BadSerial()]
+
+    assert sensor_mod._ac_battery_status_fallback_serials_for_setup(coord) is None
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_registers_entities(
     hass, config_entry, coordinator_factory, monkeypatch
@@ -97,6 +123,19 @@ async def test_async_setup_entry_registers_entities(
     new_sn = "NEWSN123"
     coord.data[new_sn] = dict(coord.data[RANDOM_SERIAL], sn=new_sn)
     coord.serials.add(new_sn)
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "iqevse": {
+                "type_label": "EV Chargers",
+                "count": 2,
+                "devices": [
+                    {"serial_number": RANDOM_SERIAL},
+                    {"serial_number": new_sn},
+                ],
+            }
+        },
+        ["iqevse"],
+    )
     sync_topology_cb()
     assert len({ent._sn for ent in added if hasattr(ent, "_sn")}) == 2
 
@@ -112,10 +151,12 @@ async def test_async_setup_entry_restored_topology_adds_dynamic_entities(
         "BAT-1": {"serial_number": "BAT-1", "name": "Battery 1"}
     }
     coord._battery_storage_order = ["BAT-1"]  # noqa: SLF001
+    _mark_battery_status_ready(coord)
     coord._inverter_data = {  # noqa: SLF001
         "INV-1": {"serial_number": "INV-1", "name": "Inverter 1"}
     }
     coord._inverter_order = ["INV-1"]  # noqa: SLF001
+    _mark_inverter_inventory_ready(coord)
     coord._restored_site_energy_channels = {"heat_pump"}  # noqa: SLF001
     coord._restored_gateway_iq_energy_router_records = [  # noqa: SLF001
         {
@@ -200,6 +241,7 @@ async def test_async_setup_entry_backfills_storm_guard_sensor_when_battery_appea
         "BAT-1": {"serial_number": "BAT-1", "name": "Battery 1"}
     }
     coord._battery_storage_order = ["BAT-1"]  # noqa: SLF001
+    _mark_battery_status_ready(coord)
 
     sync_topology_cb = next(
         cb for cb in callbacks if cb.__name__ == "_async_sync_topology"
@@ -537,6 +579,7 @@ async def test_async_setup_entry_adds_battery_storage_sensors(
         },
     }
     coord._battery_storage_order = ["BAT-1", "BAT-2"]  # noqa: SLF001
+    _mark_battery_status_ready(coord)
     coord._battery_aggregate_charge_pct = 47.5  # noqa: SLF001
     coord._battery_aggregate_status = "normal"  # noqa: SLF001
     coord._battery_aggregate_status_details = {  # noqa: SLF001
@@ -613,6 +656,7 @@ async def test_async_setup_entry_removes_battery_entity_on_serial_drop(
         }
     }
     coord._battery_storage_order = ["BAT-REMOVE"]  # noqa: SLF001
+    _mark_battery_status_ready(coord)
     callbacks: list[Any] = []
 
     def fake_add_listener(cb):
@@ -643,6 +687,7 @@ async def test_async_setup_entry_removes_battery_entity_on_serial_drop(
 
     coord._battery_storage_data = {}  # noqa: SLF001
     coord._battery_storage_order = []  # noqa: SLF001
+    _mark_battery_status_ready(coord)
     for callback in callbacks:
         callback()
 
@@ -660,6 +705,7 @@ async def test_async_setup_entry_removes_stale_battery_entity_after_restart(
     coord = coordinator_factory(serials=[RANDOM_SERIAL])
     coord._battery_storage_data = {}  # noqa: SLF001
     coord._battery_storage_order = []  # noqa: SLF001
+    _mark_battery_status_ready(coord)
     coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
@@ -687,6 +733,185 @@ async def test_async_setup_entry_removes_stale_battery_entity_after_restart(
     await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
 
     assert removed_ids == ["sensor.bat_old_status"]
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_waits_for_authoritative_serial_family_payloads_before_prune(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.const import DOMAIN
+    from custom_components.enphase_ev.sensor import async_setup_entry
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._battery_status_payload = None  # noqa: SLF001
+    coord._ac_battery_devices_payload = None  # noqa: SLF001
+    coord._inverters_inventory_payload = None  # noqa: SLF001
+    coord._battery_has_acb = True  # noqa: SLF001
+    coord.include_inverters = True
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "encharge": {"type_label": "Batteries", "count": 1, "devices": []},
+            "ac_battery": {"type_label": "AC Battery", "count": 1, "devices": []},
+            "microinverter": {
+                "type_label": "Microinverters",
+                "count": 1,
+                "devices": [],
+            },
+        },
+        ["encharge", "ac_battery", "microinverter"],
+    )
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    removed_ids: list[str] = []
+
+    class FakeRegistry:
+        def __init__(self) -> None:
+            self.entities = {
+                "sensor.bat_unknown": SimpleNamespace(
+                    entity_id="sensor.bat_unknown",
+                    domain="sensor",
+                    platform=DOMAIN,
+                    unique_id=f"{DOMAIN}_site_{coord.site_id}_battery_BAT-OLD_status",
+                    config_entry_id=config_entry.entry_id,
+                ),
+                "sensor.ac_bat_unknown": SimpleNamespace(
+                    entity_id="sensor.ac_bat_unknown",
+                    domain="sensor",
+                    platform=DOMAIN,
+                    unique_id=f"{DOMAIN}_site_{coord.site_id}_ac_battery_ACBAT-OLD_status",
+                    config_entry_id=config_entry.entry_id,
+                ),
+                "sensor.inv_unknown": SimpleNamespace(
+                    entity_id="sensor.inv_unknown",
+                    domain="sensor",
+                    platform=DOMAIN,
+                    unique_id=f"{DOMAIN}_inverter_INV-OLD_lifetime_energy",
+                    config_entry_id=config_entry.entry_id,
+                ),
+            }
+
+        def async_get_entity_id(self, *_args):
+            return None
+
+        def async_remove(self, entity_id):
+            removed_ids.append(entity_id)
+            self.entities.pop(entity_id, None)
+
+    monkeypatch.setattr(sensor_mod.er, "async_get", lambda _hass: FakeRegistry())
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+
+    assert removed_ids == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_ac_battery_status_fallback_without_prune(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.const import DOMAIN
+    from custom_components.enphase_ev.sensor import async_setup_entry
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._battery_has_acb = True  # noqa: SLF001
+    coord._ac_battery_devices_payload = None  # noqa: SLF001
+    coord._ac_battery_data = {  # noqa: SLF001
+        "BAT-AC-1": {
+            "serial_number": "BAT-AC-1",
+            "current_charge_pct": 55.0,
+            "status_normalized": "normal",
+        }
+    }
+    coord._ac_battery_order = ["BAT-AC-1"]  # noqa: SLF001
+    coord._ac_battery_aggregate_status_details = {  # noqa: SLF001
+        "status_source": "battery_status"
+    }
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {"ac_battery": {"type_label": "AC Battery", "count": 1, "devices": []}},
+        ["ac_battery"],
+    )
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    removed_ids: list[str] = []
+
+    class FakeRegistry:
+        def __init__(self) -> None:
+            self.entities = {
+                "sensor.ac_bat_old": SimpleNamespace(
+                    entity_id="sensor.ac_bat_old",
+                    domain="sensor",
+                    platform=DOMAIN,
+                    unique_id=f"{DOMAIN}_site_{coord.site_id}_ac_battery_ACBAT-OLD_status",
+                    config_entry_id=config_entry.entry_id,
+                )
+            }
+
+        def async_get_entity_id(self, *_args):
+            return None
+
+        def async_remove(self, entity_id):
+            removed_ids.append(entity_id)
+            self.entities.pop(entity_id, None)
+
+    monkeypatch.setattr(sensor_mod.er, "async_get", lambda _hass: FakeRegistry())
+
+    added: list[Any] = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+
+    per_ac_prefix = f"{DOMAIN}_site_{coord.site_id}_ac_battery_BAT-AC-1"
+    per_ac_entities = [
+        entity
+        for entity in added
+        if getattr(entity, "unique_id", "").startswith(per_ac_prefix)
+    ]
+    assert len(per_ac_entities) == 6
+    assert removed_ids == []
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_serial_family_sync_returns_when_source_becomes_unknown(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.sensor import async_setup_entry
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    responses = {
+        "battery": [set(), None],
+        "ac_battery": [set(), None],
+        "inverter": [set(), None],
+    }
+
+    def _next_response(key: str):
+        values = responses[key]
+        return values.pop(0) if values else None
+
+    monkeypatch.setattr(
+        sensor_mod,
+        "active_battery_serials_for_cleanup",
+        lambda _coord: _next_response("battery"),
+    )
+    monkeypatch.setattr(
+        sensor_mod,
+        "active_ac_battery_serials_for_cleanup",
+        lambda _coord: _next_response("ac_battery"),
+    )
+    monkeypatch.setattr(
+        sensor_mod,
+        "active_inverter_serials_for_cleanup",
+        lambda _coord: _next_response("inverter"),
+    )
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+
+    assert responses == {"battery": [], "ac_battery": [], "inverter": []}
 
 
 @pytest.mark.asyncio
@@ -802,6 +1027,7 @@ async def test_async_setup_entry_keeps_current_battery_entity(
         }
     }
     coord._battery_storage_order = ["BAT-KEEP"]  # noqa: SLF001
+    _mark_battery_status_ready(coord)
     coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
@@ -847,6 +1073,7 @@ async def test_async_setup_entry_prunes_legacy_battery_last_reported_entities_fo
         }
     }
     coord._battery_storage_order = ["BAT-KEEP"]  # noqa: SLF001
+    _mark_battery_status_ready(coord)
     coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
@@ -958,6 +1185,7 @@ async def test_async_setup_entry_adds_inverter_lifetime_sensors(
         }
     }
     coord._inverter_order = ["INV-A"]  # noqa: SLF001
+    _mark_inverter_inventory_ready(coord)
     coord._type_device_buckets = {  # noqa: SLF001
         "microinverter": {
             "type_key": "microinverter",
@@ -1004,6 +1232,7 @@ async def test_async_setup_entry_removes_deleted_inverter_entity(
         "INV-A": {"serial_number": "INV-A", "lifetime_production_wh": 100}
     }
     coord._inverter_order = ["INV-A"]  # noqa: SLF001
+    _mark_inverter_inventory_ready(coord)
     callbacks: list[Any] = []
 
     def _add_listener(cb):
@@ -1050,6 +1279,7 @@ async def test_async_setup_entry_removes_deleted_inverter_entity(
 
     coord._inverter_data = {}  # noqa: SLF001
     coord._inverter_order = []  # noqa: SLF001
+    _mark_inverter_inventory_ready(coord)
     sync_inverters()
 
     assert removed_ids == ["sensor.inv_a_lifetime_energy"]
@@ -1063,6 +1293,8 @@ async def test_async_setup_entry_removes_stale_inverter_entity_after_restart(
     from custom_components.enphase_ev.sensor import async_setup_entry
 
     coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._inverters_inventory_payload = {"inverters": []}  # noqa: SLF001
     coord._inverter_data = {}  # noqa: SLF001
     coord._inverter_order = []  # noqa: SLF001
     coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
@@ -1102,6 +1334,8 @@ async def test_async_setup_entry_registry_cleanup_filters_irrelevant_entries(
     from custom_components.enphase_ev.sensor import async_setup_entry
 
     coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._inverters_inventory_payload = {"inverters": []}  # noqa: SLF001
     coord._inverter_data = {}  # noqa: SLF001
     coord._inverter_order = []  # noqa: SLF001
     coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]

--- a/tests/components/enphase_ev/test_sensor_registry.py
+++ b/tests/components/enphase_ev/test_sensor_registry.py
@@ -63,6 +63,14 @@ def _helper(registry: object) -> EnphaseSensorRegistrySetup:
 def test_sensor_registry_serial_parsers_ignore_non_string_unique_ids() -> None:
     helper = _helper(SimpleNamespace())
 
+    assert (
+        helper.battery_sensor_unique_id("BAT-1", "_status")
+        == f"{DOMAIN}_site_{SITE_ID}_battery_BAT-1_status"
+    )
+    assert (
+        helper.ac_battery_sensor_unique_id("ACBAT-1", "_status")
+        == f"{DOMAIN}_site_{SITE_ID}_ac_battery_ACBAT-1_status"
+    )
     assert helper.battery_serial_from_unique_id(None) is None
     assert helper.ac_battery_serial_from_unique_id(None) is None
 
@@ -176,6 +184,85 @@ def test_sensor_registry_prunes_historical_and_removed_site_entities() -> None:
     assert "battery_inactive_microinverters" not in helper.known_site_entity_keys
 
 
+def test_sensor_registry_prunes_removed_charger_sensor_entities() -> None:
+    registry = FakeRegistry(
+        {
+            "sensor.old_power": _entry(
+                "sensor.old_power",
+                f"{DOMAIN}_EVOLD_power",
+            ),
+            "sensor.old_status": _entry(
+                "sensor.old_status",
+                f"{DOMAIN}_EVOLD_status",
+            ),
+            "sensor.keep_power": _entry(
+                "sensor.keep_power",
+                f"{DOMAIN}_EVKEEP_power",
+            ),
+            "sensor.keep_connector_status": _entry(
+                "sensor.keep_connector_status",
+                f"{DOMAIN}_EVKEEP_connector_status",
+            ),
+            "sensor.keep_charger_authentication": _entry(
+                "sensor.keep_charger_authentication",
+                f"{DOMAIN}_EVKEEP_charger_authentication",
+            ),
+            "sensor.missing_power": _entry(
+                "sensor.missing_power",
+                f"{DOMAIN}_EVMISSING_power",
+            ),
+            "sensor.keep_site_status": _entry(
+                "sensor.keep_site_status",
+                f"{DOMAIN}_site_{SITE_ID}_service_status",
+            ),
+            "sensor.ignore_wrong_entry": _entry(
+                "sensor.ignore_wrong_entry",
+                f"{DOMAIN}_EVOTHER_power",
+                config_entry_id="other-entry",
+            ),
+        }
+    )
+    helper = _helper(registry)
+    helper.known_charger_serials.update({"EVKEEP", "EVMISSING"})
+
+    helper.prune_removed_charger_sensor_entities({"EVKEEP"})
+    helper.remove_missing_charger_entities({"EVKEEP"})
+    registry.entities["sensor.lookup_status"] = _entry(
+        "sensor.lookup_status",
+        helper.charger_sensor_unique_id("EVLOOKUP", "_status"),
+    )
+    helper.known_charger_serials.add("EVLOOKUP")
+    helper.remove_missing_charger_entities({"EVKEEP"})
+
+    assert Counter(registry.removed) == Counter(
+        {
+            "sensor.old_power",
+            "sensor.old_status",
+            "sensor.missing_power",
+            "sensor.lookup_status",
+        }
+    )
+    assert helper.known_charger_serials == {"EVKEEP"}
+    assert (
+        helper.charger_serial_from_unique_id(f"{DOMAIN}_EVKEEP_connector_status")
+        == "EVKEEP"
+    )
+    assert (
+        helper.charger_serial_from_unique_id(f"{DOMAIN}_EVKEEP_charger_authentication")
+        == "EVKEEP"
+    )
+    assert helper.charger_serial_from_unique_id("other_EV_power") is None
+    assert (
+        helper.charger_serial_from_unique_id(f"{DOMAIN}_site_{SITE_ID}_service_status")
+        is None
+    )
+    assert (
+        helper.charger_serial_from_unique_id(f"{DOMAIN}_inverter_INV_lifetime_energy")
+        is None
+    )
+    assert helper.charger_serial_from_unique_id(f"{DOMAIN}_EV_unknown") is None
+
+
 def test_sensor_registry_prunes_battery_ac_battery_and_inverter_entities() -> None:
     registry = FakeRegistry(
         {
@@ -207,6 +294,10 @@ def test_sensor_registry_prunes_battery_ac_battery_and_inverter_entities() -> No
                 "sensor.inverter_old_lifetime",
                 f"{DOMAIN}_inverter_INVOLD_lifetime_energy",
             ),
+            "sensor.inverter_keep_lifetime": _entry(
+                "sensor.inverter_keep_lifetime",
+                f"{DOMAIN}_inverter_INVKEEP_lifetime_energy",
+            ),
             "sensor.inverter_missing_lifetime": _entry(
                 "sensor.inverter_missing_lifetime",
                 f"{DOMAIN}_inverter_INVMISSING_lifetime_energy",
@@ -227,8 +318,12 @@ def test_sensor_registry_prunes_battery_ac_battery_and_inverter_entities() -> No
     helper.remove_missing_battery_entities({"KEEP"})
     helper.prune_ac_battery_registry_once({"ACKEEP"})
     helper.remove_missing_ac_battery_entities({"ACKEEP"})
-    helper.prune_inverter_registry_once({"INVKEEP"})
+    assert helper.inverter_lifetime_sensor_unique_id("INV") == (
+        f"{DOMAIN}_inverter_INV_lifetime_energy"
+    )
+    helper.prune_inverter_registry_once({"INVKEEP", "INVMISSING"})
     helper.remove_missing_inverter_entities({"INVKEEP"})
+    helper.prune_inverter_registry_once({"INVKEEP"})
 
     assert Counter(registry.removed) == Counter(
         {

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -1271,6 +1271,7 @@ async def test_sensor_platform_adds_and_prunes_ac_battery_entities(
     coord._selected_type_keys = {"ac_battery"}  # noqa: SLF001
     coord._devices_inventory_ready = True  # noqa: SLF001
     coord._battery_has_acb = True  # noqa: SLF001
+    coord._ac_battery_devices_payload = {}  # noqa: SLF001
     coord._ac_battery_data = {  # noqa: SLF001
         "BAT-AC-1": {
             "serial_number": "BAT-AC-1",

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -581,6 +581,19 @@ async def test_async_setup_entry_syncs_chargers(
         "plugged": True,
     }
     coord._ensure_serial_tracked(new_serial)
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "iqevse": {
+                "type_label": "EV Chargers",
+                "count": 2,
+                "devices": [
+                    {"serial_number": RANDOM_SERIAL},
+                    {"serial_number": new_serial},
+                ],
+            }
+        },
+        ["iqevse"],
+    )
 
     listener()
     charger_entities = [ent for ent in added if hasattr(ent, "_sn")]

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -79,6 +79,8 @@ class DummyCoordinator:
         self._iqevse_version = "25.37.1.13"
         self._listeners = []
         self._available_types = {"envoy", "microinverter", "iqevse"}
+        self._devices_inventory_ready = False
+        self._active_evse_serials: list[str] | None = None
         self._evse_feature_flags = {
             TEST_EVSE_SERIAL: {"iqevse_itk_fw_upgrade_status": True}
         }
@@ -130,6 +132,11 @@ class DummyCoordinator:
         }
 
     def iter_serials(self) -> list[str]:
+        return list(self.data)
+
+    def _active_inventory_evse_serials(self) -> list[str] | None:
+        if self._active_evse_serials is not None:
+            return self._active_evse_serials
         return list(self.data)
 
     def evse_feature_flag_enabled(self, key: str, sn: str | None = None) -> bool | None:
@@ -293,6 +300,7 @@ async def test_async_setup_entry_prunes_removed_charger_entities(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
+    coord._devices_inventory_ready = True
     config_entry.runtime_data = EnphaseRuntimeData(
         coordinator=coord,
         firmware_catalog=DummyCatalogManager(_catalog_payload()),
@@ -324,6 +332,8 @@ async def test_async_setup_entry_prunes_charger_entities_when_type_unavailable(
 ) -> None:
     coord = DummyCoordinator()
     coord._available_types = set()
+    coord._devices_inventory_ready = True
+    coord._active_evse_serials = []
     config_entry.runtime_data = EnphaseRuntimeData(
         coordinator=coord,
         firmware_catalog=DummyCatalogManager(_catalog_payload()),


### PR DESCRIPTION
## Summary

Automatically remove retired Enphase devices and their serial-backed entities from Home Assistant registries when authoritative cloud discovery no longer reports them.

This covers EV chargers and other serial-backed Enphase inventory families while preserving aggregate/site devices, startup safety, and non-authoritative discovery states. The change also centralizes serial discovery and serial entity metadata so registry cleanup is easier to reason about and test.

## Related Issues

N/A

## Type of change

- [x] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/binary_sensor.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/discovery_snapshot.py,custom_components/enphase_ev/entity_cleanup.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/sensor_registry.py,custom_components/enphase_ev/serial_discovery.py,custom_components/enphase_ev/serial_entity_metadata.py,custom_components/enphase_ev/state_models.py,custom_components/enphase_ev/update.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

After rebasing on `origin/main`, also reran:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Manual local HA runtime verification against `.ha-config` showed:

- Retired charger device `e013ed4988835cab126ef00b88b645f4` / serial `482522020944` is no longer in active devices.
- Old charger active entity count is `0`.
- The retired charger remains only in Home Assistant `deleted_devices` / `deleted_entities`, which is expected registry bookkeeping after removal.
- Current charger `IQ EV Charger` / serial `482523013271` remains active with its entities.
- Non-retired aggregate devices remain active: Enphase Cloud, IQ Gateway, IQ Battery, IQ Microinverters, and the current IQ EV Charger.
