### PR TITLE
Fix service status badge probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Fixed IQ Gateway firmware catalog generation so US commercial-only release notes are not advertised to residential/regional gateway update entities. (#735)
+- Fixed the Enphase Service Status badge so expected 4xx responses from ancillary Enphase probes no longer publish the service as down while Home Assistant reports the cloud service as OK.
 
 ### 🔧 Improvements
 - None

--- a/scripts/service_status.py
+++ b/scripts/service_status.py
@@ -28,7 +28,6 @@ DEFAULT_WIKI_PAGE = "Service-Status-History.md"
 MIN_VISIBLE_INCIDENT_MINUTES = 60
 MAX_INCIDENT_SAMPLE_GAP_MINUTES = 90
 DEFAULT_REPOSITORY = "barneyonline/ha-enphase-energy"
-DOWN_FAILED_AFFECTING_CHECK_THRESHOLD = 2
 BROAD_OUTAGE_FAILED_CHECK_THRESHOLD = 3
 BROAD_OUTAGE_ENDPOINT_CATEGORIES = frozenset(
     {
@@ -555,9 +554,6 @@ def _evaluate_status(results: list[dict[str, Any]]) -> tuple[str, dict[str, Any]
     all_down = bool(affecting) and all(not c["ok"] for c in affecting)
     main_down = any(c["group"] == "main" for c in failed_affecting)
     degraded_down = any(c["group"] in ("degraded", "other") for c in failed_affecting)
-    multiple_affecting_down = (
-        len(failed_affecting) >= DOWN_FAILED_AFFECTING_CHECK_THRESHOLD
-    )
     failed_broad_outage_checks = [
         c for c in failed_checks if c.get("affects_broad_outage")
     ]
@@ -565,9 +561,9 @@ def _evaluate_status(results: list[dict[str, Any]]) -> tuple[str, dict[str, Any]
         len(failed_broad_outage_checks) >= BROAD_OUTAGE_FAILED_CHECK_THRESHOLD
     )
 
-    if main_down or all_down or multiple_affecting_down or broad_outage:
+    if main_down or all_down:
         status = "Down"
-    elif degraded_down:
+    elif degraded_down or broad_outage:
         status = "Degraded"
     else:
         status = "Fully Operational"
@@ -1447,6 +1443,7 @@ def main() -> int:
             group="degraded",
             category="evse_scheduler",
             headers=dict(control_headers),
+            ok_statuses=(200, 400, 401, 403, 404, 422),
         ),
         EndpointSpec(
             name="scheduler_green_settings",
@@ -1458,6 +1455,7 @@ def main() -> int:
             group="degraded",
             category="evse_scheduler",
             headers=dict(control_headers),
+            ok_statuses=(200, 400, 401, 403, 404, 422),
         ),
         EndpointSpec(
             name="scheduler_schedules",
@@ -1469,6 +1467,7 @@ def main() -> int:
             group="degraded",
             category="evse_scheduler",
             headers=dict(control_headers),
+            ok_statuses=(200, 400, 401, 403, 404, 422),
         ),
         EndpointSpec(
             name="session_history_criteria",
@@ -1477,6 +1476,7 @@ def main() -> int:
             group="degraded",
             category="session_history",
             headers=dict(history_headers),
+            ok_statuses=(200, 400, 401, 403, 404, 422),
         ),
         EndpointSpec(
             name="session_history",
@@ -1495,6 +1495,7 @@ def main() -> int:
                     "timezone": "UTC",
                 },
             },
+            ok_statuses=(200, 400, 401, 403, 404, 422),
         ),
         EndpointSpec(
             name="site_energy",
@@ -1644,7 +1645,7 @@ def main() -> int:
             headers=dict(battery_headers),
             json_body={"scheduleType": "cfg", "forceScheduleOpted": True},
             affects_status=False,
-            ok_statuses=(200, 400, 404, 422),
+            ok_statuses=(200, 400, 401, 403, 404, 422),
         ),
         EndpointSpec(
             name="devices_inventory",
@@ -1816,6 +1817,7 @@ def main() -> int:
                 {"key": "rfidSessionAuthentication"},
                 {"key": "sessionAuthentication"},
             ],
+            ok_statuses=(200, 400, 401, 403, 404, 422),
         ),
     ]
 

--- a/tests/scripts/test_service_status.py
+++ b/tests/scripts/test_service_status.py
@@ -675,7 +675,7 @@ def test_endpoint_result_and_status_evaluation(service_status_module) -> None:
     assert details["summary"]["checks_failed_affecting"] == 1
 
 
-def test_evaluate_status_escalates_multiple_degraded_failures(
+def test_evaluate_status_keeps_multiple_degraded_failures_degraded(
     service_status_module,
 ) -> None:
     status, details = service_status_module._evaluate_status(
@@ -707,12 +707,12 @@ def test_evaluate_status_escalates_multiple_degraded_failures(
         ]
     )
 
-    assert status == "Down"
+    assert status == "Degraded"
     assert details["summary"]["checks_failed"] == 2
     assert details["summary"]["checks_failed_affecting"] == 2
 
 
-def test_evaluate_status_escalates_broad_non_affecting_outage(
+def test_evaluate_status_keeps_broad_non_affecting_outage_degraded(
     service_status_module,
 ) -> None:
     status, details = service_status_module._evaluate_status(
@@ -755,11 +755,88 @@ def test_evaluate_status_escalates_broad_non_affecting_outage(
         ]
     )
 
-    assert status == "Down"
+    assert status == "Degraded"
     assert details["summary"]["checks_failed"] == 3
     assert details["summary"]["checks_failed_affecting"] == 0
     assert details["summary"]["checks_failed_non_affecting"] == 3
     assert details["summary"]["checks_failed_broad_outage"] == 3
+
+
+def test_evaluate_status_keeps_healthy_runtime_with_failed_subservices_degraded(
+    service_status_module,
+) -> None:
+    status, details = service_status_module._evaluate_status(
+        [
+            {
+                "name": "auth",
+                "group": "other",
+                "ok": True,
+                "affects_status": True,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "discovery",
+                "group": "other",
+                "ok": True,
+                "affects_status": True,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "charger_status",
+                "group": "main",
+                "ok": True,
+                "affects_status": True,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "evse_scheduler",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": True,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "session_history",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": True,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "battery_config",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": False,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "auth_settings",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": True,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+        ]
+    )
+
+    assert status == "Degraded"
+    assert details["summary"]["checks_failed"] == 4
+    assert details["summary"]["checks_failed_affecting"] == 3
+    assert details["summary"]["checks_failed_broad_outage"] == 4
 
 
 def test_evaluate_status_ignores_non_affecting_non_broad_outage_failures(
@@ -1259,6 +1336,68 @@ def test_main_success_generates_history_and_wiki(
         not in wiki_text
     )
     assert "raw.example.invalid/service-status/history.json" in wiki_text
+
+
+def test_main_treats_optional_probe_4xx_responses_as_operational(
+    service_status_module, tmp_path: Path, monkeypatch
+) -> None:
+    token = _jwt({"user_id": "user-1", "session_id": "session-1"})
+
+    monkeypatch.setenv("ENPHASE_EMAIL", "user@example.com")
+    monkeypatch.setenv("ENPHASE_PASSWORD", "secret")
+    monkeypatch.setenv("ENPHASE_SITE_ID", "SITE")
+    monkeypatch.delenv("ENPHASE_SERIAL", raising=False)
+    monkeypatch.setattr(
+        service_status_module,
+        "_cookie_header_for",
+        lambda url, jar: (
+            f"XSRF-TOKEN=xsrf-token; enlighten_manager_token_production={token}"
+            if "enlighten" in url
+            else ""
+        ),
+    )
+
+    def fake_request(opener, method, url, **kwargs):  # noqa: ARG001
+        if url == service_status_module.LOGIN_URL:
+            return 200, {}, b'{"session_id":"session-1","success":true}', None
+        if url == f"{service_status_module.ENTREZ_URL}/tokens":
+            return 400, {}, b"{}", "HTTP 400"
+        if url == service_status_module.SITE_SEARCH_URL:
+            return 200, {}, b'[{"site_id":"SITE"}]', None
+        if "ev_chargers/summary" in url:
+            return 200, {}, b'{"data":[{"serial":"SERIAL"}]}', None
+        if url.endswith("/ev_chargers/status"):
+            return 200, {}, b'{"evChargerData":[{"serial":"SERIAL"}]}', None
+        if "/service/evse_scheduler/" in url:
+            return 400, {}, b"{}", "HTTP 400"
+        if "/service/enho_historical_events_ms/" in url and method == "POST":
+            return 404, {}, b"{}", "HTTP 404"
+        if url.endswith("/schedules/isValid"):
+            return 403, {}, b"{}", "HTTP 403"
+        if "ev_charger_config" in url:
+            return 404, {}, b"{}", "HTTP 404"
+        return 200, {}, b"{}", None
+
+    monkeypatch.setattr(service_status_module, "_request", fake_request)
+
+    argv = [
+        "service_status.py",
+        "--output-dir",
+        str(tmp_path / "out"),
+    ]
+    old_argv = sys.argv
+    sys.argv = argv
+    try:
+        result = service_status_module.main()
+    finally:
+        sys.argv = old_argv
+
+    status_payload = json.loads((tmp_path / "out" / "status.json").read_text())
+
+    assert result == 0
+    assert status_payload["status"] == "Fully Operational"
+    assert status_payload["summary"]["checks_failed"] == 0
+    assert status_payload["summary"]["endpoints_failed"] == 0
 
 
 def test_main_checks_hems_endpoints_when_inventory_reports_hems(


### PR DESCRIPTION
## Summary

Fixes the synthetic Enphase Service Status badge so expected 4xx responses from ancillary probes do not publish the overall service as down while Home Assistant reports the cloud service as OK.

The checker now treats scheduler, session history, battery schedule validation, and charger auth-settings 4xx responses as acceptable probe outcomes, matching the integration's handling of unsupported, no-data, or permission-limited optional endpoints. Ancillary 5xx failures still surface as degraded rather than down when the core charger runtime path is healthy.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black scripts/service_status.py tests/scripts/test_service_status.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/service_status.coverage python -m coverage erase && COVERAGE_FILE=/tmp/service_status.coverage python -m coverage run -m pytest tests/scripts/test_service_status.py -q && COVERAGE_FILE=/tmp/service_status.coverage python -m coverage report -m --include=scripts/service_status.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The regular Docker pre-commit command could not see the host worktree Git metadata because this Codex worktree's `.git` file points at an absolute host path outside the compose mount. The listed pre-commit command mounts that Git metadata path explicitly and passed.

Full pytest passed with 3459 tests. Targeted coverage reported `scripts/service_status.py` at 100%.
