### PR TITLE
Prepare release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,30 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- Fixed Storm Guard entities becoming unavailable while Enphase reports the active storm state during a weather alert.
+- None
 
 ### 🔧 Improvements
 - None
 
 ### 🔄 Other changes
 - None
+
+## v3.2.0 - 2026-07-02
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Removed retired Enphase serial-backed devices and entities from Home Assistant registries when authoritative cloud discovery no longer reports them, while preserving aggregate/site devices and non-authoritative discovery states. (#732)
+
+### 🐛 Bug fixes
+- Fixed Storm Guard entities becoming unavailable while Enphase reports the active storm state during a weather alert. (#731)
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `3.2.0`.
 
 ## v3.1.9 - 2026-06-28
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.1.9"
+  "version": "3.2.0"
 }


### PR DESCRIPTION
## Summary

Prepare the `3.2.0` release by bumping the integration manifest version and moving the merged `#731` and `#732` changes into a dated changelog entry.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [x] Other (describe below)

Release metadata and changelog update.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

No targeted coverage command was run because this release prep only touches `CHANGELOG.md` and `custom_components/enphase_ev/manifest.json`; no Python modules changed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The targeted coverage checklist item is not applicable because no Python module was touched.
