### PR TITLE
Fix EVSE amp bounds refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed IQ EV Charger amp number ranges staying on fallback bounds for up to 10 minutes when the first EVSE summary payload omitted current-limit details.
 
 ### 🔧 Improvements
 - None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,36 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- Added an IQ EV Charger Default Charge Level number entity for chargers whose Enphase config endpoint exposes the `DefaultChargeLevel` setting.
+- None
 
 ### 🐛 Bug fixes
-- Fixed IQ Gateway firmware catalog generation so US commercial-only release notes are not advertised to residential/regional gateway update entities. (#735)
-- Fixed the Enphase Service Status badge so expected 4xx responses from ancillary Enphase probes no longer publish the service as down while Home Assistant reports the cloud service as OK.
+- None
 
 ### 🔧 Improvements
-- Added a bounded installed firmware version history to firmware update entities, logged firmware version changes to Logbook, and reduced diagnostic-only firmware update attributes shown in Home Assistant.
+- None
 
 ### 🔄 Other changes
-- Documented newly observed EVSE feature flags and the Default Charge Level charger-config endpoint behavior.
+- None
+
+## v3.2.1 - 2026-07-07
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added an IQ EV Charger Default Charge Level number entity for chargers whose Enphase config endpoint exposes the `DefaultChargeLevel` setting. (#738)
+
+### 🐛 Bug fixes
+- Fixed IQ Gateway firmware catalog generation so US commercial-only release notes are not advertised to residential/regional gateway update entities. (#736)
+- Fixed the Enphase Service Status badge so expected 4xx responses from ancillary Enphase probes no longer publish the service as down while Home Assistant reports the cloud service as OK. (#737)
+
+### 🔧 Improvements
+- Added a bounded installed firmware version history to firmware update entities, logged firmware version changes to Logbook, and reduced diagnostic-only firmware update attributes shown in Home Assistant. (#740)
+
+### 🔄 Other changes
+- Added regression coverage for reauth repair issue cleanup. (#734)
+- Documented newly observed EVSE feature flags and the Default Charge Level charger-config endpoint behavior. (#738)
+- Bumped the integration manifest version to `3.2.1`.
 
 ## v3.2.0 - 2026-07-02
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -2927,6 +2927,55 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 except Exception:
                     pass
 
+    @staticmethod
+    def _charger_amp_bounds_missing(data: dict[str, object]) -> bool:
+        """Return True when a charger snapshot still lacks number range bounds."""
+
+        charging_amps_supported = _coerce_optional_boolish(
+            data.get("charging_amps_supported")
+        )
+        if charging_amps_supported is False:
+            return False
+        has_amp_hint = any(
+            data.get(key) is not None
+            for key in (
+                "charging_level",
+                "session_charge_level",
+                "default_charge_level",
+                "max_current",
+            )
+        )
+        if charging_amps_supported is not True and not has_amp_hint:
+            return False
+        return (
+            _coerce_intish(data.get("min_amp")) is None
+            or _coerce_intish(data.get("max_amp")) is None
+        )
+
+    def _summary_refresh_needed_for_amp_bounds(
+        self, data: dict[str, dict[str, object]]
+    ) -> bool:
+        """Return True when cached summary data is missing EVSE amp bounds."""
+
+        previous_data = self.data if isinstance(self.data, dict) else {}
+        for sn in self.iter_serials():
+            if not sn:
+                continue
+            snapshot = data.get(sn)
+            if not isinstance(snapshot, dict):
+                continue
+            if self._charger_amp_bounds_missing(snapshot):
+                previous = previous_data.get(sn)
+                if isinstance(previous, dict):
+                    merged = dict(snapshot)
+                    for key in ("min_amp", "max_amp"):
+                        if merged.get(key) is None and previous.get(key) is not None:
+                            merged[key] = previous.get(key)
+                    if not self._charger_amp_bounds_missing(merged):
+                        continue
+                return True
+        return False
+
     def _finish_refresh_pipeline(
         self,
         context: RefreshPipelineContext,
@@ -3810,6 +3859,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             want_fast=polling_state["want_fast"],
             target_interval=float(polling_state["target"]),
         )
+        if not summary_force and self._summary_refresh_needed_for_amp_bounds(out):
+            summary_force = True
 
         # Enrich with summary v2 data
         summary_start = time.monotonic()
@@ -3825,20 +3876,29 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 cur.setdefault("nominal_v", self._nominal_v)
                 prev_sn = prev_data.get(sn) if isinstance(prev_data, dict) else None
                 # Max current capability and phase/status
-                cur["max_current"] = item.get("maxCurrent")
+                max_current = item.get("maxCurrent")
+                if max_current is None and isinstance(prev_sn, dict):
+                    max_current = prev_sn.get("max_current")
+                cur["max_current"] = max_current
                 cld = item.get("chargeLevelDetails") or {}
+                if not isinstance(cld, dict):
+                    cld = {}
                 try:
                     cur["min_amp"] = (
                         int(str(cld.get("min"))) if cld.get("min") is not None else None
                     )
                 except Exception:
                     cur["min_amp"] = None
+                if cur["min_amp"] is None and isinstance(prev_sn, dict):
+                    cur["min_amp"] = _as_int(prev_sn.get("min_amp"))
                 try:
                     cur["max_amp"] = (
                         int(str(cld.get("max"))) if cld.get("max") is not None else None
                     )
                 except Exception:
                     cur["max_amp"] = None
+                if cur["max_amp"] is None and isinstance(prev_sn, dict):
+                    cur["max_amp"] = _as_int(prev_sn.get("max_amp"))
                 try:
                     cur["amp_granularity"] = (
                         int(str(cld.get("granularity")))
@@ -3847,6 +3907,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     )
                 except Exception:
                     cur["amp_granularity"] = None
+                if cur["amp_granularity"] is None and isinstance(prev_sn, dict):
+                    cur["amp_granularity"] = _as_int(prev_sn.get("amp_granularity"))
                 if any(
                     cur.get(key) is not None
                     for key in (

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.2.0"
+  "version": "3.2.1"
 }

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -3656,6 +3656,146 @@ async def test_async_update_data_merges_charger_config_fallback_fields(
 
 
 @pytest.mark.asyncio
+async def test_async_update_data_refetches_summary_when_amp_bounds_missing(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord._has_successful_refresh = True  # noqa: SLF001
+    payload = {
+        "evChargerData": [
+            {
+                "sn": SERIAL_ONE,
+                "name": "Garage",
+                "connectors": [{}],
+                "pluggedIn": True,
+                "charging": False,
+                "faulted": False,
+                "chargeMode": "MANUAL",
+                "session_d": {"chargeLevel": "30", "e_c": 0},
+            }
+        ],
+        "ts": 0,
+    }
+    coord.client.status = AsyncMock(return_value=payload)
+    coord.client.charger_config = AsyncMock(return_value=[])
+    coord.client.charger_auth_settings = AsyncMock(return_value=[])
+    coord.client.green_charging_settings = AsyncMock(return_value=[])
+    coord.summary.prepare_refresh = MagicMock(return_value=False)
+    coord.summary.async_fetch = AsyncMock(
+        side_effect=[
+            [{"serialNumber": SERIAL_ONE, "maxCurrent": 30}],
+            [
+                {
+                    "serialNumber": SERIAL_ONE,
+                    "maxCurrent": 48,
+                    "chargeLevelDetails": {
+                        "min": "6",
+                        "max": "40",
+                        "granularity": "1",
+                    },
+                }
+            ],
+            [
+                {
+                    "serialNumber": SERIAL_ONE,
+                    "maxCurrent": 48,
+                    "chargeLevelDetails": {
+                        "min": "6",
+                        "max": "40",
+                        "granularity": "1",
+                    },
+                }
+            ],
+        ]
+    )
+    coord.energy._async_refresh_site_energy = AsyncMock()
+
+    first = await coord._async_update_data()
+    second = await coord._async_update_data()
+    coord.data = second
+    third = await coord._async_update_data()
+
+    assert first[SERIAL_ONE]["min_amp"] is None
+    assert first[SERIAL_ONE]["max_amp"] is None
+    assert second[SERIAL_ONE]["min_amp"] == 6
+    assert second[SERIAL_ONE]["max_amp"] == 40
+    assert third[SERIAL_ONE]["min_amp"] == 6
+    assert third[SERIAL_ONE]["max_amp"] == 40
+    assert [
+        call.kwargs["force"] for call in coord.summary.async_fetch.await_args_list
+    ] == [True, True, False]
+
+
+def test_summary_refresh_needed_for_amp_bounds_skips_invalid_serial_snapshots(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.iter_serials = lambda: ["", "NOT-A-DICT", SERIAL_ONE]  # type: ignore[method-assign]
+
+    assert (
+        coord._summary_refresh_needed_for_amp_bounds(  # noqa: SLF001
+            {
+                "NOT-A-DICT": "bad",
+                SERIAL_ONE: {"charging_amps_supported": True},
+            }
+        )
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_preserves_known_amp_bounds_when_summary_omits_them(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(
+        serials=[SERIAL_ONE],
+        data={
+            SERIAL_ONE: {
+                "sn": SERIAL_ONE,
+                "name": "Garage",
+                "min_amp": "6",
+                "max_amp": "40",
+                "amp_granularity": "1",
+                "max_current": "48",
+            }
+        },
+    )
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": SERIAL_ONE,
+                    "name": "Garage",
+                    "connectors": [{}],
+                    "pluggedIn": True,
+                    "charging": False,
+                    "faulted": False,
+                    "chargeMode": "MANUAL",
+                    "session_d": {"chargeLevel": "30", "e_c": 0},
+                }
+            ],
+            "ts": 0,
+        }
+    )
+    coord.client.charger_config = AsyncMock(return_value=[])
+    coord.client.charger_auth_settings = AsyncMock(return_value=[])
+    coord.client.green_charging_settings = AsyncMock(return_value=[])
+    coord.summary.prepare_refresh = MagicMock(return_value=False)
+    coord.summary.async_fetch = AsyncMock(
+        return_value=[{"serialNumber": SERIAL_ONE, "chargeLevelDetails": "bad"}]
+    )
+    coord.energy._async_refresh_site_energy = AsyncMock()
+
+    result = await coord._async_update_data()
+
+    assert result[SERIAL_ONE]["min_amp"] == 6
+    assert result[SERIAL_ONE]["max_amp"] == 40
+    assert result[SERIAL_ONE]["amp_granularity"] == 1
+    assert result[SERIAL_ONE]["max_current"] == "48"
+
+
+@pytest.mark.asyncio
 async def test_async_update_data_keeps_default_charge_level_unsupported_when_omitted(
     coordinator_factory,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes IQ EV Charger amp number ranges staying on fallback bounds when the first EVSE summary payload omits current-limit details. The coordinator now forces a fresh summary while supported charger snapshots still lack amp bounds, preserves previously learned bounds when a later summary omits them, and stops forcing summary once bounds are known.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Full component coverage passed with `coordinator.py` at 100%.
- The first coverage attempt was killed while run concurrently with the full test suites; the solo rerun passed.
