### PR TITLE
Add reauth repair coverage

### DIFF
--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -42,14 +42,17 @@ from custom_components.enphase_ev.const import (
     DEFAULT_FAST_POLL_INTERVAL,
     DEFAULT_SLOW_POLL_INTERVAL,
     GREEN_BATTERY_SETTING,
+    ISSUE_AUTH_BLOCKED,
     ISSUE_CLOUD_ERRORS,
     ISSUE_DNS_RESOLUTION,
+    ISSUE_REAUTH_REQUIRED,
     ISSUE_NETWORK_UNREACHABLE,
     ISSUE_AUTH_SETTINGS_UNAVAILABLE,
     ISSUE_HEMS_AUTH_DEGRADED,
     ISSUE_SCHEDULER_UNAVAILABLE,
     ISSUE_SESSION_HISTORY_UNAVAILABLE,
     ISSUE_SITE_ENERGY_UNAVAILABLE,
+    ISSUE_TOO_MANY_ACTIVE_SESSIONS,
     MIN_FAST_POLL_INTERVAL,
     MIN_SLOW_POLL_INTERVAL,
     OPT_DEGRADED_SERVICE_REPAIR_ISSUES,
@@ -4143,6 +4146,25 @@ async def test_handle_client_unauthorized_paths(
         issue[1] == "reauth_required" for issue in mock_issue_registry.created
     )
     assert any(issue[1] == "reauth_required" for issue in mock_issue_registry.deleted)
+
+
+def test_create_reauth_issue_clears_auth_block_repairs(
+    coordinator_factory, mock_issue_registry
+) -> None:
+    coord = coordinator_factory()
+    coord._auth_block_issue_reported = True
+    coord.diagnostics.create_reauth_issue()
+
+    deleted_issue_ids = {issue_id for _domain, issue_id in mock_issue_registry.deleted}
+    assert ISSUE_AUTH_BLOCKED in deleted_issue_ids
+    assert ISSUE_TOO_MANY_ACTIVE_SESSIONS in deleted_issue_ids
+
+    domain, issue_id, payload = mock_issue_registry.created[-1]
+    assert domain == coord_mod.DOMAIN
+    assert issue_id == ISSUE_REAUTH_REQUIRED
+    assert payload["severity"] is coord_diag_mod.ir.IssueSeverity.ERROR
+    assert payload["translation_key"] == ISSUE_REAUTH_REQUIRED
+    assert "site_metrics" in payload["data"]
 
 
 def test_persist_tokens_updates_entry(coordinator_factory, config_entry):


### PR DESCRIPTION
## Summary

Add targeted regression coverage for the coordinator diagnostics reauth repair helper so the integration returns to 100% coverage after syncing with `origin/main`.

The missing path was `CoordinatorDiagnostics.create_reauth_issue()`, which clears existing auth-block repair issues before creating the reauthentication repair issue.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Test coverage only.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_additional_coverage.py::test_create_reauth_issue_clears_auth_block_repairs"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/* --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check tests/components/enphase_ev/test_coordinator_additional_coverage.py"
git diff --check
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Coverage result: `TOTAL 36994 statements, 0 missed, 100% coverage`.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No runtime behavior changes; test coverage only.
