### PR TITLE
Fix sparse site grid import fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed Site Grid Import lifetime energy so sparse direct import buckets fall back to fuller component totals instead of leaving import totals stale. (#744)
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/energy.py
+++ b/custom_components/enphase_ev/energy.py
@@ -369,8 +369,14 @@ class EnergyManager:
         fallback_count: int,
         fallback_fields: list[str],
     ) -> tuple[float, int, list[str]]:
-        """Prefer a direct channel unless it only reports zeros and fallback is richer."""
+        """Prefer direct channels unless they are zero-only or sparsely populated."""
 
+        if (
+            direct_count > 0
+            and fallback_count > direct_count
+            and fallback_total > direct_total
+        ):
+            return fallback_total, fallback_count, fallback_fields
         if direct_count > 0 and (
             direct_total > 0 or fallback_count <= 0 or fallback_total <= 0
         ):

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -809,6 +809,23 @@ def test_site_energy_import_direct_channel_takes_precedence(
     assert flows["grid_import"].fields_used == ["import"]
 
 
+def test_site_energy_sparse_positive_import_channel_falls_back_to_component_totals(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    payload = {
+        "import": [500, None, None],
+        "grid_home": [600, 700, 800],
+        "grid_battery": [50, 60, 70],
+        "interval_minutes": 60,
+    }
+    flows, _meta = coord.energy._aggregate_site_energy(payload)  # noqa: SLF001
+    assert flows is not None
+    assert flows["grid_import"].value_kwh == pytest.approx(2.28)
+    assert flows["grid_import"].bucket_count == 3
+    assert flows["grid_import"].fields_used == ["grid_home", "grid_battery"]
+
+
 def test_site_energy_sparse_zero_import_channel_falls_back_to_component_totals(
     coordinator_factory,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #744.

Site Grid Import lifetime energy now falls back to fuller component totals when the direct Enphase `import` bucket array is sparse but positive. The issue diagnostics showed direct import using far fewer usable buckets than the component channels, which could leave the import total stale while export continued updating.

## Related Issues

Fixes #744

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_site_energy.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/energy.py tests/components/enphase_ev/test_site_energy.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git rev-parse --show-toplevel && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/energy.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Issue diagnostics showed `grid_import` sourced from `import` with 386 usable buckets while component/export channels had 1617 buckets. This change preserves direct-channel precedence when coverage is comparable, but uses the richer component total when direct import is sparse.
