### PR TITLE
Fix gateway firmware catalog filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed IQ Gateway firmware catalog generation so US commercial-only release notes are not advertised to residential/regional gateway update entities. (#735)
 
 ### 🔧 Improvements
 - None

--- a/scripts/firmware_catalog.py
+++ b/scripts/firmware_catalog.py
@@ -45,6 +45,17 @@ TARGET_PRODUCTS: dict[str, dict[str, Any]] = {
     },
 }
 
+COMMERCIAL_ONLY_GATEWAY_TERMS = (
+    "iq gateway commercial 2",
+    "iq gateway commercial pro",
+)
+RESIDENTIAL_GATEWAY_TERMS = (
+    "envoy s",
+    "iq combiner",
+    "iq gateway metered",
+    "residential",
+)
+
 DEFAULT_TIMEOUT = 30
 DEFAULT_MAX_PAGES = 40
 SCHEMA_VERSION = 1
@@ -957,18 +968,29 @@ class ReleaseCardParser(HTMLParser):
         if not text:
             return None
 
-        for label in ("Countries", "Geographies"):
-            marker = f"{label}:"
-            idx = text.lower().find(marker.lower())
-            if idx < 0:
+        for label in (
+            "Countries",
+            "Geographies",
+            "Supported countries",
+            "Supported regions",
+        ):
+            match = re.search(
+                rf"\b{re.escape(label)}\s*:\s*",
+                text,
+                flags=re.IGNORECASE,
+            )
+            if match is None:
                 continue
-            tail = text[idx + len(marker) :].strip()
+            tail = text[match.end() :].strip()
             if not tail:
                 continue
             # Stop at likely next field labels in structured release notes.
             stops = [
+                "# Feature classification",
+                "Batteries supported:",
                 "Platforms supported:",
                 "Microinverters supported:",
+                "Gateways supported:",
                 "Supported system configurations:",
                 "Release notes:",
                 "Release note:",
@@ -1384,6 +1406,16 @@ def release_applies_to_country(
         card.countries_text, alias_map=alias_map
     )
     return country_applicability_matches(applicability, country_code)
+
+
+def release_applies_to_device(card: ReleaseCard, device_key: str) -> bool:
+    if device_key != "envoy":
+        return True
+
+    text = _collapse_ws(f"{card.title} {card.summary}").lower()
+    if not any(term in text for term in COMMERCIAL_ONLY_GATEWAY_TERMS):
+        return True
+    return any(term in text for term in RESIDENTIAL_GATEWAY_TERMS)
 
 
 def _is_same_release_card(left: ReleaseCard, right: ReleaseCard) -> bool:
@@ -1923,6 +1955,9 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
                     device_key,
                     err,
                 )
+            cards = [
+                card for card in cards if release_applies_to_device(card, device_key)
+            ]
             total_count += len(cards)
             target_crawl[str(target["key"])] = {
                 "site_url": target["site_url"],

--- a/tests/scripts/test_firmware_catalog.py
+++ b/tests/scripts/test_firmware_catalog.py
@@ -404,6 +404,19 @@ def test_helper_edge_branches(
         )
         == "United States, Canada"
     )
+    assert (
+        parser._extract_country_text(
+            "Supported regions : United States. # Feature classification Feature"
+        )
+        == "United States"
+    )
+    assert (
+        parser._extract_country_text(
+            "Supported countries: The United States of America, Puerto Rico. "
+            "Gateways supported: IQ Gateway"
+        )
+        == "The United States of America, Puerto Rico"
+    )
     assert parser._extract_country_text("No labels here") is None
     parser._flush_card()
     assert parser.cards == []
@@ -464,6 +477,44 @@ def test_helper_edge_branches(
     ]
     assert firmware_catalog_module._token_to_iso("   ") is None
     assert firmware_catalog_module._token_to_iso("au") == "AU"
+
+    residential_gateway = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (8.3.5421)",
+        version="8.3.5421",
+        release_date="2026-05-29",
+        media_id="residential-gateway",
+        langcode="en",
+        summary=(
+            "The IQ Gateway software version 8.3.5421 introduces support for "
+            "IQ9N Microinverters (residential) in North America."
+        ),
+        countries_text="United States",
+    )
+    commercial_gateway = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (9.1.1188)",
+        version="9.1.1188",
+        release_date="2026-06-10",
+        media_id="commercial-gateway",
+        langcode="en",
+        summary=(
+            "IQ Gateway software version 9.1.1188 addresses stability issues "
+            "for grid-tied systems with IQ9N Microinverters (277 V) and "
+            "IQ Gateway Commercial Pro. Supported regions: United States."
+        ),
+        countries_text="United States",
+    )
+    assert (
+        firmware_catalog_module.release_applies_to_device(residential_gateway, "envoy")
+        is True
+    )
+    assert (
+        firmware_catalog_module.release_applies_to_device(commercial_gateway, "envoy")
+        is False
+    )
+    assert (
+        firmware_catalog_module.release_applies_to_device(commercial_gateway, "iqevse")
+        is True
+    )
 
     mapping = firmware_catalog_module.build_region_country_mapping(
         {
@@ -1600,6 +1651,19 @@ def test_build_catalog_filters_country_scoped_releases(
             "and the Philippines"
         ),
     )
+    commercial_envoy = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (9.1.1188)",
+        version="9.1.1188",
+        release_date="2026-06-10",
+        media_id="commercial-envoy",
+        langcode="und",
+        summary=(
+            "IQ Gateway software version 9.1.1188 addresses stability issues "
+            "for grid-tied systems with IQ9N Microinverters (277 V) and "
+            "IQ Gateway Commercial Pro. Supported regions: United States."
+        ),
+        countries_text="United States",
+    )
     br_scoped_envoy = firmware_catalog_module.ReleaseCard(
         title="Notas de versao do software IQ Gateway (8.2.4401)",
         version="8.2.4401",
@@ -1621,7 +1685,7 @@ def test_build_catalog_filters_country_scoped_releases(
 
     def _fake_crawl_release_cards(**kwargs):
         if kwargs["product_media_name_id"] == 5002 and kwargs["search_locale"] == "en":
-            return [scoped_envoy, worldwide_envoy], [
+            return [commercial_envoy, scoped_envoy, worldwide_envoy], [
                 f"https://example.test/envoy/{kwargs['search_locale']}"
             ]
         if (


### PR DESCRIPTION
## Summary

Fixes #735.

The firmware catalog generator now recognizes Enphase release-note applicability written as `Supported regions:` or `Supported countries:`. It also filters generic IQ Gateway catalog candidates that are explicitly scoped to commercial-only gateway products, preventing the US commercial `9.1.1188` release from being advertised to AU residential IQ Gateway systems.

## Related Issues

Fixes #735

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black scripts/firmware_catalog.py tests/scripts/test_firmware_catalog.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/scripts/test_firmware_catalog.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:delegated ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Manual live-page sanity check confirmed the current Enphase AU page parses `8.3.5528` as Australia/New Zealand applicable and the US `9.1.1188` commercial release is rejected for the generic gateway catalog.

No `custom_components/enphase_ev` Python modules were touched, so targeted integration coverage reporting was not applicable.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The published firmware catalog branch will need regeneration after merge so Home Assistant instances fetch the corrected runtime catalog data.
