### PR TITLE
Expose gateway IP on status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🔧 Improvements
-- None
+- Exposed the IQ Gateway IP address on the Gateway Status entity attributes when available.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -136,6 +136,48 @@ class InventoryRuntime:
     def _type_member_text(self, member: dict[str, object], *keys: str) -> str | None:
         return type_member_text(member, *keys)
 
+    def _gateway_member_ip_address(self, member: dict[str, object]) -> str | None:
+        return self._type_member_text(member, "ip", "ip_address", "ip-address")
+
+    def _gateway_member_is_not_primary_gateway(self, member: dict[str, object]) -> bool:
+        member_kind = self.coordinator.inventory_view._envoy_member_kind(member)
+        return member_kind in {"production", "consumption", "controller"}
+
+    def _gateway_member_preferred_for_ip(self, member: dict[str, object]) -> bool:
+        if self._gateway_member_is_not_primary_gateway(member):
+            return False
+        name = (self._type_member_text(member, "name") or "").lower()
+        if "gateway" in name:
+            return True
+        return any(
+            member.get(key) is not None
+            for key in (
+                "envoy_sw_version",
+                "ap_mode",
+                "supportsEntrez",
+                "show_connection_details",
+            )
+        )
+
+    def _gateway_summary_ip_address(
+        self,
+        members: list[dict[str, object]],
+        dashboard_envoy: object,
+    ) -> str | None:
+        candidate_members = list(members)
+        if isinstance(dashboard_envoy, dict):
+            candidate_members.append(dashboard_envoy)
+        for member in candidate_members:
+            if self._gateway_member_preferred_for_ip(member):
+                ip_address = self._gateway_member_ip_address(member)
+                if ip_address:
+                    return ip_address
+        for member in candidate_members:
+            ip_address = self._gateway_member_ip_address(member)
+            if ip_address and not self._gateway_member_is_not_primary_gateway(member):
+                return ip_address
+        return None
+
     def _coerce_optional_text(self, value: object) -> str | None:
         return coerce_optional_text(value)
 
@@ -1206,6 +1248,7 @@ class InventoryRuntime:
             dashboard_envoy = self.coordinator.system_dashboard_envoy_detail()
         if not members and isinstance(dashboard_envoy, dict):
             members = [dict(dashboard_envoy)]
+        ip_address = self._gateway_summary_ip_address(members, dashboard_envoy)
         try:
             total_devices = int(bucket.get("count", len(members)) or 0)
         except Exception:
@@ -1340,6 +1383,7 @@ class InventoryRuntime:
             "model_summary": self._format_inverter_model_summary(model_counts),
             "firmware_counts": firmware_counts,
             "firmware_summary": self._format_inverter_model_summary(firmware_counts),
+            "ip_address": ip_address,
             "latest_reported": latest_reported,
             "latest_reported_utc": (
                 latest_reported.isoformat() if latest_reported is not None else None

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -3695,6 +3695,7 @@ _GATEWAY_LAST_REPORT_KEYS: tuple[str, ...] = (
     "last_reported",
     "lastReportedAt",
 )
+_GATEWAY_IP_KEYS: tuple[str, ...] = ("ip", "ip_address", "ip-address")
 
 
 def _gateway_optional_bool(value: object) -> bool | None:
@@ -3730,6 +3731,87 @@ def _gateway_normalize_status(value: object) -> str:
     if any(token in normalized for token in ("normal", "online", "connected", "ok")):
         return "normal"
     return "unknown"
+
+
+def _gateway_member_ip_address(member: dict[str, object]) -> str | None:
+    for key in _GATEWAY_IP_KEYS:
+        ip_address = _gateway_clean_text(member.get(key))
+        if ip_address:
+            return ip_address
+    return None
+
+
+def _gateway_ip_member_kind(member: dict[str, object]) -> str | None:
+    for key in ("channel_type", "channelType", "meter_type"):
+        channel_type = _gateway_clean_text(member.get(key))
+        if not channel_type:
+            continue
+        normalized = "".join(ch if ch.isalnum() else "_" for ch in channel_type.lower())
+        if (
+            normalized in ("enpower", "system_controller", "systemcontroller")
+            or "enpower" in normalized
+            or "system_controller" in normalized
+            or normalized.startswith("systemcontroller")
+        ):
+            return "controller"
+        if "production" in normalized or normalized in ("prod", "pv", "solar"):
+            return "production"
+        if "consumption" in normalized or normalized in (
+            "cons",
+            "load",
+            "site_load",
+        ):
+            return "consumption"
+    name = (_gateway_clean_text(member.get("name")) or "").lower()
+    if "system controller" in name:
+        return "controller"
+    if "controller" in name and "meter" not in name:
+        return "controller"
+    if "production" in name:
+        return "production"
+    if "consumption" in name:
+        return "consumption"
+    return None
+
+
+def _gateway_member_preferred_for_ip(member: dict[str, object]) -> bool:
+    if _gateway_ip_member_kind(member) in {"production", "consumption", "controller"}:
+        return False
+    name = (_gateway_clean_text(member.get("name")) or "").lower()
+    if "gateway" in name:
+        return True
+    return any(
+        member.get(key) is not None
+        for key in (
+            "envoy_sw_version",
+            "ap_mode",
+            "supportsEntrez",
+            "show_connection_details",
+        )
+    )
+
+
+def _gateway_summary_ip_address(
+    members: list[dict[str, object]],
+    dashboard_envoy: object,
+) -> str | None:
+    candidate_members = list(members)
+    if isinstance(dashboard_envoy, dict):
+        candidate_members.append(dashboard_envoy)
+    for member in candidate_members:
+        if _gateway_member_preferred_for_ip(member):
+            ip_address = _gateway_member_ip_address(member)
+            if ip_address:
+                return ip_address
+    for member in candidate_members:
+        ip_address = _gateway_member_ip_address(member)
+        if ip_address and _gateway_ip_member_kind(member) not in {
+            "production",
+            "consumption",
+            "controller",
+        }:
+            return ip_address
+    return None
 
 
 def _gateway_parse_timestamp(value: object) -> datetime | None:
@@ -3814,6 +3896,7 @@ def _gateway_inventory_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
     dashboard_envoy = detail_getter() if callable(detail_getter) else None
     if not members and isinstance(dashboard_envoy, dict):
         members = [dict(dashboard_envoy)]
+    ip_address = _gateway_summary_ip_address(members, dashboard_envoy)
     try:
         total_devices = int(bucket.get("count", len(members)))
     except Exception:  # noqa: BLE001
@@ -3937,6 +4020,7 @@ def _gateway_inventory_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
         "model_summary": _gateway_format_counts(model_counts),
         "firmware_counts": firmware_counts,
         "firmware_summary": _gateway_format_counts(firmware_counts),
+        "ip_address": ip_address,
         "latest_reported": latest_reported,
         "latest_reported_utc": (
             latest_reported.isoformat() if latest_reported is not None else None
@@ -7166,6 +7250,7 @@ class EnphaseGatewayConnectivityStatusSensor(_SiteBaseEntity):
             "status_summary": snapshot.get("status_summary"),
             "model_summary": snapshot.get("model_summary"),
             "firmware_summary": snapshot.get("firmware_summary"),
+            "ip_address": snapshot.get("ip_address"),
             "latest_reported_utc": snapshot.get("latest_reported_utc"),
             "latest_reported_device": snapshot.get("latest_reported_device"),
             "property_keys": snapshot.get("property_keys"),

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -1271,7 +1271,12 @@
         "name": "Consumption Meter"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway Status"
+        "name": "Gateway Status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP Address"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -1232,7 +1232,12 @@
         "name": "Разходомер"
       },
       "gateway_connectivity_status": {
-        "name": "Състояние на шлюза"
+        "name": "Състояние на шлюза",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP адрес"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Последно докладван шлюз"

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -1232,7 +1232,12 @@
         "name": "Měřič spotřeby"
       },
       "gateway_connectivity_status": {
-        "name": "Stav brány"
+        "name": "Stav brány",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP adresa"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Brána naposledy hlášena"

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -1232,7 +1232,12 @@
         "name": "Forbrugsmåler"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway-status"
+        "name": "Gateway-status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP-adresse"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway sidst rapporteret"

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -1232,7 +1232,12 @@
         "name": "Verbrauchsmesser"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway-Status"
+        "name": "Gateway-Status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP-Adresse"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Zuletzt gemeldetes Gateway"

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -1232,7 +1232,12 @@
         "name": "Μετρητής Κατανάλωσης"
       },
       "gateway_connectivity_status": {
-        "name": "Κατάσταση πύλης"
+        "name": "Κατάσταση πύλης",
+        "state_attributes": {
+          "ip_address": {
+            "name": "Διεύθυνση IP"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Τελευταία αναφορά Gateway"

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -1232,7 +1232,12 @@
         "name": "Consumption Meter"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway Status"
+        "name": "Gateway Status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP Address"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -1232,7 +1232,12 @@
         "name": "Consumption Meter"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway Status"
+        "name": "Gateway Status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP Address"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -1232,7 +1232,12 @@
         "name": "Consumption Meter"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway Status"
+        "name": "Gateway Status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP Address"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -1232,7 +1232,12 @@
         "name": "Consumption Meter"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway Status"
+        "name": "Gateway Status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP Address"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -1232,7 +1232,12 @@
         "name": "Consumption Meter"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway Status"
+        "name": "Gateway Status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP Address"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -1232,7 +1232,12 @@
         "name": "Consumption Meter"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway Status"
+        "name": "Gateway Status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP Address"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -1232,7 +1232,12 @@
         "name": "Medidor de consumo"
       },
       "gateway_connectivity_status": {
-        "name": "Estado de la puerta de enlace"
+        "name": "Estado de la puerta de enlace",
+        "state_attributes": {
+          "ip_address": {
+            "name": "Dirección IP"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Puerta de enlace reportada por última vez"

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -1232,7 +1232,12 @@
         "name": "Tarbimismõõtur"
       },
       "gateway_connectivity_status": {
-        "name": "Lüüsi olek"
+        "name": "Lüüsi olek",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP-aadress"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway viimati teatatud"

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -1232,7 +1232,12 @@
         "name": "Kulutusmittari"
       },
       "gateway_connectivity_status": {
-        "name": "Yhdyskäytävän tila"
+        "name": "Yhdyskäytävän tila",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP-osoite"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway viimeksi raportoitu"

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -1232,7 +1232,12 @@
         "name": "Compteur de consommation"
       },
       "gateway_connectivity_status": {
-        "name": "État de la passerelle"
+        "name": "État de la passerelle",
+        "state_attributes": {
+          "ip_address": {
+            "name": "Adresse IP"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Passerelle signalée pour la dernière fois"

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -1232,7 +1232,12 @@
         "name": "Fogyasztásmérő"
       },
       "gateway_connectivity_status": {
-        "name": "Átjáró állapota"
+        "name": "Átjáró állapota",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP-cím"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "A Gateway legutóbbi jelentése"

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -1232,7 +1232,12 @@
         "name": "Misuratore di consumo"
       },
       "gateway_connectivity_status": {
-        "name": "Stato del gateway"
+        "name": "Stato del gateway",
+        "state_attributes": {
+          "ip_address": {
+            "name": "Indirizzo IP"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Ultimo gateway segnalato"

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -1232,7 +1232,12 @@
         "name": "Vartojimo matuoklis"
       },
       "gateway_connectivity_status": {
-        "name": "Vartų būsena"
+        "name": "Vartų būsena",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP adresas"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Vartai paskutinį kartą pranešta"

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -1232,7 +1232,12 @@
         "name": "Patēriņa skaitītājs"
       },
       "gateway_connectivity_status": {
-        "name": "Vārtejas statuss"
+        "name": "Vārtejas statuss",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP adrese"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway pēdējo reizi ziņots"

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -1232,7 +1232,12 @@
         "name": "Forbruksmåler"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway-status"
+        "name": "Gateway-status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP-adresse"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway sist rapportert"

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -1232,7 +1232,12 @@
         "name": "Verbruiksmeter"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway-status"
+        "name": "Gateway-status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP-adres"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway Laatst gerapporteerd"

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -1232,7 +1232,12 @@
         "name": "Licznik zużycia"
       },
       "gateway_connectivity_status": {
-        "name": "Stan bramy"
+        "name": "Stan bramy",
+        "state_attributes": {
+          "ip_address": {
+            "name": "Adres IP"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Ostatni raport dotyczący bramy"

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -1232,7 +1232,12 @@
         "name": "Medidor de Consumo"
       },
       "gateway_connectivity_status": {
-        "name": "Status do gateway"
+        "name": "Status do gateway",
+        "state_attributes": {
+          "ip_address": {
+            "name": "Endereço IP"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway relatado pela última vez"

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -1232,7 +1232,12 @@
         "name": "Contor de consum"
       },
       "gateway_connectivity_status": {
-        "name": "Stare gateway"
+        "name": "Stare gateway",
+        "state_attributes": {
+          "ip_address": {
+            "name": "Adresă IP"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway Raportat ultima dată"

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -1232,7 +1232,12 @@
         "name": "Förbrukningsmätare"
       },
       "gateway_connectivity_status": {
-        "name": "Gateway-status"
+        "name": "Gateway-status",
+        "state_attributes": {
+          "ip_address": {
+            "name": "IP-adress"
+          }
+        }
       },
       "gateway_last_reported": {
         "name": "Gateway senast rapporterad"

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -154,12 +154,14 @@ def test_inventory_runtime_summary_and_inverter_helper_paths(
                     "connected": "yes",
                     "model": "IQ Gateway",
                     "envoy_sw_version": "8.2.0",
+                    "ip_address": "192.0.2.10",
                     "last_report": "2026-02-15T10:00:00Z",
                 },
                 {
                     "name": "Gateway B",
                     "status": "offline",
                     "connected": "no",
+                    "ip_address": "192.0.2.11",
                 },
                 {
                     "name": "Gateway C",
@@ -179,6 +181,45 @@ def test_inventory_runtime_summary_and_inverter_helper_paths(
     assert gateway_snapshot["connected_devices"] == 1
     assert gateway_snapshot["disconnected_devices"] == 1
     assert gateway_snapshot["unknown_connection_devices"] == 1
+    assert gateway_snapshot["ip_address"] == "192.0.2.10"
+    assert (
+        runtime._gateway_summary_ip_address(  # noqa: SLF001
+            [{"name": "Production Meter", "ip_address": "192.0.2.12"}],
+            None,
+        )
+        is None
+    )
+    assert (
+        runtime._gateway_summary_ip_address(  # noqa: SLF001
+            [{"name": "Unknown Device", "ip_address": "192.0.2.12"}],
+            None,
+        )
+        == "192.0.2.12"
+    )
+    assert (
+        runtime._gateway_summary_ip_address(  # noqa: SLF001
+            [
+                {
+                    "name": "Production Meter",
+                    "channel_type": "production_meter",
+                    "show_connection_details": True,
+                    "ip_address": "192.0.2.13",
+                },
+                {
+                    "name": "System Controller",
+                    "show_connection_details": True,
+                    "ip_address": "192.0.2.14",
+                },
+                {
+                    "name": "Communications device",
+                    "show_connection_details": True,
+                    "ip_address": "192.0.2.15",
+                },
+            ],
+            None,
+        )
+        == "192.0.2.15"
+    )
 
     micro_snapshot = runtime._build_microinverter_inventory_summary()  # noqa: SLF001
     assert micro_snapshot["connectivity_state"] == "degraded"

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -1774,6 +1774,7 @@ def test_gateway_diagnostic_sensors_expose_inventory_summary(
                         "status": "normal",
                         "model": "IQ Gateway",
                         "envoy_sw_version": "8.2.0",
+                        "ip_address": "192.0.2.10",
                         "last_report": "2026-02-15T18:00:00Z",
                     },
                     {
@@ -1804,6 +1805,7 @@ def test_gateway_diagnostic_sensors_expose_inventory_summary(
     assert status_attrs["disconnected_devices"] == 1
     assert status_attrs["unknown_connection_devices"] == 1
     assert status_attrs["status_counts"]["warning"] == 1
+    assert status_attrs["ip_address"] == "192.0.2.10"
 
     last_reported_sensor = EnphaseGatewayLastReportedSensor(coord)
     assert last_reported_sensor.entity_registry_enabled_default is False
@@ -1827,6 +1829,91 @@ def test_gateway_diagnostic_sensors_handle_missing_inventory(
 
     assert EnphaseGatewayConnectivityStatusSensor(coord).native_value is None
     assert EnphaseGatewayLastReportedSensor(coord).native_value is None
+
+
+def test_gateway_status_ip_helper_paths() -> None:
+    assert (
+        sensor_mod._gateway_member_ip_address(  # noqa: SLF001
+            {"ip-address": " 192.0.2.20 "}
+        )
+        == "192.0.2.20"
+    )
+    assert (
+        sensor_mod._gateway_ip_member_kind({"channel_type": "enpower"})  # noqa: SLF001
+        == "controller"
+    )
+    assert (
+        sensor_mod._gateway_ip_member_kind(  # noqa: SLF001
+            {"channelType": "consumption_meter"}
+        )
+        == "consumption"
+    )
+    assert (
+        sensor_mod._gateway_ip_member_kind({"name": "Main Controller"})  # noqa: SLF001
+        == "controller"
+    )
+    assert (
+        sensor_mod._gateway_ip_member_kind({"name": "Production Meter"})  # noqa: SLF001
+        == "production"
+    )
+    assert (
+        sensor_mod._gateway_ip_member_kind(  # noqa: SLF001
+            {"name": "Consumption Meter"}
+        )
+        == "consumption"
+    )
+    assert (
+        sensor_mod._gateway_summary_ip_address(  # noqa: SLF001
+            [
+                {"name": "Meter", "ip_address": "192.0.2.30"},
+                {
+                    "name": "Communications device",
+                    "show_connection_details": True,
+                    "ip_address": "192.0.2.31",
+                },
+            ],
+            None,
+        )
+        == "192.0.2.31"
+    )
+    assert (
+        sensor_mod._gateway_summary_ip_address(  # noqa: SLF001
+            [{"name": "Production Meter", "ip_address": "192.0.2.32"}],
+            None,
+        )
+        is None
+    )
+    assert (
+        sensor_mod._gateway_summary_ip_address(  # noqa: SLF001
+            [{"name": "Unknown Device", "ip_address": "192.0.2.32"}],
+            None,
+        )
+        == "192.0.2.32"
+    )
+    assert (
+        sensor_mod._gateway_summary_ip_address(  # noqa: SLF001
+            [
+                {
+                    "name": "Production Meter",
+                    "channel_type": "production_meter",
+                    "show_connection_details": True,
+                    "ip_address": "192.0.2.33",
+                },
+                {
+                    "name": "System Controller",
+                    "show_connection_details": True,
+                    "ip_address": "192.0.2.34",
+                },
+                {
+                    "name": "Communications device",
+                    "show_connection_details": True,
+                    "ip_address": "192.0.2.35",
+                },
+            ],
+            None,
+        )
+        == "192.0.2.35"
+    )
 
 
 def test_microinverter_diagnostic_sensors_expose_inventory_summary(


### PR DESCRIPTION
## Summary

Expose the IQ Gateway IP address on the enabled Gateway Status entity attributes when Enphase inventory/dashboard payloads provide one.

The IP selection prefers gateway-like inventory rows and avoids publishing production meter, consumption meter, or system controller IP addresses as the gateway IP. Attribute translations were added for every locale and the changelog documents the user-facing improvement.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

User-facing entity attribute improvement.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/sensor.py custom_components/enphase_ev/inventory_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py tests/components/enphase_ev/test_inventory_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_sensor_additional_coverage.py::test_gateway_status_ip_helper_paths tests/components/enphase_ev/test_inventory_runtime.py::test_inventory_runtime_summary_and_inverter_helper_paths"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/inventory_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:delegated ha-dev bash -lc "git status --short && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Targeted coverage reported 100% for `custom_components/enphase_ev/sensor.py` and `custom_components/enphase_ev/inventory_runtime.py`.

The standard Docker compose mount does not include the host gitdir referenced by this Codex worktree's `.git` file, so the successful pre-commit run included an explicit git metadata volume mount.
