### PR TITLE
Prepare release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,36 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- Added an IQ EV Charger Default Charge Level number entity for chargers whose Enphase config endpoint exposes the `DefaultChargeLevel` setting.
+- None
 
 ### 🐛 Bug fixes
-- Fixed IQ Gateway firmware catalog generation so US commercial-only release notes are not advertised to residential/regional gateway update entities. (#735)
-- Fixed the Enphase Service Status badge so expected 4xx responses from ancillary Enphase probes no longer publish the service as down while Home Assistant reports the cloud service as OK.
+- None
 
 ### 🔧 Improvements
-- Added a bounded installed firmware version history to firmware update entities, logged firmware version changes to Logbook, and reduced diagnostic-only firmware update attributes shown in Home Assistant.
+- None
 
 ### 🔄 Other changes
-- Documented newly observed EVSE feature flags and the Default Charge Level charger-config endpoint behavior.
+- None
+
+## v3.2.1 - 2026-07-07
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added an IQ EV Charger Default Charge Level number entity for chargers whose Enphase config endpoint exposes the `DefaultChargeLevel` setting. (#738)
+
+### 🐛 Bug fixes
+- Fixed IQ Gateway firmware catalog generation so US commercial-only release notes are not advertised to residential/regional gateway update entities. (#736)
+- Fixed the Enphase Service Status badge so expected 4xx responses from ancillary Enphase probes no longer publish the service as down while Home Assistant reports the cloud service as OK. (#737)
+
+### 🔧 Improvements
+- Added a bounded installed firmware version history to firmware update entities, logged firmware version changes to Logbook, and reduced diagnostic-only firmware update attributes shown in Home Assistant. (#740)
+
+### 🔄 Other changes
+- Added regression coverage for reauth repair issue cleanup. (#734)
+- Documented newly observed EVSE feature flags and the Default Charge Level charger-config endpoint behavior. (#738)
+- Bumped the integration manifest version to `3.2.1`.
 
 ## v3.2.0 - 2026-07-02
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.2.0"
+  "version": "3.2.1"
 }


### PR DESCRIPTION
## Summary

Prepare release 3.2.1 by moving the current unreleased changelog entries into a dated release section and bumping the integration manifest version to `3.2.1`.

The changelog now explicitly includes the release contents from PRs #734, #736, #737, #738, and #740.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation.

## Testing

```bash
git diff --check
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m json.tool custom_components/enphase_ev/manifest.json >/tmp/enphase_manifest_check.json && python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --files CHANGELOG.md custom_components/enphase_ev/manifest.json"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

`pytest -q tests/components/enphase_ev`: 3356 passed.

`pytest -q`: 3477 passed.

Black and targeted Python coverage were not applicable because this release-prep change does not touch Python modules.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No runtime behavior changes beyond the manifest release version bump.
