### PR TITLE
Add EV charger default charge level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- None
+- Added an IQ EV Charger Default Charge Level number entity for chargers whose Enphase config endpoint exposes the `DefaultChargeLevel` setting.
 
 ### 🐛 Bug fixes
 - Fixed IQ Gateway firmware catalog generation so US commercial-only release notes are not advertised to residential/regional gateway update entities. (#735)
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🔄 Other changes
-- None
+- Documented newly observed EVSE feature flags and the Default Charge Level charger-config endpoint behavior.
 
 ## v3.2.0 - 2026-07-02
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 
 - Guided onboarding for site selection and device-category enablement
 - Unified support for EV chargers, gateway, battery, and microinverter entities
-- EV charging controls and session telemetry, including charge-mode aware behavior
+- EV charging controls and session telemetry, including charge-mode aware behavior and persistent default charge-level controls when exposed by Enphase
 - Advisory firmware update entities for gateway and EV charger devices with locale-aware release-note links
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -31,6 +31,7 @@ from .const import (
     AUTH_APP_SETTING,
     AUTH_RFID_SETTING,
     BASE_URL,
+    DEFAULT_CHARGE_LEVEL_SETTING,
     DEFAULT_AUTH_TIMEOUT,
     ENTREZ_URL,
     GREEN_BATTERY_SETTING,
@@ -195,6 +196,10 @@ class EVSETimeseriesUnavailable(Exception):
 
 class AuthSettingsUnavailable(Exception):
     """Raised when the charger auth settings service is unavailable."""
+
+
+class ChargerConfigUnavailable(Exception):
+    """Raised when the charger config service is unavailable."""
 
 
 class OptionalEndpointUnavailable(Exception):
@@ -5847,6 +5852,27 @@ class EnphaseEVClient:
             if is_auth_settings_unavailable_error(err.message, err.status, url):
                 raise AuthSettingsUnavailable(str(err)) from err
             raise
+
+    async def set_default_charge_level(self, sn: str, amps: int) -> dict:
+        """Set the charger's stored default charge level.
+
+        PUT /service/evse_controller/api/v1/<site>/<sn>/ev_charger_config
+        Body: [{ "key": "DefaultChargeLevel", "value": <amps> }]
+        """
+        url = (
+            f"{BASE_URL}/service/evse_controller/api/v1/{self._site}/ev_chargers/"
+            f"{sn}/ev_charger_config"
+        )
+        headers = self._today_json_headers()
+        headers.update(self._control_headers())
+        payload = [{"key": DEFAULT_CHARGE_LEVEL_SETTING, "value": int(amps)}]
+        try:
+            response = await self._json("PUT", url, json=payload, headers=headers)
+        except aiohttp.ClientResponseError as err:
+            if is_auth_settings_unavailable_error(err.message, err.status, url):
+                raise ChargerConfigUnavailable(str(err)) from err
+            raise
+        return response if isinstance(response, dict) else {}
 
     async def get_schedules(self, sn: str) -> dict:
         """Return scheduler config and slots for the charger.

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -3684,7 +3684,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 if sess.get("auth_token") is not None
                 else sess.get("authToken")
             )
-            config_values = charger_config.get(sn) or {}
+            config_values = charger_config.get(sn)
 
             entry = {
                 "sn": sn,
@@ -3774,14 +3774,20 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 )
                 if previous_lifetime_kwh is not None:
                     entry.setdefault("lifetime_kwh", previous_lifetime_kwh)
-            if PHASE_SWITCH_CONFIG_SETTING in config_values:
-                entry["phase_switch_config"] = config_values[
-                    PHASE_SWITCH_CONFIG_SETTING
-                ]
-            if DEFAULT_CHARGE_LEVEL_SETTING in config_values:
-                entry["default_charge_level"] = config_values[
-                    DEFAULT_CHARGE_LEVEL_SETTING
-                ]
+            if isinstance(config_values, dict):
+                if PHASE_SWITCH_CONFIG_SETTING in config_values:
+                    entry["phase_switch_config"] = config_values[
+                        PHASE_SWITCH_CONFIG_SETTING
+                    ]
+                if DEFAULT_CHARGE_LEVEL_SETTING in config_values:
+                    entry["default_charge_level_supported"] = True
+                    entry["default_charge_level_supported_source"] = "charger_config"
+                    entry["default_charge_level"] = config_values[
+                        DEFAULT_CHARGE_LEVEL_SETTING
+                    ]
+                else:
+                    entry["default_charge_level_supported"] = False
+                    entry["default_charge_level_supported_source"] = "charger_config"
             if green_supported is not None:
                 entry["green_battery_supported"] = green_supported
                 if green_supported:

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -16,10 +16,11 @@ import aiohttp
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 
-from .api import AuthSettingsUnavailable, SchedulerUnavailable
+from .api import AuthSettingsUnavailable, ChargerConfigUnavailable, SchedulerUnavailable
 from .const import (
     AUTH_APP_SETTING,
     AUTH_RFID_SETTING,
+    DEFAULT_CHARGE_LEVEL_SETTING,
     DEFAULT_FAST_POLL_INTERVAL,
     DEFAULT_SLOW_POLL_INTERVAL,
     DOMAIN,
@@ -76,6 +77,7 @@ EVSE_INACTIVE_POWER_STATUSES: frozenset[str] = frozenset(
     {"SUSPENDED", "SUSPENDED_EV", SUSPENDED_EVSE_STATUS}
 )
 EVSE_ACTIVE_POWER_STATUSES: frozenset[str] = frozenset({"CHARGING", "FINISHING"})
+_MISSING_CHARGER_CONFIG_VALUE = object()
 
 
 @dataclass(slots=True)
@@ -1350,7 +1352,11 @@ class EvseRuntime:
             cache_fresh = True
             cached_values = dict(cached[0])
             if all(key in cached_values for key in requested):
-                return {key: cached_values[key] for key in requested}
+                return {
+                    key: cached_values[key]
+                    for key in requested
+                    if cached_values[key] is not _MISSING_CHARGER_CONFIG_VALUE
+                }
         elif cached:
             cached_values = dict(cached[0])
 
@@ -1358,7 +1364,12 @@ class EvseRuntime:
         if backoff_until is not None and backoff_until > now:
             if cache_fresh:
                 return {
-                    key: cached_values[key] for key in requested if key in cached_values
+                    key: cached_values[key]
+                    for key in requested
+                    if (
+                        key in cached_values
+                        and cached_values[key] is not _MISSING_CHARGER_CONFIG_VALUE
+                    )
                 }
             return None
 
@@ -1370,11 +1381,17 @@ class EvseRuntime:
             )
             if cache_fresh:
                 return {
-                    key: cached_values[key] for key in requested if key in cached_values
+                    key: cached_values[key]
+                    for key in requested
+                    if (
+                        key in cached_values
+                        and cached_values[key] is not _MISSING_CHARGER_CONFIG_VALUE
+                    )
                 }
             return None
 
         merged = dict(cached_values)
+        returned_keys: set[str] = set()
         if isinstance(settings, list):
             for item in settings:
                 if not isinstance(item, dict):
@@ -1386,14 +1403,23 @@ class EvseRuntime:
                     continue
                 if key_text not in seen:
                     continue
+                returned_keys.add(key_text)
                 if "value" in item:
                     merged[key_text] = item.get("value")
                 elif "reqValue" in item:
                     merged[key_text] = item.get("reqValue")
+        if isinstance(settings, list):
+            for key in requested:
+                if key not in returned_keys:
+                    merged[key] = _MISSING_CHARGER_CONFIG_VALUE
 
         coord._charger_config_cache[sn] = (merged, now)
         coord._charger_config_backoff_until.pop(sn, None)
-        return {key: merged[key] for key in requested if key in merged}
+        return {
+            key: merged[key]
+            for key in requested
+            if (key in merged and merged[key] is not _MISSING_CHARGER_CONFIG_VALUE)
+        }
 
     def set_charge_mode_cache(self, sn: str, mode: str) -> None:
         normalized = self.normalize_charge_mode_preference(mode)
@@ -1431,6 +1457,23 @@ class EvseRuntime:
             False,
             now,
         )
+
+    @staticmethod
+    def _coerce_charge_level(value: object) -> int | None:
+        if value in (None, ""):
+            return None
+        try:
+            return int(float(str(value).strip()))
+        except Exception:  # noqa: BLE001
+            return None
+
+    def set_default_charge_level_cache(self, sn: str, amps: int) -> None:
+        sn_str = str(sn)
+        now = time.monotonic()
+        cached = self.coordinator._charger_config_cache.get(sn_str)
+        values = dict(cached[0]) if cached else {}
+        values[DEFAULT_CHARGE_LEVEL_SETTING] = int(amps)
+        self.coordinator._charger_config_cache[sn_str] = (values, now)
 
     def _set_evse_toggle_pending(self, attr_name: str, sn: str, enabled: bool) -> None:
         pending = getattr(self.coordinator, attr_name, None)
@@ -1489,6 +1532,39 @@ class EvseRuntime:
         self.coordinator.mark_auth_settings_available()
         self.set_app_auth_cache(sn_str, enabled)
         self._set_evse_toggle_pending("_app_auth_pending", sn_str, enabled)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_default_charge_level(self, sn: str, amps: int) -> None:
+        sn_str = str(sn)
+        try:
+            response = await self.coordinator.client.set_default_charge_level(
+                sn_str,
+                int(amps),
+            )
+        except ChargerConfigUnavailable as err:
+            raise ServiceValidationError(
+                "Default charge level settings are unavailable while the Enphase "
+                "service is down.",
+                translation_domain=DOMAIN,
+                translation_key="default_charge_level_unavailable",
+            ) from err
+
+        accepted_amps = int(amps)
+        data = response.get("data") if isinstance(response, dict) else None
+        if isinstance(data, list):
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("key") != DEFAULT_CHARGE_LEVEL_SETTING:
+                    continue
+                raw_value = item.get("value")
+                if raw_value is None:
+                    raw_value = item.get("reqValue")
+                coerced = self._coerce_charge_level(raw_value)
+                if coerced is not None:
+                    accepted_amps = coerced
+                break
+        self.set_default_charge_level_cache(sn_str, accepted_amps)
         await self.coordinator.async_request_refresh()
 
     async def async_resolve_green_battery_settings(
@@ -1601,12 +1677,16 @@ class EvseRuntime:
                         filtered = {
                             key: cached_values[key]
                             for key in requested
-                            if key in cached_values
+                            if (
+                                key in cached_values
+                                and cached_values[key]
+                                is not _MISSING_CHARGER_CONFIG_VALUE
+                            )
                         }
                         if filtered:
                             results[sn] = filtered
                     continue
-                if response:
+                if response is not None:
                     results[sn] = response
         return results
 
@@ -1724,7 +1804,9 @@ class EvseRuntime:
             cached_values = dict(cached[0])
             if all(key in cached_values for key in requested):
                 results[sn] = {
-                    key: cached_values[key] for key in requested if key in cached_values
+                    key: cached_values[key]
+                    for key in requested
+                    if cached_values[key] is not _MISSING_CHARGER_CONFIG_VALUE
                 }
         return results
 

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -122,6 +122,7 @@ async def async_setup_entry(
     coord: EnphaseCoordinator = get_runtime_data(entry).coordinator
     ent_reg = er.async_get(hass)
     known_serials: set[str] = set()
+    added_default_charge_level_unique_ids: set[str] = set()
     added_site_number_unique_ids: set[str] = set()
 
     def _managed_site_number_unique_ids() -> set[str]:
@@ -148,6 +149,9 @@ async def async_setup_entry(
 
     def _charger_number_unique_id(sn: str) -> str:
         return f"{DOMAIN}_{sn}_amps_number"
+
+    def _default_charge_level_number_unique_id(sn: str) -> str:
+        return f"{DOMAIN}_{sn}_default_charge_level_number"
 
     def _site_number_entities_by_unique_id(
         retained_site_number_unique_ids: set[str],
@@ -226,8 +230,23 @@ async def async_setup_entry(
             entities = []
             for sn in serials:
                 entities.append(ChargingAmpsNumber(coord, sn))
+        for sn in current_serials:
+            data = coord.data.get(sn, {}) if isinstance(coord.data, dict) else {}
+            unique_id = _default_charge_level_number_unique_id(sn)
+            if (
+                isinstance(data, dict)
+                and data.get("default_charge_level_supported") is True
+                and unique_id not in added_default_charge_level_unique_ids
+            ):
+                entities.append(DefaultChargeLevelNumber(coord, sn))
         if entities:
             async_add_entities(entities, update_before_add=False)
+            added_default_charge_level_unique_ids.update(
+                entity.unique_id
+                for entity in entities
+                if isinstance(entity, DefaultChargeLevelNumber)
+                and isinstance(entity.unique_id, str)
+            )
         known_serials.intersection_update(current_serials)
         known_serials.update(serials)
 
@@ -252,6 +271,17 @@ async def async_setup_entry(
         active_charger_unique_ids = {
             _charger_number_unique_id(sn) for sn in current_serials
         }
+        for sn in current_serials:
+            data = coord.data.get(sn, {}) if isinstance(coord.data, dict) else {}
+            unique_id = _default_charge_level_number_unique_id(sn)
+            if isinstance(data, dict) and (
+                data.get("default_charge_level_supported") is True
+                or (
+                    unique_id in added_default_charge_level_unique_ids
+                    and data.get("default_charge_level_supported") is not False
+                )
+            ):
+                active_charger_unique_ids.add(unique_id)
         prune_managed_entities(
             ent_reg,
             entry.entry_id,
@@ -265,7 +295,13 @@ async def async_setup_entry(
             is_managed=lambda unique_id: (
                 unique_id in _managed_site_number_unique_ids()
                 or _tariff_number_managed(unique_id)
-                or unique_id.endswith(("_amps_number", "_schedule_edit_limit"))
+                or unique_id.endswith(
+                    (
+                        "_amps_number",
+                        "_default_charge_level_number",
+                        "_schedule_edit_limit",
+                    )
+                )
             ),
         )
 
@@ -424,6 +460,66 @@ class ChargingAmpsNumber(EnphaseBaseEntity, NumberEntity):
         ):
             # Restart the active session so the updated amps take effect
             self._coord.schedule_amp_restart(self._sn)
+
+
+class DefaultChargeLevelNumber(EnphaseBaseEntity, NumberEntity):
+    _attr_has_entity_name = True
+    _attr_translation_key = "default_charge_level"
+    _attr_native_unit_of_measurement = UnitOfElectricCurrent.AMPERE
+
+    def __init__(self, coord: EnphaseCoordinator, sn: str):
+        super().__init__(coord, sn)
+        self._attr_unique_id = f"{DOMAIN}_{sn}_default_charge_level_number"
+
+    @staticmethod
+    def _coerce_amp(value) -> int | None:
+        return ChargingAmpsNumber._coerce_amp(value)
+
+    @property
+    def available(self) -> bool:  # type: ignore[override]
+        return (
+            super().available
+            and self.data.get("default_charge_level_supported") is True
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        value = self._coerce_amp(self.data.get("default_charge_level"))
+        return float(value) if value is not None else None
+
+    @property
+    def native_min_value(self) -> float:
+        v = self._coerce_amp(self.data.get("min_amp"))
+        return float(v) if v is not None else 6.0
+
+    @property
+    def native_max_value(self) -> float:
+        v = self._coerce_amp(self.data.get("max_amp"))
+        return float(v) if v is not None else 40.0
+
+    @property
+    def native_step(self) -> float:
+        v = self._coerce_amp(self.data.get("amp_granularity"))
+        return float(v) if v is not None and v > 0 else 1.0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object | None]:
+        return {
+            "min_amp": self._coerce_amp(self.data.get("min_amp")),
+            "max_amp": self._coerce_amp(self.data.get("max_amp")),
+            "max_current": self._coerce_amp(self.data.get("max_current")),
+            "amp_granularity": self._coerce_amp(self.data.get("amp_granularity")),
+            "charging_amps": self._coerce_amp(self.data.get("charging_level")),
+            "default_charge_level_supported_source": self.data.get(
+                "default_charge_level_supported_source"
+            ),
+        }
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self._coord.evse_runtime.async_set_default_charge_level(
+            self._sn,
+            int(value),
+        )
 
 
 class BatteryShutdownLevelNumber(CoordinatorEntity, NumberEntity):

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -454,9 +454,14 @@ class RefreshRunner:
                         PHASE_SWITCH_CONFIG_SETTING
                     ]
                 if DEFAULT_CHARGE_LEVEL_SETTING in config_values:
+                    payload["default_charge_level_supported"] = True
+                    payload["default_charge_level_supported_source"] = "charger_config"
                     payload["default_charge_level"] = config_values[
                         DEFAULT_CHARGE_LEVEL_SETTING
                     ]
+                else:
+                    payload["default_charge_level_supported"] = False
+                    payload["default_charge_level_supported_source"] = "charger_config"
         if working_data is None:
             coordinator.async_set_updated_data(merged)
 

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Selected charging mode is not available."
     },
+    "default_charge_level_unavailable": {
+      "message": "Default charge level settings are unavailable while the Enphase service is down."
+    },
     "evse_schedule_day_required": {
       "message": "Select at least one weekday for the schedule."
     },
@@ -1765,6 +1768,9 @@
       },
       "charging_amps": {
         "name": "Charging Amps"
+      },
+      "default_charge_level": {
+        "name": "Default Charge Level"
       },
       "battery_dtg_schedule_limit": {
         "name": "Discharge To Grid Limit"

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Избраният режим на зареждане не е наличен."
     },
+    "default_charge_level_unavailable": {
+      "message": "Настройките за ниво на зареждане по подразбиране не са налични, докато услугата Enphase е недостъпна."
+    },
     "evse_schedule_day_required": {
       "message": "Изберете поне един ден от седмицата за графика."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Ампери за зареждане"
+      },
+      "default_charge_level": {
+        "name": "Ниво на зареждане по подразбиране"
       },
       "battery_reserve": {
         "name": "Резервна батерия"

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Vybraný režim nabíjení není k dispozici."
     },
+    "default_charge_level_unavailable": {
+      "message": "Nastavení výchozí úrovně nabíjení není dostupné, dokud je služba Enphase nedostupná."
+    },
     "evse_schedule_day_required": {
       "message": "Vyberte pro harmonogram alespoň jeden den v týdnu."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Nabíjecí ampéry"
+      },
+      "default_charge_level": {
+        "name": "Výchozí úroveň nabíjení"
       },
       "battery_reserve": {
         "name": "Rezerva baterie"

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Den valgte opladningstilstand er ikke tilgængelig."
     },
+    "default_charge_level_unavailable": {
+      "message": "Indstillinger for standard ladeniveau er ikke tilgængelige, mens Enphase-tjenesten er nede."
+    },
     "evse_schedule_day_required": {
       "message": "Vælg mindst én ugedag for tidsplanen."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Opladningsampere"
+      },
+      "default_charge_level": {
+        "name": "Standard ladeniveau"
       },
       "battery_reserve": {
         "name": "Batterireserve"

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Der ausgewählte Lademodus ist nicht verfügbar."
     },
+    "default_charge_level_unavailable": {
+      "message": "Die Einstellungen für die Standard-Ladestufe sind nicht verfügbar, solange der Enphase-Dienst ausgefallen ist."
+    },
     "evse_schedule_day_required": {
       "message": "Wählen Sie mindestens einen Wochentag für den Zeitplan aus."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Ladestrom"
+      },
+      "default_charge_level": {
+        "name": "Standard-Ladestufe"
       },
       "battery_reserve": {
         "name": "Batteriereserve"

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Η επιλεγμένη λειτουργία φόρτισης δεν είναι διαθέσιμη."
     },
+    "default_charge_level_unavailable": {
+      "message": "Οι ρυθμίσεις προεπιλεγμένου επιπέδου φόρτισης δεν είναι διαθέσιμες όσο η υπηρεσία Enphase δεν λειτουργεί."
+    },
     "evse_schedule_day_required": {
       "message": "Επιλέξτε τουλάχιστον μία ημέρα της εβδομάδας για το πρόγραμμα."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Αμπέρ φόρτισης"
+      },
+      "default_charge_level": {
+        "name": "Προεπιλεγμένο επίπεδο φόρτισης"
       },
       "battery_reserve": {
         "name": "Απόθεμα μπαταρίας"

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Selected charging mode is not available."
     },
+    "default_charge_level_unavailable": {
+      "message": "Default charge level settings are unavailable while the Enphase service is down."
+    },
     "evse_schedule_day_required": {
       "message": "Select at least one weekday for the schedule."
     },
@@ -1765,6 +1768,9 @@
       },
       "charging_amps": {
         "name": "Charging Amps"
+      },
+      "default_charge_level": {
+        "name": "Default Charge Level"
       },
       "battery_dtg_schedule_limit": {
         "name": "Discharge To Grid Limit"

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Selected charging mode is not available."
     },
+    "default_charge_level_unavailable": {
+      "message": "Default charge level settings are unavailable while the Enphase service is down."
+    },
     "evse_schedule_day_required": {
       "message": "Select at least one weekday for the schedule."
     },
@@ -1765,6 +1768,9 @@
       },
       "charging_amps": {
         "name": "Charging Amps"
+      },
+      "default_charge_level": {
+        "name": "Default Charge Level"
       },
       "battery_dtg_schedule_limit": {
         "name": "Discharge To Grid Limit"

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Selected charging mode is not available."
     },
+    "default_charge_level_unavailable": {
+      "message": "Default charge level settings are unavailable while the Enphase service is down."
+    },
     "evse_schedule_day_required": {
       "message": "Select at least one weekday for the schedule."
     },
@@ -1765,6 +1768,9 @@
       },
       "charging_amps": {
         "name": "Charging Amps"
+      },
+      "default_charge_level": {
+        "name": "Default Charge Level"
       },
       "battery_dtg_schedule_limit": {
         "name": "Discharge To Grid Limit"

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Selected charging mode is not available."
     },
+    "default_charge_level_unavailable": {
+      "message": "Default charge level settings are unavailable while the Enphase service is down."
+    },
     "evse_schedule_day_required": {
       "message": "Select at least one weekday for the schedule."
     },
@@ -1765,6 +1768,9 @@
       },
       "charging_amps": {
         "name": "Charging Amps"
+      },
+      "default_charge_level": {
+        "name": "Default Charge Level"
       },
       "battery_dtg_schedule_limit": {
         "name": "Discharge To Grid Limit"

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Selected charging mode is not available."
     },
+    "default_charge_level_unavailable": {
+      "message": "Default charge level settings are unavailable while the Enphase service is down."
+    },
     "evse_schedule_day_required": {
       "message": "Select at least one weekday for the schedule."
     },
@@ -1765,6 +1768,9 @@
       },
       "charging_amps": {
         "name": "Charging Amps"
+      },
+      "default_charge_level": {
+        "name": "Default Charge Level"
       },
       "battery_dtg_schedule_limit": {
         "name": "Discharge To Grid Limit"

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Selected charging mode is not available."
     },
+    "default_charge_level_unavailable": {
+      "message": "Default charge level settings are unavailable while the Enphase service is down."
+    },
     "evse_schedule_day_required": {
       "message": "Select at least one weekday for the schedule."
     },
@@ -1765,6 +1768,9 @@
       },
       "charging_amps": {
         "name": "Charging Amps"
+      },
+      "default_charge_level": {
+        "name": "Default Charge Level"
       },
       "battery_dtg_schedule_limit": {
         "name": "Discharge To Grid Limit"

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "El modo de carga seleccionado no está disponible."
     },
+    "default_charge_level_unavailable": {
+      "message": "La configuración del nivel de carga predeterminado no está disponible mientras el servicio de Enphase no funciona."
+    },
     "evse_schedule_day_required": {
       "message": "Seleccione al menos un día de la semana para el horario."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Amperios de carga"
+      },
+      "default_charge_level": {
+        "name": "Nivel de carga predeterminado"
       },
       "battery_reserve": {
         "name": "Reserva de batería"

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Valitud laadimisrežiim pole saadaval."
     },
+    "default_charge_level_unavailable": {
+      "message": "Vaikimisi laadimistaseme seaded pole saadaval, kuni Enphase'i teenus ei tööta."
+    },
     "evse_schedule_day_required": {
       "message": "Valige ajakava jaoks vähemalt üks nädalapäev."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Laadimisamprid"
+      },
+      "default_charge_level": {
+        "name": "Vaikimisi laadimistase"
       },
       "battery_reserve": {
         "name": "Aku reserv"

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Valittu lataustila ei ole käytettävissä."
     },
+    "default_charge_level_unavailable": {
+      "message": "Oletuslataustason asetukset eivät ole käytettävissä, kun Enphase-palvelu ei ole toiminnassa."
+    },
     "evse_schedule_day_required": {
       "message": "Valitse aikataululle vähintään yksi viikonpäivä."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Latausvahvistimet"
+      },
+      "default_charge_level": {
+        "name": "Oletuslataustaso"
       },
       "battery_reserve": {
         "name": "Akun varaus"

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Le mode de charge sélectionné n’est pas disponible."
     },
+    "default_charge_level_unavailable": {
+      "message": "Les réglages du niveau de charge par défaut sont indisponibles tant que le service Enphase est hors service."
+    },
     "evse_schedule_day_required": {
       "message": "Sélectionnez au moins un jour de la semaine pour la programmation."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Ampères de charge"
+      },
+      "default_charge_level": {
+        "name": "Niveau de charge par défaut"
       },
       "battery_reserve": {
         "name": "Réserve de batterie"

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "A kiválasztott töltési mód nem érhető el."
     },
+    "default_charge_level_unavailable": {
+      "message": "Az alapértelmezett töltési szint beállításai nem érhetők el, amíg az Enphase szolgáltatás nem működik."
+    },
     "evse_schedule_day_required": {
       "message": "Válasszon legalább egy napot a hétből az ütemezéshez."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Töltési amper"
+      },
+      "default_charge_level": {
+        "name": "Alapértelmezett töltési szint"
       },
       "battery_reserve": {
         "name": "Akkumulátor tartalék"

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "La modalità di ricarica selezionata non è disponibile."
     },
+    "default_charge_level_unavailable": {
+      "message": "Le impostazioni del livello di ricarica predefinito non sono disponibili mentre il servizio Enphase non è raggiungibile."
+    },
     "evse_schedule_day_required": {
       "message": "Seleziona almeno un giorno della settimana per la pianificazione."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Ampere di ricarica"
+      },
+      "default_charge_level": {
+        "name": "Livello di ricarica predefinito"
       },
       "battery_reserve": {
         "name": "Riserva della batteria"

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Pasirinktas įkrovimo režimas nepasiekiamas."
     },
+    "default_charge_level_unavailable": {
+      "message": "Numatytojo įkrovimo lygio nustatymai nepasiekiami, kol Enphase paslauga neveikia."
+    },
     "evse_schedule_day_required": {
       "message": "Pasirinkite bent vieną savaitės dieną tvarkaraščiui."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Įkrovimo amperai"
+      },
+      "default_charge_level": {
+        "name": "Numatytasis įkrovimo lygis"
       },
       "battery_reserve": {
         "name": "Baterijos rezervas"

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Izvēlētais uzlādes režīms nav pieejams."
     },
+    "default_charge_level_unavailable": {
+      "message": "Noklusējuma uzlādes līmeņa iestatījumi nav pieejami, kamēr Enphase pakalpojums nedarbojas."
+    },
     "evse_schedule_day_required": {
       "message": "Grafikam izvēlieties vismaz vienu nedēļas dienu."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Uzlādes ampēri"
+      },
+      "default_charge_level": {
+        "name": "Noklusējuma uzlādes līmenis"
       },
       "battery_reserve": {
         "name": "Akumulatora rezerve"

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Den valgte lademodusen er ikke tilgjengelig."
     },
+    "default_charge_level_unavailable": {
+      "message": "Innstillingene for standard ladenivå er ikke tilgjengelige mens Enphase-tjenesten er nede."
+    },
     "evse_schedule_day_required": {
       "message": "Velg minst én ukedag for tidsplanen."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Ladeampere"
+      },
+      "default_charge_level": {
+        "name": "Standard ladenivå"
       },
       "battery_reserve": {
         "name": "Batterireserve"

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "De geselecteerde laadmodus is niet beschikbaar."
     },
+    "default_charge_level_unavailable": {
+      "message": "Instellingen voor het standaard laadniveau zijn niet beschikbaar terwijl de Enphase-service niet beschikbaar is."
+    },
     "evse_schedule_day_required": {
       "message": "Selecteer minstens één weekdag voor het schema."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Laadampère"
+      },
+      "default_charge_level": {
+        "name": "Standaard laadniveau"
       },
       "battery_reserve": {
         "name": "Batterijreserve"

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Wybrany tryb ładowania jest niedostępny."
     },
+    "default_charge_level_unavailable": {
+      "message": "Ustawienia domyślnego poziomu ładowania są niedostępne, gdy usługa Enphase nie działa."
+    },
     "evse_schedule_day_required": {
       "message": "Wybierz co najmniej jeden dzień tygodnia dla harmonogramu."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Ampery ładowania"
+      },
+      "default_charge_level": {
+        "name": "Domyślny poziom ładowania"
       },
       "battery_reserve": {
         "name": "Rezerwa baterii"

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "O modo de carregamento selecionado não está disponível."
     },
+    "default_charge_level_unavailable": {
+      "message": "As configurações do nível de carga padrão estão indisponíveis enquanto o serviço Enphase está fora do ar."
+    },
     "evse_schedule_day_required": {
       "message": "Selecione pelo menos um dia da semana para a programação."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Corrente de carga"
+      },
+      "default_charge_level": {
+        "name": "Nível de carga padrão"
       },
       "battery_reserve": {
         "name": "Reserva de bateria"

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Modul de încărcare selectat nu este disponibil."
     },
+    "default_charge_level_unavailable": {
+      "message": "Setările nivelului implicit de încărcare nu sunt disponibile cât timp serviciul Enphase este indisponibil."
+    },
     "evse_schedule_day_required": {
       "message": "Selectați cel puțin o zi a săptămânii pentru programare."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Amperi de încărcare"
+      },
+      "default_charge_level": {
+        "name": "Nivel implicit de încărcare"
       },
       "battery_reserve": {
         "name": "Rezervă baterie"

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -124,6 +124,9 @@
     "charge_mode_invalid_option": {
       "message": "Det valda laddningsläget är inte tillgängligt."
     },
+    "default_charge_level_unavailable": {
+      "message": "Inställningarna för standardladdningsnivå är inte tillgängliga medan Enphase-tjänsten är nere."
+    },
     "evse_schedule_day_required": {
       "message": "Välj minst en veckodag för schemat."
     },
@@ -1756,6 +1759,9 @@
     "number": {
       "charging_amps": {
         "name": "Laddampere"
+      },
+      "default_charge_level": {
+        "name": "Standardladdningsnivå"
       },
       "battery_reserve": {
         "name": "Batterireserv"

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -437,7 +437,7 @@ Captured web requests include authenticated cookies, session tokens, user IDs, s
 
 Observed query parameters:
 - `site_id`: numeric site identifier.
-- `country`: optional ISO country code used by the web UI; observed value `DE`.
+- `country`: optional ISO country code used by the web UI; observed values include `DE` and `AU`.
 
 Example response:
 ```json
@@ -502,16 +502,16 @@ Observed structure:
 - `meta.serverTimeStamp` is an ISO 8601 timestamp string in this endpoint, unlike some other EVSE endpoints that return epoch milliseconds.
 
 Observed site-level flags:
-- `evse_charging_mode`, `evse_launch_countries`, `evse_charge_range_slider`, `off_peak_schedule`, `evse_phase_switching`, `ev_charging`
+- `evse_charging_mode`, `evse_multi_step_auto_ota`, `evse_launch_countries`, `evse_charge_range_slider`, `off_peak_schedule`, `evse_phase_switching`, `ev_charging`
 - `evse_beta_users`, `evse_prelogin_cta`, `default_off_peak_schedule`, `iqevse_smart_charging`, `iqevse_usebatterynew`
-- `evse_tamper_detection`, `ev_charger_faqs`, `evse_storm_guard`, `evse_auto_local_connection`, `evse_activation_logs`, `evse_ev_integration`
+- `evse_tamper_detection`, `ev_charger_faqs`, `evse_storm_guard`, `evse_auto_local_connection`, `evse_activation_logs`, `evse_bi_di_ux`, `evse_ev_integration`
 
 Observed per-charger flags:
 - Connectivity and setup: `evse_ble_control`, `evse_enpki_support`, `evse_network_settings`, `evse_gateway_connectivity`, `evse_connect_to_internet_flow_cellular`, `evse_wifi_recommendation`, `new_connect_to_internet_flow`
 - Electrical and load management: `dynamic_load_supported`, `phase_config_support`, `max_current_config_support`, `evse_operating_voltage`, `rcd_breaker_confirmation`
-- Charging controls: `evse_charge_level_gen1`, `evse_charge_level_control`, `evse_charging_modes_cancel_task`, `local_green_charging`, `plug_and_charge`
-- Identity and integrations: `evse_authentication`, `iqevse_rfid`, `evse_ocpp_server_settings`, `iqevse_meter_connection`, `evse_v2_livestream`, `evse_connector_lock`
-- Rollout and certification gates: `evse_ctep_certification`, `iqevse_itk_fw_upgrade_status`, `na_gen2_add_devices`
+- Charging controls: `evse_charge_level_gen1`, `evse_charge_level_control`, `evse_charging_modes_cancel_task`, `local_green_charging`, `iqevse_external_meter_green_charging`, `plug_and_charge`
+- Identity and integrations: `evse_authentication`, `iqevse_rfid`, `evse_ocpp_server_settings`, `iqevse_meter_connection`, `evse_v2_livestream`, `evse_connector_lock`, `evse_itk_external_meter_list`
+- Rollout and certification gates: `evse_ctep_certification`, `iqevse_itk_fw_upgrade_status`, `iqevse_itk_additional_fw_upgrade`, `na_gen2_add_devices`, `ocmf_eichrecht_mail_report`
 
 ### 2.3 Start Live Stream
 ```
@@ -573,7 +573,7 @@ Legacy or normalized client responses may still use:
 { "status": "accepted" }
 ```
 
-### 2.5 Session Authentication Settings (App + RFID)
+### 2.5 EV Charger Config (Authentication, Phase, Default Charge Level)
 ```
 POST /service/evse_controller/api/v1/<site_id>/ev_chargers/<sn>/ev_charger_config
 Body: [
@@ -616,14 +616,15 @@ Observed phase/default-charge read request:
 ```json
 [
   { "key": "DefaultChargeLevel" },
-  { "key": "phase_switch_config" }
+  { "key": "phase_switch_config" },
+  { "key": "ConnectorLock" }
 ]
 ```
 
 Observed response (anonymized):
 ```json
 {
-  "meta": { "serverTimeStamp": 1760000000000, "rowCount": 2 },
+  "meta": { "serverTimeStamp": 1760000000000, "rowCount": 3 },
   "data": [
     {
       "key": "DefaultChargeLevel",
@@ -633,7 +634,13 @@ Observed response (anonymized):
     },
     {
       "key": "phase_switch_config",
-      "value": "auto",
+      "value": "3",
+      "reqValue": null,
+      "status": 1
+    },
+    {
+      "key": "ConnectorLock",
+      "value": null,
       "reqValue": null,
       "status": 1
     }
@@ -671,14 +678,46 @@ Disable request payload:
 ]
 ```
 
+Update the default charge level:
+```
+PUT /service/evse_controller/api/v1/<site_id>/ev_chargers/<sn>/ev_charger_config
+Body: [ { "key": "DefaultChargeLevel", "value": <amps> } ]
+```
+
+Observed request payloads used integer amp values:
+```json
+[
+  { "key": "DefaultChargeLevel", "value": 30 }
+]
+```
+
+Observed response (anonymized):
+```json
+{
+  "meta": { "serverTimeStamp": 1760000000000, "rowCount": 1 },
+  "data": [
+    {
+      "key": "DefaultChargeLevel",
+      "value": "30",
+      "reqValue": null,
+      "status": 2
+    }
+  ],
+  "error": {}
+}
+```
+
 Notes:
 - `sessionAuthentication` controls "Auth via App"; `rfidSessionAuthentication` controls RFID auth.
-- `phase_switch_config` appears to expose the charger's automatic phase-switching mode; the observed read value was `"auto"`.
-- `DefaultChargeLevel` was observed as `null`; the exact semantics remain unconfirmed and may indicate unset/disabled state.
+- `phase_switch_config` appears to expose the charger's phase-switching mode; observed read values include `"3"`, and earlier captures used `"auto"`.
+- `ConnectorLock` can be requested through the same config read endpoint; the observed value was `null`.
+- `DefaultChargeLevel` was observed as `null` before update, which appears to indicate unset/disabled state. After writing `30`, the service returned `"30"` as a string with `status=2` and `reqValue=null`.
+- Implementation: Home Assistant exposes the Default Charge Level number entity only when this config read returns the `DefaultChargeLevel` key for that charger. Existing charge-level feature flags are treated as advisory because firmware/cloud rollout can differ across otherwise similar chargers.
+- Implementation: the Default Charge Level entity uses the same discovered charger amp limits as Charging Amps, but writes this persistent config value instead of updating the immediate/session charging setpoint.
 - When either setting is enabled, charging sessions require user authentication before starting.
-- Observed: read responses use `status=1`; update responses use `status=2`, with `value` reflecting the prior state and `reqValue` the desired state.
+- Observed: read responses use `status=1`; update responses use `status=2`. Authentication-setting update responses have shown `value` as the prior state and `reqValue` as the desired state, while `DefaultChargeLevel` returned the accepted target in `value` and left `reqValue` as `null`.
 - Observed: both `sessionAuthentication` and `rfidSessionAuthentication` can return `null` for both `value` and `reqValue`, which appears to represent a disabled or unset state.
-- Observed in one web capture: the request succeeded with session cookies plus XSRF cookies present, while `e-auth-token` was sent as `null` and no bearer token header was present. Treat the auth requirements here as UI-path dependent.
+- Observed web captures succeeded with session cookies, XSRF cookies, `e-auth-token`, and sometimes an `Authorization: Bearer <token>` overlay. Treat the auth requirements here as UI-path dependent.
 - Implementation: config reads first use normal today JSON headers plus the control `Authorization` overlay. If that returns `Unauthorized` or `403` while bearer auth was present, the client retries the same POST with both `Authorization` and `e-auth-token` explicitly suppressed.
 - Privacy: real captures include site IDs, charger serial numbers, cookies, JWTs, names, and email addresses. Redact all such values when preserving examples.
 

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -6792,6 +6792,50 @@ async def test_charger_config_returns_empty_when_no_valid_keys() -> None:
 
 
 @pytest.mark.asyncio
+async def test_set_default_charge_level_uses_charger_config_put() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "data": [{"key": DEFAULT_CHARGE_LEVEL_SETTING, "value": "30", "status": 2}]
+        }
+    )
+
+    result = await client.set_default_charge_level("SN", 30)
+
+    assert result == {
+        "data": [{"key": DEFAULT_CHARGE_LEVEL_SETTING, "value": "30", "status": 2}]
+    }
+    args, kwargs = client._json.await_args
+    assert args[0] == "PUT"
+    assert "ev_charger_config" in args[1]
+    assert kwargs["json"] == [{"key": DEFAULT_CHARGE_LEVEL_SETTING, "value": 30}]
+    expected_headers = client._today_json_headers()
+    expected_headers.update(client._control_headers())
+    assert kwargs["headers"] == expected_headers
+
+
+@pytest.mark.asyncio
+async def test_set_default_charge_level_wraps_config_unavailable() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=_make_cre(503, "ev_charger_config service unavailable")
+    )
+
+    with pytest.raises(api.ChargerConfigUnavailable):
+        await client.set_default_charge_level("SN", 30)
+    client._json.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_set_default_charge_level_reraises_non_config_error() -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(400, "bad request"))
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.set_default_charge_level("SN", 30)
+
+
+@pytest.mark.asyncio
 async def test_set_app_authentication_passes_payload() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"status": "ok"})

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -32,6 +32,7 @@ from custom_components.enphase_ev.coordinator import (
 )
 from custom_components.enphase_ev.api import (
     AuthSettingsUnavailable,
+    ChargerConfigUnavailable,
     SchedulerUnavailable,
     Unauthorized,
 )
@@ -3646,8 +3647,103 @@ async def test_async_update_data_merges_charger_config_fallback_fields(
 
     assert "default_charge_level" in result[SERIAL_ONE]
     assert result[SERIAL_ONE]["default_charge_level"] is None
+    assert result[SERIAL_ONE]["default_charge_level_supported"] is True
+    assert result[SERIAL_ONE]["default_charge_level_supported_source"] == (
+        "charger_config"
+    )
     assert result[SERIAL_ONE]["phase_switch_config"] == "auto"
     coord.client.charger_config.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_keeps_default_charge_level_unsupported_when_omitted(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord._has_successful_refresh = True  # noqa: SLF001
+    payload = {
+        "evChargerData": [
+            {
+                "sn": SERIAL_ONE,
+                "name": "Garage",
+                "connectors": [{}],
+                "pluggedIn": True,
+                "charging": False,
+                "faulted": False,
+                "session_d": {"e_c": 0},
+            }
+        ],
+        "ts": 0,
+    }
+    coord.client.status = AsyncMock(return_value=payload)
+    coord.client.charger_config = AsyncMock(
+        return_value=[{"key": PHASE_SWITCH_CONFIG_SETTING, "value": "auto"}]
+    )
+    coord.client.charger_auth_settings = AsyncMock(return_value=[])
+    coord.client.green_charging_settings = AsyncMock(return_value=[])
+    coord.summary.prepare_refresh = MagicMock(return_value=False)
+    coord.summary.async_fetch = AsyncMock(
+        return_value=[
+            {
+                "serialNumber": SERIAL_ONE,
+                "chargeLevelDetails": {"defaultChargeLevel": "30"},
+            }
+        ]
+    )
+    coord.energy._async_refresh_site_energy = AsyncMock()
+
+    result = await coord._async_update_data()
+
+    assert result[SERIAL_ONE]["default_charge_level"] == "30"
+    assert result[SERIAL_ONE]["default_charge_level_supported"] is False
+    assert result[SERIAL_ONE]["default_charge_level_supported_source"] == (
+        "charger_config"
+    )
+    assert result[SERIAL_ONE]["phase_switch_config"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_keeps_default_charge_level_unsupported_when_empty(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord._has_successful_refresh = True  # noqa: SLF001
+    payload = {
+        "evChargerData": [
+            {
+                "sn": SERIAL_ONE,
+                "name": "Garage",
+                "connectors": [{}],
+                "pluggedIn": True,
+                "charging": False,
+                "faulted": False,
+                "session_d": {"e_c": 0},
+            }
+        ],
+        "ts": 0,
+    }
+    coord.client.status = AsyncMock(return_value=payload)
+    coord.client.charger_config = AsyncMock(return_value=[])
+    coord.client.charger_auth_settings = AsyncMock(return_value=[])
+    coord.client.green_charging_settings = AsyncMock(return_value=[])
+    coord.summary.prepare_refresh = MagicMock(return_value=False)
+    coord.summary.async_fetch = AsyncMock(
+        return_value=[
+            {
+                "serialNumber": SERIAL_ONE,
+                "chargeLevelDetails": {"defaultChargeLevel": "30"},
+            }
+        ]
+    )
+    coord.energy._async_refresh_site_energy = AsyncMock()
+
+    result = await coord._async_update_data()
+
+    assert result[SERIAL_ONE]["default_charge_level"] == "30"
+    assert result[SERIAL_ONE]["default_charge_level_supported"] is False
+    assert result[SERIAL_ONE]["default_charge_level_supported_source"] == (
+        "charger_config"
+    )
 
 
 @pytest.mark.asyncio
@@ -3731,6 +3827,81 @@ async def test_async_get_charger_config_returns_empty_with_no_valid_keys(
 
 
 @pytest.mark.asyncio
+async def test_async_set_default_charge_level_caches_accepted_value(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.set_default_charge_level = AsyncMock(
+        return_value={
+            "data": [{"key": DEFAULT_CHARGE_LEVEL_SETTING, "value": "30", "status": 2}]
+        }
+    )
+    coord.async_request_refresh = AsyncMock()
+
+    await coord.evse_runtime.async_set_default_charge_level(SERIAL_ONE, 24)
+
+    coord.client.set_default_charge_level.assert_awaited_once_with(SERIAL_ONE, 24)
+    assert coord._charger_config_cache[SERIAL_ONE][0][DEFAULT_CHARGE_LEVEL_SETTING] == (
+        30
+    )
+    coord.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_set_default_charge_level_uses_reqvalue_and_ignores_noise(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.set_default_charge_level = AsyncMock(
+        return_value={
+            "data": [
+                "invalid",
+                {"key": "Other", "value": "99"},
+                {"key": DEFAULT_CHARGE_LEVEL_SETTING, "value": None, "reqValue": "32"},
+            ]
+        }
+    )
+    coord.async_request_refresh = AsyncMock()
+
+    await coord.evse_runtime.async_set_default_charge_level(SERIAL_ONE, 24)
+
+    assert coord._charger_config_cache[SERIAL_ONE][0][DEFAULT_CHARGE_LEVEL_SETTING] == (
+        32
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_set_default_charge_level_keeps_requested_value_for_bad_response(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.set_default_charge_level = AsyncMock(
+        return_value={"data": [{"key": DEFAULT_CHARGE_LEVEL_SETTING, "value": "bad"}]}
+    )
+    coord.async_request_refresh = AsyncMock()
+
+    await coord.evse_runtime.async_set_default_charge_level(SERIAL_ONE, 24)
+
+    assert coord._charger_config_cache[SERIAL_ONE][0][DEFAULT_CHARGE_LEVEL_SETTING] == (
+        24
+    )
+    assert coord.evse_runtime._coerce_charge_level(None) is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_async_set_default_charge_level_wraps_unavailable(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.set_default_charge_level = AsyncMock(
+        side_effect=ChargerConfigUnavailable("down")
+    )
+
+    with pytest.raises(ServiceValidationError):
+        await coord.evse_runtime.async_set_default_charge_level(SERIAL_ONE, 24)
+
+
+@pytest.mark.asyncio
 async def test_async_get_charger_config_returns_full_fresh_cache(
     coordinator_factory,
 ) -> None:
@@ -3754,6 +3925,40 @@ async def test_async_get_charger_config_returns_full_fresh_cache(
         PHASE_SWITCH_CONFIG_SETTING: "auto",
     }
     coord.client.charger_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_get_charger_config_caches_missing_requested_key(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.charger_config = AsyncMock(
+        return_value=[{"key": PHASE_SWITCH_CONFIG_SETTING, "value": "auto"}]
+    )
+
+    result = await coord.evse_runtime.async_get_charger_config(
+        SERIAL_ONE,
+        keys=(DEFAULT_CHARGE_LEVEL_SETTING, PHASE_SWITCH_CONFIG_SETTING),
+    )
+
+    assert result == {PHASE_SWITCH_CONFIG_SETTING: "auto"}
+    coord.client.charger_config.assert_awaited_once()
+
+    coord.client.charger_config.reset_mock()
+    result = await coord.evse_runtime.async_get_charger_config(
+        SERIAL_ONE,
+        keys=(DEFAULT_CHARGE_LEVEL_SETTING, PHASE_SWITCH_CONFIG_SETTING),
+    )
+
+    assert result == {PHASE_SWITCH_CONFIG_SETTING: "auto"}
+    coord.client.charger_config.assert_not_awaited()
+    assert (
+        coord.evse_runtime.charger_config_lookup_candidates(
+            [SERIAL_ONE],
+            keys=(DEFAULT_CHARGE_LEVEL_SETTING, PHASE_SWITCH_CONFIG_SETTING),
+        )
+        == []
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -4510,8 +4510,31 @@ async def test_startup_warmup_helper_refreshes_cover_fallback_and_merge_paths(
     assert merged_secondary[RANDOM_SERIAL]["rfid_auth_supported"] is True
     assert merged_secondary[RANDOM_SERIAL]["auth_required"] is True
     assert merged_secondary[RANDOM_SERIAL]["phase_switch_config"] == "auto"
+    assert merged_secondary[RANDOM_SERIAL]["default_charge_level_supported"] is True
     assert "default_charge_level" in merged_secondary[RANDOM_SERIAL]
     assert merged_secondary[RANDOM_SERIAL]["default_charge_level"] is None
+
+    coord.evse_runtime.async_resolve_charger_config = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+        return_value={RANDOM_SERIAL: {"phase_switch_config": "auto"}}
+    )
+    await coord.refresh_runner.async_refresh_secondary_evse_state_for_warmup()
+    merged_secondary = set_updated.call_args_list[-1].args[0]
+    assert merged_secondary[RANDOM_SERIAL]["default_charge_level_supported"] is False
+    assert (
+        merged_secondary[RANDOM_SERIAL]["default_charge_level_supported_source"]
+        == "charger_config"
+    )
+
+    coord.evse_runtime.async_resolve_charger_config = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+        return_value={RANDOM_SERIAL: {}}
+    )
+    await coord.refresh_runner.async_refresh_secondary_evse_state_for_warmup()
+    merged_secondary = set_updated.call_args_list[-1].args[0]
+    assert merged_secondary[RANDOM_SERIAL]["default_charge_level_supported"] is False
+    assert (
+        merged_secondary[RANDOM_SERIAL]["default_charge_level_supported_source"]
+        == "charger_config"
+    )
 
     coord.iter_serials = lambda: [""]  # type: ignore[assignment]
     await coord.refresh_runner.async_refresh_secondary_evse_state_for_warmup()

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -14,6 +14,7 @@ from custom_components.enphase_ev.number import (
     BatteryScheduleEditLimitNumber,
     BatteryShutdownLevelNumber,
     ChargingAmpsNumber,
+    DefaultChargeLevelNumber,
     EnphaseTariffRateNumber,
     async_setup_entry,
 )
@@ -193,6 +194,34 @@ async def test_async_setup_entry_adds_site_numbers_and_charger_numbers(
     assert any(isinstance(ent, BatteryShutdownLevelNumber) for ent in added)
     assert any(isinstance(ent, BatteryScheduleEditLimitNumber) for ent in added)
     assert any(isinstance(ent, ChargingAmpsNumber) for ent in added)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_default_charge_level_when_supported(
+    hass, config_entry, coordinator_factory
+) -> None:
+    coord = coordinator_factory(
+        data={
+            RANDOM_SERIAL: {
+                "sn": RANDOM_SERIAL,
+                "name": "Garage",
+                "default_charge_level_supported": True,
+                "default_charge_level": 30,
+            }
+        }
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added: list = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    assert any(isinstance(ent, ChargingAmpsNumber) for ent in added)
+    assert any(isinstance(ent, DefaultChargeLevelNumber) for ent in added)
 
 
 @pytest.mark.asyncio
@@ -459,6 +488,88 @@ def test_charging_number_uses_pick_start_for_non_applicable_and_safe_limit(
     coord.data[RANDOM_SERIAL]["min_amp"] = "16"
     assert number.native_value == 16.0
     assert number.native_max_value == 40.0
+
+
+def test_default_charge_level_number_uses_config_value_and_bounds(
+    hass, config_entry
+) -> None:
+    coord = _make_coordinator(
+        hass,
+        config_entry,
+        {
+            RANDOM_SERIAL: {
+                "default_charge_level_supported": True,
+                "default_charge_level_supported_source": "charger_config",
+                "default_charge_level": "30",
+                "charging_level": "24",
+                "min_amp": "6",
+                "max_amp": "48",
+                "max_current": "50",
+                "amp_granularity": "2",
+            }
+        },
+    )
+
+    number = DefaultChargeLevelNumber(coord, RANDOM_SERIAL)
+
+    assert number.available is True
+    assert number.native_value == 30.0
+    assert number.native_min_value == 6.0
+    assert number.native_max_value == 48.0
+    assert number.native_step == 2.0
+    assert number.extra_state_attributes == {
+        "min_amp": 6,
+        "max_amp": 48,
+        "max_current": 50,
+        "amp_granularity": 2,
+        "charging_amps": 24,
+        "default_charge_level_supported_source": "charger_config",
+    }
+
+
+def test_default_charge_level_number_unavailable_when_unsupported(
+    hass, config_entry
+) -> None:
+    coord = _make_coordinator(
+        hass,
+        config_entry,
+        {
+            RANDOM_SERIAL: {
+                "default_charge_level_supported": False,
+                "default_charge_level": "30",
+            }
+        },
+    )
+
+    number = DefaultChargeLevelNumber(coord, RANDOM_SERIAL)
+
+    assert number.available is False
+    assert number.native_value == 30.0
+
+
+@pytest.mark.asyncio
+async def test_default_charge_level_number_writes_persistent_default(
+    hass, config_entry
+) -> None:
+    coord = _make_coordinator(
+        hass,
+        config_entry,
+        {
+            RANDOM_SERIAL: {
+                "default_charge_level_supported": True,
+                "default_charge_level": 24,
+            }
+        },
+    )
+    coord.evse_runtime.async_set_default_charge_level = AsyncMock()
+
+    number = DefaultChargeLevelNumber(coord, RANDOM_SERIAL)
+    await number.async_set_native_value(30)
+
+    coord.evse_runtime.async_set_default_charge_level.assert_awaited_once_with(
+        RANDOM_SERIAL,
+        30,
+    )
 
 
 def test_battery_reserve_number_dynamic_bounds_and_device_info(

--- a/tests/components/enphase_ev/test_summary_enrichment.py
+++ b/tests/components/enphase_ev/test_summary_enrichment.py
@@ -122,5 +122,7 @@ async def test_summary_v2_enrichment(hass, monkeypatch):
     assert st["model_id"] == "MODEL-SKU-0000"
     assert st["display_name"] == "Garage Charger"
     assert st["green_battery_supported"] is True
+    assert st["default_charge_level"] == "disabled"
+    assert "default_charge_level_supported" not in st
     assert st["energy_today_sessions"] == []
     assert st["energy_today_sessions_kwh"] == 0.0


### PR DESCRIPTION
## Summary

Adds an IQ EV Charger Default Charge Level number entity for chargers whose Enphase charger-config endpoint exposes `DefaultChargeLevel`.

The new entity uses the same discovered amp bounds as the existing Charging Amps control, but writes the persistent charger default through the charger-config endpoint instead of changing the immediate/session setpoint. Compatibility is determined from the config endpoint response, with summary data retained only as contextual state.

The PR also documents the newly observed EVSE feature flags and Default Charge Level read/write behavior, with sensitive capture details anonymized.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [x] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/number.py custom_components/enphase_ev/refresh_runner.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_summary_enrichment.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/number.py,custom_components/enphase_ev/refresh_runner.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- `DefaultChargeLevel` compatibility is based on the charger-config endpoint returning that key for the charger.
- Summary `chargeLevelDetails.defaultChargeLevel` is preserved as context but does not enable the entity by itself.
- API examples and observed endpoint details are anonymized.
