### PR TITLE
Fix Grid Mode outage context refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Fixed Site Grid Import lifetime energy so sparse direct import buckets fall back to fuller component totals instead of leaving import totals stale. (#744)
+- Fixed Grid Mode so it uses the gateway/battery grid-outage context endpoint instead of EV charger status data.
 
 ### 🔧 Improvements
 - Exposed the IQ Gateway IP address on the Gateway Status entity attributes when available.

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -6878,6 +6878,18 @@ class EnphaseEVClient:
             return data
         return {}
 
+    async def off_grid_due_to_grid_outage(self) -> dict:
+        """Return live grid-outage/off-grid context for the site.
+
+        GET /app-api/<site_id>/off_grid_due_to_grid_outage
+        """
+
+        url = f"{BASE_URL}/app-api/{self._site}/off_grid_due_to_grid_outage"
+        data = await self._json("GET", url, headers=self._history_headers())
+        if isinstance(data, dict):
+            return data
+        return {}
+
     async def request_grid_toggle_otp(self) -> dict:
         """Request OTP delivery for a site grid-mode toggle.
 

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -51,6 +51,8 @@ from .const import (
     FAST_TOGGLE_POLL_HOLD_S,
     GRID_CONTROL_CHECK_CACHE_TTL,
     GRID_CONTROL_CHECK_STALE_AFTER_S,
+    GRID_OUTAGE_CONTEXT_CACHE_TTL,
+    GRID_OUTAGE_CONTEXT_STALE_AFTER_S,
     SAVINGS_OPERATION_MODE_SUBTYPE,
     STORM_ALERT_CACHE_TTL,
     STORM_ALERT_INACTIVE_STATUSES,
@@ -714,6 +716,35 @@ class BatteryRuntime:
         if not callable(fetcher):
             return state_present
         family = "grid_control_check"
+        if coord._endpoint_family_should_run(family, force=force):
+            return True
+        return (
+            state_present
+            and coord._endpoint_family_state(family).cooldown_active
+            and not coord._endpoint_family_can_use_stale(family)
+        )
+
+    def grid_outage_context_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        if not force and state._grid_outage_context_cache_until:
+            if now < state._grid_outage_context_cache_until:
+                return False
+        state_present = any(
+            getattr(state, attr, None) is not None
+            for attr in (
+                "_grid_outage_context_supported",
+                "_grid_outage_is_grid_outage",
+                "_grid_outage_show_grid_connect",
+                "_grid_outage_has_battery",
+                "_grid_outage_is_sunlight_backup",
+            )
+        )
+        fetcher = getattr(coord.client, "off_grid_due_to_grid_outage", None)
+        if not callable(fetcher):
+            return state_present
+        family = "grid_outage_context"
         if coord._endpoint_family_should_run(family, force=force):
             return True
         return (
@@ -3364,6 +3395,45 @@ class BatteryRuntime:
             payload.get("userInitiatedGridToggle")
         )
 
+    def parse_grid_outage_context_payload(self, payload: object) -> None:
+        state = self.battery_state
+        keys = (
+            "is_grid_outage",
+            "show_grid_connect",
+            "has_battery",
+            "is_sunlight_backup",
+        )
+        if not isinstance(payload, dict):
+            state._grid_outage_context_supported = False
+            state._grid_outage_is_grid_outage = None
+            state._grid_outage_show_grid_connect = None
+            state._grid_outage_has_battery = None
+            state._grid_outage_is_sunlight_backup = None
+            return
+        data = payload.get("data")
+        if isinstance(data, dict):
+            payload = data
+        if not any(key in payload for key in keys):
+            state._grid_outage_context_supported = False
+            state._grid_outage_is_grid_outage = None
+            state._grid_outage_show_grid_connect = None
+            state._grid_outage_has_battery = None
+            state._grid_outage_is_sunlight_backup = None
+            return
+        state._grid_outage_context_supported = True
+        state._grid_outage_is_grid_outage = self._coerce_optional_bool(
+            payload.get("is_grid_outage")
+        )
+        state._grid_outage_show_grid_connect = self._coerce_optional_bool(
+            payload.get("show_grid_connect")
+        )
+        state._grid_outage_has_battery = self._coerce_optional_bool(
+            payload.get("has_battery")
+        )
+        state._grid_outage_is_sunlight_backup = self._coerce_optional_bool(
+            payload.get("is_sunlight_backup")
+        )
+
     def backup_history_tzinfo(self) -> _tz | ZoneInfo:
         tz_name = getattr(self.battery_state, "_battery_timezone", None)
         if isinstance(tz_name, str) and tz_name.strip():
@@ -3611,6 +3681,66 @@ class BatteryRuntime:
         state._grid_control_check_failures = 0
         state._grid_control_check_last_success_mono = now
         state._grid_control_check_cache_until = now + GRID_CONTROL_CHECK_CACHE_TTL
+        coord._note_endpoint_family_success(family)
+
+    async def async_refresh_grid_outage_context(self, *, force: bool = False) -> None:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        family = "grid_outage_context"
+        if not force and state._grid_outage_context_cache_until:
+            if now < state._grid_outage_context_cache_until:
+                return
+        if not coord._endpoint_family_should_run(family, force=force):
+            if state._grid_outage_context_supported is not None and (
+                coord._endpoint_family_state(family).cooldown_active
+                and not coord._endpoint_family_can_use_stale(family)
+            ):
+                state._grid_outage_context_supported = None
+                state._grid_outage_is_grid_outage = None
+                state._grid_outage_show_grid_connect = None
+                state._grid_outage_has_battery = None
+                state._grid_outage_is_sunlight_backup = None
+            return
+        fetcher = getattr(coord.client, "off_grid_due_to_grid_outage", None)
+        if not callable(fetcher):
+            state._grid_outage_context_supported = None
+            state._grid_outage_is_grid_outage = None
+            state._grid_outage_show_grid_connect = None
+            state._grid_outage_has_battery = None
+            state._grid_outage_is_sunlight_backup = None
+            return
+        try:
+            payload = await fetcher()
+        except Exception as err:  # noqa: BLE001
+            coord._note_endpoint_family_failure(family, err)
+            state._grid_outage_context_failures = max(
+                state._grid_outage_context_failures + 1,
+                coord._endpoint_family_state(family).consecutive_failures,
+            )
+            last_success = getattr(
+                state, "_grid_outage_context_last_success_mono", None
+            )
+            if (
+                not isinstance(last_success, (int, float))
+                or (now - float(last_success)) >= GRID_OUTAGE_CONTEXT_STALE_AFTER_S
+            ):
+                state._grid_outage_context_supported = None
+                state._grid_outage_is_grid_outage = None
+                state._grid_outage_show_grid_connect = None
+                state._grid_outage_has_battery = None
+                state._grid_outage_is_sunlight_backup = None
+            state._grid_outage_context_cache_until = now + 15.0
+            return
+        redacted_payload = coord.redact_battery_payload(payload)
+        if isinstance(redacted_payload, dict):
+            state._grid_outage_context_payload = redacted_payload
+        else:
+            state._grid_outage_context_payload = {"value": redacted_payload}
+        self.parse_grid_outage_context_payload(payload)
+        state._grid_outage_context_failures = 0
+        state._grid_outage_context_last_success_mono = now
+        state._grid_outage_context_cache_until = now + GRID_OUTAGE_CONTEXT_CACHE_TTL
         coord._note_endpoint_family_success(family)
 
     async def async_refresh_dry_contact_settings(self, *, force: bool = False) -> None:

--- a/custom_components/enphase_ev/const.py
+++ b/custom_components/enphase_ev/const.py
@@ -120,10 +120,12 @@ STORM_GUARD_CACHE_TTL = 300.0
 STORM_ALERT_CACHE_TTL = 300.0
 STORM_GUARD_PENDING_HOLD_S = 90.0
 GRID_CONTROL_CHECK_CACHE_TTL = 60.0
+GRID_OUTAGE_CONTEXT_CACHE_TTL = 60.0
 # Keep the last confirmed grid-control state valid across the initial
 # endpoint-family cooldown window after a transient failure. This avoids
 # spurious ready/unknown flapping while the retry is intentionally deferred.
 GRID_CONTROL_CHECK_STALE_AFTER_S = 360.0
+GRID_OUTAGE_CONTEXT_STALE_AFTER_S = 360.0
 DRY_CONTACT_SETTINGS_CACHE_TTL = 300.0
 DRY_CONTACT_SETTINGS_FAILURE_CACHE_TTL = 15.0
 DRY_CONTACT_SETTINGS_STALE_AFTER_S = 900.0

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -86,6 +86,8 @@ from .const import (
     DRY_CONTACT_SETTINGS_STALE_AFTER_S,
     DOMAIN,
     GRID_CONTROL_CHECK_STALE_AFTER_S,
+    GRID_OUTAGE_CONTEXT_CACHE_TTL,
+    GRID_OUTAGE_CONTEXT_STALE_AFTER_S,
     HEMS_AUTH_BACKOFF_STEPS_S,
     HEMS_AUTH_MANUAL_CLEAR_COOLDOWN_S,
     OPT_API_TIMEOUT,
@@ -901,6 +903,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             "grid_control_check": EndpointFamilyPolicy(
                 success_ttl_s=300.0,
                 stale_after_s=GRID_CONTROL_CHECK_STALE_AFTER_S,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+            "grid_outage_context": EndpointFamilyPolicy(
+                success_ttl_s=GRID_OUTAGE_CONTEXT_CACHE_TTL,
+                stale_after_s=GRID_OUTAGE_CONTEXT_STALE_AFTER_S,
                 failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
                 max_backoff_s=3600.0,
                 optional=True,
@@ -2342,6 +2353,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             "status_payload": getattr(self, "_battery_status_payload", None),
             "grid_control_check_payload": getattr(
                 self, "_grid_control_check_payload", None
+            ),
+            "grid_outage_context_payload": getattr(
+                self, "_grid_outage_context_payload", None
             ),
             "dry_contacts_payload": getattr(
                 self, "_dry_contact_settings_payload", None
@@ -6209,6 +6223,51 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return None
         return getattr(self, "_grid_control_user_initiated_toggle", None)
 
+    def _grid_outage_context_is_stale(self) -> bool:
+        raw_supported = getattr(self, "_grid_outage_context_supported", None)
+        if raw_supported is None:
+            return True
+        last_success = getattr(self, "_grid_outage_context_last_success_mono", None)
+        if not isinstance(last_success, (int, float)):
+            return False
+        age = time.monotonic() - float(last_success)
+        if age < 0:
+            return False
+        return age >= GRID_OUTAGE_CONTEXT_STALE_AFTER_S
+
+    @property
+    def grid_outage_context_supported(self) -> bool | None:
+        raw_supported = getattr(self, "_grid_outage_context_supported", None)
+        if raw_supported is None:
+            return None
+        if self._grid_outage_context_is_stale():
+            return None
+        return raw_supported
+
+    @property
+    def grid_outage_is_grid_outage(self) -> bool | None:
+        if self.grid_outage_context_supported is not True:
+            return None
+        return getattr(self, "_grid_outage_is_grid_outage", None)
+
+    @property
+    def grid_outage_show_grid_connect(self) -> bool | None:
+        if self.grid_outage_context_supported is not True:
+            return None
+        return getattr(self, "_grid_outage_show_grid_connect", None)
+
+    @property
+    def grid_outage_has_battery(self) -> bool | None:
+        if self.grid_outage_context_supported is not True:
+            return None
+        return getattr(self, "_grid_outage_has_battery", None)
+
+    @property
+    def grid_outage_is_sunlight_backup(self) -> bool | None:
+        if self.grid_outage_context_supported is not True:
+            return None
+        return getattr(self, "_grid_outage_is_sunlight_backup", None)
+
     @property
     def grid_toggle_pending(self) -> bool:
         return self.grid_control_user_initiated_toggle is True
@@ -6301,34 +6360,21 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @property
     def grid_mode_raw_states(self) -> list[str]:
-        out: list[str] = []
-        seen: set[str] = set()
-        data = self.data if isinstance(self.data, dict) else {}
-        for payload in data.values():
-            if not isinstance(payload, dict):
-                continue
-            raw = self._coerce_optional_text(payload.get("off_grid_state"))
-            if not raw:
-                continue
-            if raw in seen:
-                continue
-            seen.add(raw)
-            out.append(raw)
-        return sorted(out)
+        outage_state = self.grid_outage_is_grid_outage
+        if outage_state is True:
+            return ["is_grid_outage:true"]
+        if outage_state is False:
+            return ["is_grid_outage:false"]
+        return []
 
     @property
     def grid_mode(self) -> str | None:
-        raw_states = self.grid_mode_raw_states
-        if not raw_states:
-            return None
-        normalized = {
-            mode
-            for mode in (self._normalize_grid_mode_value(state) for state in raw_states)
-            if mode is not None
-        }
-        if len(normalized) == 1:
-            return next(iter(normalized))
-        return "unknown"
+        outage_state = self.grid_outage_is_grid_outage
+        if outage_state is True:
+            return "off_grid"
+        if outage_state is False:
+            return "on_grid"
+        return None
 
     def _raise_grid_validation(
         self,
@@ -7279,6 +7325,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     async def _async_refresh_grid_control_check(self, *, force: bool = False) -> None:
         await self.battery_runtime.async_refresh_grid_control_check(force=force)
+
+    async def _async_refresh_grid_outage_context(self, *, force: bool = False) -> None:
+        await self.battery_runtime.async_refresh_grid_outage_context(force=force)
 
     async def _async_refresh_dry_contact_settings(self, *, force: bool = False) -> None:
         await self.battery_runtime.async_refresh_dry_contact_settings(force=force)

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -864,6 +864,17 @@ class CoordinatorDiagnostics:
                 coord, "_grid_control_check_failures", 0
             ),
             "grid_control_data_stale": coord.grid_control_supported is None,
+            "grid_outage_context_supported": coord.grid_outage_context_supported,
+            "grid_outage_is_grid_outage": coord.grid_outage_is_grid_outage,
+            "grid_outage_show_grid_connect": coord.grid_outage_show_grid_connect,
+            "grid_outage_has_battery": coord.grid_outage_has_battery,
+            "grid_outage_is_sunlight_backup": coord.grid_outage_is_sunlight_backup,
+            "grid_outage_context_fetch_failures": getattr(
+                coord, "_grid_outage_context_failures", 0
+            ),
+            "grid_outage_context_data_stale": (
+                coord.grid_outage_context_supported is None
+            ),
             "dry_contact_settings_supported": coord.dry_contact_settings_supported,
             "dry_contact_settings_contact_count": len(
                 getattr(coord, "_dry_contact_settings_entries", []) or []
@@ -888,6 +899,14 @@ class CoordinatorDiagnostics:
             age = time.monotonic() - float(grid_last_success)
             if age >= 0:
                 metrics["grid_control_last_success_age_s"] = round(age, 1)
+
+        grid_outage_last_success = getattr(
+            coord, "_grid_outage_context_last_success_mono", None
+        )
+        if isinstance(grid_outage_last_success, (int, float)):
+            age = time.monotonic() - float(grid_outage_last_success)
+            if age >= 0:
+                metrics["grid_outage_context_last_success_age_s"] = round(age, 1)
 
         dry_contacts_last_success = getattr(
             coord, "_dry_contact_settings_last_success_mono", None

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -16,6 +16,7 @@ REFRESH_TASK_ENDPOINT_FAMILIES: dict[str, str] = {
     "storm_alert_s": "storm_alert",
     "tariff_s": "tariff",
     "grid_control_check_s": "grid_control_check",
+    "grid_outage_context_s": "grid_outage_context",
     "dry_contact_settings_s": "dry_contact_settings",
     "battery_status_s": "battery_status",
     "ac_battery_devices_s": "ac_battery_devices",
@@ -230,6 +231,12 @@ WARMUP_STATE_STAGE = RefreshStage(
             "battery_runtime",
             "async_refresh_grid_control_check",
         ),
+        object_method_task(
+            "grid_outage_context_s",
+            "grid outage context",
+            "battery_runtime",
+            "async_refresh_grid_outage_context",
+        ),
         method_task(
             "dry_contact_settings_s",
             "dry contact settings",
@@ -284,6 +291,12 @@ SITE_ONLY_FOLLOWUP_STAGE = RefreshStage(
             "grid control",
             "battery_runtime",
             "async_refresh_grid_control_check",
+        ),
+        object_method_task(
+            "grid_outage_context_s",
+            "grid outage context",
+            "battery_runtime",
+            "async_refresh_grid_outage_context",
         ),
         method_task(
             "dry_contact_settings_s",
@@ -599,6 +612,15 @@ def build_followup_plan(owner: object, *, force_full: bool = False) -> RefreshPl
                 "grid control",
                 "battery_runtime",
                 "async_refresh_grid_control_check",
+            )
+        )
+    if battery.grid_outage_context_refresh_due():
+        parallel.append(
+            object_method_task(
+                "grid_outage_context_s",
+                "grid outage context",
+                "battery_runtime",
+                "async_refresh_grid_outage_context",
             )
         )
     if battery.dry_contact_settings_refresh_due():

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -8872,7 +8872,19 @@ class EnphaseGridModeSensor(_SiteBaseEntity):
     @property
     def extra_state_attributes(self):
         return {
+            "source": "grid_outage_context",
             "raw_states": getattr(self._coord, "grid_mode_raw_states", []),
+            "grid_outage_context_supported": getattr(
+                self._coord, "grid_outage_context_supported", None
+            ),
+            "is_grid_outage": getattr(self._coord, "grid_outage_is_grid_outage", None),
+            "show_grid_connect": getattr(
+                self._coord, "grid_outage_show_grid_connect", None
+            ),
+            "has_battery": getattr(self._coord, "grid_outage_has_battery", None),
+            "is_sunlight_backup": getattr(
+                self._coord, "grid_outage_is_sunlight_backup", None
+            ),
             "grid_control_supported": self._coord.grid_control_supported,
             "grid_toggle_allowed": self._coord.grid_toggle_allowed,
         }

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -322,6 +322,15 @@ class BatteryState:
     _grid_control_grid_outage_check: bool | None = None
     _grid_control_user_initiated_toggle: bool | None = None
     _grid_control_supported: bool | None = None
+    _grid_outage_context_cache_until: float | None = None
+    _grid_outage_context_last_success_mono: float | None = None
+    _grid_outage_context_failures: int = 0
+    _grid_outage_context_payload: PayloadMap | None = None
+    _grid_outage_context_supported: bool | None = None
+    _grid_outage_is_grid_outage: bool | None = None
+    _grid_outage_show_grid_connect: bool | None = None
+    _grid_outage_has_battery: bool | None = None
+    _grid_outage_is_sunlight_backup: bool | None = None
     _dry_contact_settings_cache_until: float | None = None
     _dry_contact_settings_last_success_mono: float | None = None
     _dry_contact_settings_failures: int = 0

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -2546,6 +2546,40 @@ async def test_grid_control_check_uses_grid_control_check_endpoint() -> None:
 
 
 @pytest.mark.asyncio
+async def test_off_grid_due_to_grid_outage_uses_status_context_endpoint() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"is_grid_outage": True})
+
+    result = await client.off_grid_due_to_grid_outage()
+
+    assert result == {"is_grid_outage": True}
+    client._json.assert_awaited_once_with(
+        "GET",
+        f"{api.BASE_URL}/app-api/SITE/off_grid_due_to_grid_outage",
+        headers={
+            "Accept": "*/*",
+            "X-Requested-With": "XMLHttpRequest",
+            "Referer": f"{api.BASE_URL}/web/SITE/history/graph/years",
+            "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
+            "Cookie": "COOKIE",
+            "e-auth-token": "EAUTH",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_off_grid_due_to_grid_outage_returns_empty_when_payload_not_dict() -> (
+    None
+):
+    client = _make_client()
+    client._json = AsyncMock(return_value=["bad"])
+
+    result = await client.off_grid_due_to_grid_outage()
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
 async def test_request_grid_toggle_otp_uses_endpoint() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"success": "email sent successfully"})

--- a/tests/components/enphase_ev/test_api_urls.py
+++ b/tests/components/enphase_ev/test_api_urls.py
@@ -25,6 +25,7 @@ async def test_api_builds_urls_correctly():
     await c.battery_status()
     await c.dry_contacts_settings()
     await c.grid_control_check()
+    await c.off_grid_due_to_grid_outage()
     await c.request_grid_toggle_otp()
     await c.validate_grid_toggle_otp("1234")
     await c.set_grid_state("ENV123", 1)
@@ -54,24 +55,28 @@ async def test_api_builds_urls_correctly():
     assert methods_urls[3][0] == "GET"
     assert f"/app-api/{RANDOM_SITE_ID}/grid_control_check.json" in methods_urls[3][1]
     assert methods_urls[4][0] == "GET"
-    assert f"/app-api/{RANDOM_SITE_ID}/grid_toggle_otp.json" in methods_urls[4][1]
-    assert methods_urls[5][0] == "POST"
-    assert "/app-api/grid_toggle_otp.json" in methods_urls[5][1]
-    assert methods_urls[6][0] == "POST"
-    assert "/pv/settings/grid_state.json" in methods_urls[6][1]
-    assert methods_urls[7][0] == "POST"
-    assert "/pv/settings/log_grid_change.json" in methods_urls[7][1]
-    assert methods_urls[8][0] == "GET"
     assert (
-        f"/app-api/{RANDOM_SITE_ID}/battery_backup_history.json" in methods_urls[8][1]
+        f"/app-api/{RANDOM_SITE_ID}/off_grid_due_to_grid_outage" in methods_urls[4][1]
     )
+    assert methods_urls[5][0] == "GET"
+    assert f"/app-api/{RANDOM_SITE_ID}/grid_toggle_otp.json" in methods_urls[5][1]
+    assert methods_urls[6][0] == "POST"
+    assert "/app-api/grid_toggle_otp.json" in methods_urls[6][1]
+    assert methods_urls[7][0] == "POST"
+    assert "/pv/settings/grid_state.json" in methods_urls[7][1]
+    assert methods_urls[8][0] == "POST"
+    assert "/pv/settings/log_grid_change.json" in methods_urls[8][1]
     assert methods_urls[9][0] == "GET"
-    assert f"/app-api/{RANDOM_SITE_ID}/inverters.json" in methods_urls[9][1]
-    assert methods_urls[10][0] == "GET"
-    assert f"/systems/{RANDOM_SITE_ID}/inverter_status_x.json" in methods_urls[10][1]
-    assert methods_urls[11][0] == "GET"
     assert (
-        f"/systems/{RANDOM_SITE_ID}/inverter_data_x/energy.json" in methods_urls[11][1]
+        f"/app-api/{RANDOM_SITE_ID}/battery_backup_history.json" in methods_urls[9][1]
+    )
+    assert methods_urls[10][0] == "GET"
+    assert f"/app-api/{RANDOM_SITE_ID}/inverters.json" in methods_urls[10][1]
+    assert methods_urls[11][0] == "GET"
+    assert f"/systems/{RANDOM_SITE_ID}/inverter_status_x.json" in methods_urls[11][1]
+    assert methods_urls[12][0] == "GET"
+    assert (
+        f"/systems/{RANDOM_SITE_ID}/inverter_data_x/energy.json" in methods_urls[12][1]
     )
     opt_out_call = next(
         (

--- a/tests/components/enphase_ev/test_battery_runtime_grid_control.py
+++ b/tests/components/enphase_ev/test_battery_runtime_grid_control.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 import time
 from unittest.mock import AsyncMock
 
 import pytest
+
+from custom_components.enphase_ev.const import GRID_OUTAGE_CONTEXT_CACHE_TTL
 
 
 def test_grid_control_supported_is_unknown_before_first_payload(
@@ -183,6 +186,178 @@ async def test_refresh_grid_control_check_wraps_non_dict_redaction(
 
 
 @pytest.mark.asyncio
+async def test_refresh_grid_outage_context_caches_and_redacts(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.off_grid_due_to_grid_outage = AsyncMock(
+        return_value={
+            "is_grid_outage": True,
+            "show_grid_connect": False,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+            "token": "secret-token",
+        }
+    )
+
+    await coord.battery_runtime.async_refresh_grid_outage_context(force=True)
+
+    assert coord.grid_outage_context_supported is True
+    assert coord.grid_outage_is_grid_outage is True
+    assert coord.grid_mode == "off_grid"
+    assert coord._grid_outage_context_payload is not None  # noqa: SLF001
+    assert coord._grid_outage_context_payload["token"] == "[redacted]"  # noqa: SLF001
+
+    coord._grid_outage_context_cache_until = time.monotonic() + 300  # noqa: SLF001
+    coord.client.off_grid_due_to_grid_outage.reset_mock()
+    await coord.battery_runtime.async_refresh_grid_outage_context()
+    coord.client.off_grid_due_to_grid_outage.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_outage_context_family_ttl_matches_cache(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.off_grid_due_to_grid_outage = AsyncMock(
+        return_value={
+            "is_grid_outage": False,
+            "show_grid_connect": True,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+
+    await coord.battery_runtime.async_refresh_grid_outage_context(force=True)
+
+    family_state = coord._endpoint_family_state("grid_outage_context")  # noqa: SLF001
+    assert family_state.last_success_mono is not None
+    assert family_state.next_retry_mono is not None
+    assert (
+        family_state.next_retry_mono - family_state.last_success_mono
+    ) == GRID_OUTAGE_CONTEXT_CACHE_TTL
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_outage_context_failure_marks_unknown_when_stale(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": False,
+            "show_grid_connect": True,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    coord._grid_outage_context_last_success_mono = (
+        time.monotonic() - 999
+    )  # noqa: SLF001
+    coord.client.off_grid_due_to_grid_outage = AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+
+    await coord.battery_runtime.async_refresh_grid_outage_context(force=True)
+
+    assert coord.grid_outage_context_supported is None
+    assert coord.grid_outage_is_grid_outage is None
+    assert coord.grid_mode is None
+    assert coord._grid_outage_context_failures == 1  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_outage_context_keeps_recent_state_on_failure(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": False,
+            "show_grid_connect": True,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    coord._grid_outage_context_last_success_mono = time.monotonic()  # noqa: SLF001
+    coord.client.off_grid_due_to_grid_outage = AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+
+    await coord.battery_runtime.async_refresh_grid_outage_context(force=True)
+
+    assert coord.grid_outage_context_supported is True
+    assert coord.grid_mode == "on_grid"
+    assert coord._grid_outage_context_failures == 1  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_outage_context_clears_when_endpoint_in_cooldown(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": False,
+            "show_grid_connect": True,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    coord._endpoint_family_should_run = lambda *_args, **_kwargs: False  # type: ignore[method-assign]  # noqa: SLF001
+    coord._endpoint_family_state = lambda *_args, **_kwargs: SimpleNamespace(  # type: ignore[method-assign]  # noqa: SLF001
+        cooldown_active=True
+    )
+    coord._endpoint_family_can_use_stale = lambda *_args, **_kwargs: False  # type: ignore[method-assign]  # noqa: SLF001
+
+    await coord.battery_runtime.async_refresh_grid_outage_context()
+
+    assert coord.grid_outage_context_supported is None
+    assert coord.grid_outage_is_grid_outage is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_outage_context_missing_fetcher_clears_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": True,
+            "show_grid_connect": False,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    coord.client.off_grid_due_to_grid_outage = None
+
+    await coord.battery_runtime.async_refresh_grid_outage_context(force=True)
+
+    assert coord.grid_outage_context_supported is None
+    assert coord.grid_mode is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_outage_context_wraps_non_dict_redaction(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.off_grid_due_to_grid_outage = AsyncMock(
+        return_value={
+            "is_grid_outage": False,
+            "show_grid_connect": True,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    coord._redact_battery_payload = lambda _payload: "masked"  # type: ignore[method-assign]  # noqa: SLF001
+
+    await coord.battery_runtime.async_refresh_grid_outage_context(force=True)
+
+    assert coord._grid_outage_context_payload == {"value": "masked"}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_refresh_grid_control_check_failure_marks_unknown_when_stale(
     coordinator_factory,
 ) -> None:
@@ -310,37 +485,157 @@ def test_collect_site_metrics_includes_grid_control_last_success_age(
     assert isinstance(metrics["grid_control_last_success_age_s"], float)
 
 
-def test_grid_mode_normalization_and_raw_states(coordinator_factory) -> None:
+def test_grid_mode_uses_grid_outage_context(coordinator_factory) -> None:
     coord = coordinator_factory()
     assert coord._normalize_grid_mode_value(None) is None  # noqa: SLF001
+
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": False,
+            "show_grid_connect": True,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    assert coord.grid_mode_raw_states == ["is_grid_outage:false"]
+    assert coord.grid_mode == "on_grid"
+
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "data": {
+                "is_grid_outage": True,
+                "show_grid_connect": False,
+                "has_battery": True,
+                "is_sunlight_backup": False,
+            }
+        }
+    )
+    assert coord.grid_mode_raw_states == ["is_grid_outage:true"]
+    assert coord.grid_mode == "off_grid"
+
+    coord.battery_runtime.parse_grid_outage_context_payload({})
+    assert coord.grid_mode_raw_states == []
+    assert coord.grid_mode is None
 
     coord.data = {
         "A": {"off_grid_state": "ON_GRID"},
         "B": {"off_grid_state": "ON_GRID"},
     }
-    assert coord.grid_mode_raw_states == ["ON_GRID"]
-    assert coord.grid_mode == "on_grid"
-
-    coord.data = {
-        "A": {"off_grid_state": "OFF_GRID"},
-        "B": {"off_grid_state": "ON_GRID"},
-    }
-    assert coord.grid_mode == "unknown"
-
-    coord.data = {
-        "A": {"off_grid_state": "unexpected"},
-    }
-    assert coord.grid_mode == "unknown"
-
-    coord.data = {}
     assert coord.grid_mode is None
-
-    coord.data = {
-        "A": "bad",
-        "B": {"off_grid_state": None},
-        "C": {"off_grid_state": ""},
-    }
     assert coord.grid_mode_raw_states == []
+
+
+def test_parse_grid_outage_context_payload_tracks_fields(coordinator_factory) -> None:
+    coord = coordinator_factory()
+
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": "true",
+            "show_grid_connect": "false",
+            "has_battery": 1,
+            "is_sunlight_backup": 0,
+        }
+    )
+
+    assert coord.grid_outage_context_supported is True
+    assert coord.grid_outage_is_grid_outage is True
+    assert coord.grid_outage_show_grid_connect is False
+    assert coord.grid_outage_has_battery is True
+    assert coord.grid_outage_is_sunlight_backup is False
+
+    coord.battery_runtime.parse_grid_outage_context_payload(["bad"])
+
+    assert coord.grid_outage_context_supported is False
+    assert coord.grid_outage_is_grid_outage is None
+
+
+def test_grid_outage_context_metrics(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": True,
+            "show_grid_connect": False,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    coord._grid_outage_context_last_success_mono = (
+        time.monotonic() - 1.0
+    )  # noqa: SLF001
+
+    metrics = coord.collect_site_metrics()
+
+    assert metrics["grid_outage_context_supported"] is True
+    assert metrics["grid_outage_is_grid_outage"] is True
+    assert metrics["grid_outage_show_grid_connect"] is False
+    assert metrics["grid_outage_context_fetch_failures"] == 0
+    assert metrics["grid_outage_context_data_stale"] is False
+    assert "grid_outage_context_last_success_age_s" in metrics
+
+
+def test_grid_outage_context_refresh_due_uses_cooldown_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": False,
+            "show_grid_connect": True,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    coord._endpoint_family_should_run = lambda *_args, **_kwargs: False  # type: ignore[method-assign]  # noqa: SLF001
+    coord._endpoint_family_state = lambda *_args, **_kwargs: SimpleNamespace(  # type: ignore[method-assign]  # noqa: SLF001
+        cooldown_active=True
+    )
+    coord._endpoint_family_can_use_stale = lambda *_args, **_kwargs: False  # type: ignore[method-assign]  # noqa: SLF001
+
+    assert coord.battery_runtime.grid_outage_context_refresh_due() is True
+
+
+def test_grid_outage_context_staleness_edges(coordinator_factory) -> None:
+    coord = coordinator_factory()
+
+    assert coord._grid_outage_context_is_stale() is True  # noqa: SLF001
+
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": False,
+            "show_grid_connect": True,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    coord._grid_outage_context_last_success_mono = time.monotonic() + 5  # noqa: SLF001
+    assert coord._grid_outage_context_is_stale() is False  # noqa: SLF001
+
+    coord._grid_outage_context_last_success_mono = (
+        time.monotonic() - 999
+    )  # noqa: SLF001
+    assert coord.grid_outage_context_supported is None
+
+
+def test_grid_mode_legacy_normalizer_is_retained(coordinator_factory) -> None:
+    coord = coordinator_factory()
+
+    assert coord._normalize_grid_mode_value("OFF_GRID") == "off_grid"  # noqa: SLF001
+    assert coord._normalize_grid_mode_value("ON_GRID") == "on_grid"  # noqa: SLF001
+    assert coord._normalize_grid_mode_value("unexpected") is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_coordinator_refresh_grid_outage_context_proxy(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.battery_runtime.async_refresh_grid_outage_context = AsyncMock()  # type: ignore[method-assign]
+
+    await coord._async_refresh_grid_outage_context(force=True)  # noqa: SLF001
+
+    coord.battery_runtime.async_refresh_grid_outage_context.assert_awaited_once_with(
+        force=True
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -294,6 +294,7 @@ class _RefreshOwner:
         )
         self.battery_runtime = SimpleNamespace(
             async_refresh_grid_control_check=self._async_refresh_grid_control_check,
+            async_refresh_grid_outage_context=self._async_refresh_grid_outage_context,
             async_refresh_battery_status=self._async_refresh_battery_status,
             battery_site_settings_refresh_due=lambda: True,
             battery_backup_history_refresh_due=lambda: True,
@@ -302,6 +303,7 @@ class _RefreshOwner:
             storm_guard_refresh_due=lambda: True,
             storm_alert_refresh_due=lambda: True,
             grid_control_check_refresh_due=lambda: True,
+            grid_outage_context_refresh_due=lambda: True,
             dry_contact_settings_refresh_due=lambda: True,
             battery_status_refresh_due=lambda: True,
             ac_battery_devices_refresh_due=lambda: True,
@@ -365,6 +367,10 @@ class _RefreshOwner:
     def _async_refresh_grid_control_check(self) -> str:
         self.calls.append("grid_control")
         return "grid-control"
+
+    def _async_refresh_grid_outage_context(self) -> str:
+        self.calls.append("grid_outage_context")
+        return "grid-outage-context"
 
     def _async_refresh_dry_contact_settings(self) -> str:
         self.calls.append("dry_contact")
@@ -449,6 +455,7 @@ def test_followup_refresh_stage_binds_zero_arg_calls() -> None:
         "storm_alert_s",
         "tariff_s",
         "grid_control_check_s",
+        "grid_outage_context_s",
         "dry_contact_settings_s",
         "current_power_s",
     ]
@@ -503,6 +510,7 @@ def test_dynamic_followup_plan_skips_up_to_date_tasks() -> None:
     owner.battery_runtime.storm_guard_refresh_due = lambda: False
     owner.battery_runtime.storm_alert_refresh_due = lambda: False
     owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.grid_outage_context_refresh_due = lambda: False
     owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
     owner.battery_runtime.battery_status_refresh_due = lambda: False
     owner.battery_runtime.ac_battery_devices_refresh_due = lambda: False
@@ -536,6 +544,7 @@ def test_dynamic_followup_plan_selects_due_subset() -> None:
     assert [task.timing_key for task in stage.parallel_tasks] == [
         "battery_site_settings_s",
         "tariff_s",
+        "grid_outage_context_s",
     ]
     assert [task.timing_key for task in stage.ordered_tasks] == [
         "battery_status_s",
@@ -569,6 +578,7 @@ def test_dynamic_site_only_followup_plan_creates_inverter_stage_without_base_fol
     owner.battery_runtime.storm_guard_refresh_due = lambda: False
     owner.battery_runtime.storm_alert_refresh_due = lambda: False
     owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.grid_outage_context_refresh_due = lambda: False
     owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
     owner.battery_runtime.battery_status_refresh_due = lambda: False
     owner.battery_runtime.ac_battery_devices_refresh_due = lambda: False
@@ -599,6 +609,7 @@ def test_dynamic_followup_plan_includes_due_evse_feature_flags() -> None:
     owner.battery_runtime.storm_guard_refresh_due = lambda: False
     owner.battery_runtime.storm_alert_refresh_due = lambda: False
     owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.grid_outage_context_refresh_due = lambda: False
     owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
     owner.battery_runtime.battery_status_refresh_due = lambda: False
     owner.battery_runtime.ac_battery_devices_refresh_due = lambda: False
@@ -743,7 +754,7 @@ async def test_coordinator_refresh_plan_runner_executes_each_stage(
     await coord.refresh_runner.async_run_refresh_plan({}, plan=FOLLOWUP_PLAN)
 
     assert seen == [
-        (None, True, 10, 4),
+        (None, True, 11, 4),
     ]
 
 

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -311,6 +311,11 @@ class DummyCoordinator(SimpleNamespace):
             "disableGridControl": False,
             "activeDownload": False,
         }
+        self._grid_outage_context_payload = {
+            "is_grid_outage": False,
+            "show_grid_connect": True,
+            "has_battery": True,
+        }
         self._dry_contact_settings_payload = {
             "data": {
                 "contacts": [
@@ -663,6 +668,7 @@ class DummyCoordinator(SimpleNamespace):
             "settings_payload": self._battery_settings_payload,
             "status_payload": self._battery_status_payload,
             "grid_control_check_payload": self._grid_control_check_payload,
+            "grid_outage_context_payload": self._grid_outage_context_payload,
             "dry_contacts_payload": self._dry_contact_settings_payload,
             "backup_history_payload": self._battery_backup_history_payload,
             "hems_devices_payload": self._hems_devices_payload,
@@ -817,6 +823,12 @@ async def test_config_entry_diagnostics_includes_coordinator(
     assert (
         diag["coordinator"]["battery_config"]["grid_control_check_payload"][
             "disableGridControl"
+        ]
+        is False
+    )
+    assert (
+        diag["coordinator"]["battery_config"]["grid_outage_context_payload"][
+            "is_grid_outage"
         ]
         is False
     )

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -1757,7 +1757,12 @@ def test_grid_mode_sensor_states_and_attributes():
         battery_has_encharge=True,
         has_type=lambda key: key in ("envoy", "enpower"),
         grid_mode="on_grid",
-        grid_mode_raw_states=["ON_GRID"],
+        grid_mode_raw_states=["is_grid_outage:false"],
+        grid_outage_context_supported=True,
+        grid_outage_is_grid_outage=False,
+        grid_outage_show_grid_connect=True,
+        grid_outage_has_battery=True,
+        grid_outage_is_sunlight_backup=False,
         grid_control_supported=True,
         grid_toggle_allowed=True,
         last_success_utc=None,
@@ -1767,16 +1772,24 @@ def test_grid_mode_sensor_states_and_attributes():
     assert sensor.available is True
     assert sensor.native_value == "on_grid"
     attrs = sensor.extra_state_attributes
-    assert attrs["raw_states"] == ["ON_GRID"]
+    assert attrs["source"] == "grid_outage_context"
+    assert attrs["raw_states"] == ["is_grid_outage:false"]
+    assert attrs["grid_outage_context_supported"] is True
+    assert attrs["is_grid_outage"] is False
+    assert attrs["show_grid_connect"] is True
+    assert attrs["has_battery"] is True
+    assert attrs["is_sunlight_backup"] is False
     assert attrs["grid_control_supported"] is True
     assert attrs["grid_toggle_allowed"] is True
 
     coord.grid_mode = "off_grid"
-    coord.grid_mode_raw_states = ["OFF_GRID"]
+    coord.grid_mode_raw_states = ["is_grid_outage:true"]
+    coord.grid_outage_is_grid_outage = True
     assert sensor.native_value == "off_grid"
 
     coord.grid_mode = None
     coord.grid_mode_raw_states = []
+    coord.grid_outage_is_grid_outage = None
     assert sensor.native_value == "unknown"
     coord.last_success_utc = datetime(2026, 2, 15, 5, 31, 33, tzinfo=timezone.utc)
     coord.last_update_success = False
@@ -1793,7 +1806,12 @@ def test_grid_mode_sensor_unavailable_without_supported_types():
         battery_has_encharge=True,
         has_type=lambda _key: False,
         grid_mode="on_grid",
-        grid_mode_raw_states=["ON_GRID"],
+        grid_mode_raw_states=["is_grid_outage:false"],
+        grid_outage_context_supported=True,
+        grid_outage_is_grid_outage=False,
+        grid_outage_show_grid_connect=True,
+        grid_outage_has_battery=True,
+        grid_outage_is_sunlight_backup=False,
         grid_control_supported=True,
         grid_toggle_allowed=True,
         last_success_utc=None,
@@ -1813,7 +1831,12 @@ def test_grid_mode_sensor_unavailable_when_site_not_battery_capable():
         battery_has_enpower=False,
         has_type=lambda key: key in ("envoy", "enpower"),
         grid_mode="on_grid",
-        grid_mode_raw_states=["ON_GRID"],
+        grid_mode_raw_states=["is_grid_outage:false"],
+        grid_outage_context_supported=True,
+        grid_outage_is_grid_outage=False,
+        grid_outage_show_grid_connect=True,
+        grid_outage_has_battery=True,
+        grid_outage_is_sunlight_backup=False,
         grid_control_supported=True,
         grid_toggle_allowed=True,
         last_success_utc=None,


### PR DESCRIPTION
## Summary

Fix Grid Mode so it is sourced from the gateway/battery grid-outage context endpoint instead of EV charger status data. This adds polling, caching, stale-state handling, diagnostics, sensor attributes, and tests for `/app-api/<site_id>/off_grid_due_to_grid_outage`.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/const.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_api_urls.py tests/components/enphase_ev/test_battery_runtime_grid_control.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_sensors.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/const.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/refresh_plan.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/state_models.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Pre-commit was run in Docker with the repository Git common directory mounted because this Codex worktree's `.git` file points to a host worktree metadata path that is otherwise unavailable inside the container.
