### PR TITLE
Use live grid relay state for Grid Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed Grid Mode so it reads the live-stream `meters.gridRelay` value and
+  falls back to outage-context fields such as `show_grid_connect` only when the
+  live relay state is unavailable.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -19,7 +19,7 @@ import re
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from http import HTTPStatus
-from urllib.parse import unquote
+from urllib.parse import unquote, urlencode
 import uuid
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Iterable
@@ -64,6 +64,14 @@ _BATTERY_CONFIG_VARIANT_LEAN = "official_web_lean"
 _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH = "cookie_eauth_compatible"
 _BATTERY_CONFIG_VARIANT_MIXED = "mixed_auth_compatible"
 _ENLIGHTEN_READ_CONCURRENCY_LIMIT = 2
+_LIVE_STATUS_GRID_RELAY_ENUM = {
+    0: "OPER_RELAY_UNKNOWN",
+    1: "OPER_RELAY_OPEN",
+    2: "OPER_RELAY_CLOSED",
+    3: "OPER_RELAY_OFFGRID_AC_GRID_PRESENT",
+    4: "OPER_RELAY_OFFGRID_READY_FOR_RESYNC_CMD",
+    5: "OPER_RELAY_WAITING_TO_INITIALIZE_ON_GRID",
+}
 OCPP_TRIGGER_MESSAGES = frozenset(
     {
         "BootNotification",
@@ -6088,6 +6096,360 @@ class EnphaseEVClient:
                 return None
             raise
         return data if isinstance(data, dict) else None
+
+    async def site_livestream_authorizer(
+        self,
+        serial_num: str,
+        *,
+        live_debug: bool = False,
+        allow_reauth: bool = True,
+    ) -> dict[str, object] | None:
+        """Return signed AWS IoT connection details for the site live stream."""
+
+        query: dict[str, str] = {"serial_num": str(serial_num)}
+        if live_debug:
+            query["live_debug"] = "true"
+        url = URL(f"{BASE_URL}/pv/aws_sigv4/livestream.json").with_query(query)
+        headers = self._today_headers()
+        headers["X-Requested-With"] = "XMLHttpRequest"
+        try:
+            data = await self._json(
+                "GET",
+                str(url),
+                headers=headers,
+                allow_reauth=allow_reauth,
+            )
+        except Unauthorized:
+            if not allow_reauth:
+                raise
+            return None
+        except InvalidPayloadError as err:
+            if _is_optional_non_json_payload(err):
+                return None
+            raise
+        except aiohttp.ClientResponseError as err:
+            if err.status in (401, 403, 404):
+                if not allow_reauth and err.status in (401, 403):
+                    raise
+                return None
+            raise
+        return data if isinstance(data, dict) else None
+
+    async def site_livestream_payload(
+        self,
+        serial_num: str,
+        *,
+        live_debug: bool = False,
+        timeout_s: float = 15.0,
+        allow_reauth: bool = True,
+    ) -> dict[str, object] | None:
+        """Read and decode one MQTT payload from the signed site live stream."""
+
+        authorizer = await self.site_livestream_authorizer(
+            serial_num,
+            live_debug=live_debug,
+            allow_reauth=allow_reauth,
+        )
+        if not isinstance(authorizer, dict):
+            return None
+        topic_key = "live_debug_topic" if live_debug else "live_stream_topic"
+        topic = self._coerce_text(authorizer.get(topic_key))
+        endpoint = self._coerce_text(authorizer.get("aws_iot_endpoint"))
+        username = self._site_livestream_mqtt_username(authorizer)
+        if topic is None or endpoint is None or username is None:
+            return None
+        payload = await self._read_mqtt_websocket_payload(
+            endpoint,
+            topic,
+            username,
+            timeout_s=timeout_s,
+        )
+        decoded = self._decode_site_livestream_payload(payload)
+        return decoded if isinstance(decoded, dict) else None
+
+    @staticmethod
+    def _coerce_text(value: object) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _site_livestream_mqtt_username(
+        self, authorizer: dict[str, object]
+    ) -> str | None:
+        authorizer_name = self._coerce_text(authorizer.get("aws_authorizer"))
+        token_key = self._coerce_text(authorizer.get("aws_token_key"))
+        token_value = self._coerce_text(authorizer.get("aws_token_value"))
+        digest = self._coerce_text(authorizer.get("aws_digest"))
+        if (
+            authorizer_name is None
+            or token_key is None
+            or token_value is None
+            or digest is None
+        ):
+            return None
+        return "?" + urlencode(
+            {
+                "x-amz-customauthorizer-name": authorizer_name,
+                token_key: token_value,
+                "site-id": str(self._site),
+                "x-amz-customauthorizer-signature": digest,
+                "env": "production",
+            }
+        )
+
+    async def _read_mqtt_websocket_payload(
+        self,
+        endpoint: str,
+        topic: str,
+        username: str,
+        *,
+        timeout_s: float,
+    ) -> bytes:
+        ws_url = f"wss://{endpoint}/mqtt"
+        client_id = f"ha-enphase-ev-{uuid.uuid4().hex[:20]}"
+        deadline = asyncio.get_running_loop().time() + timeout_s
+        async with self._s.ws_connect(
+            ws_url,
+            protocols=("mqtt",),
+            headers={"Origin": BASE_URL},
+            timeout=self._mqtt_remaining_timeout(deadline),
+        ) as ws:
+            await ws.send_bytes(self._mqtt_connect_packet(client_id, username))
+            _, connack_payload = await self._wait_for_mqtt_packet(
+                ws, {0x20}, deadline=deadline
+            )
+            self._validate_mqtt_connack(connack_payload)
+            await ws.send_bytes(self._mqtt_subscribe_packet(topic))
+            _, suback_payload = await self._wait_for_mqtt_packet(
+                ws, {0x90}, deadline=deadline
+            )
+            self._validate_mqtt_suback(suback_payload)
+            packet_type, payload = await self._wait_for_mqtt_packet(
+                ws, {0x30}, deadline=deadline
+            )
+            return self._mqtt_publish_payload(packet_type, payload)
+
+    @staticmethod
+    def _mqtt_remaining_timeout(deadline: float) -> float:
+        remaining = deadline - asyncio.get_running_loop().time()
+        if remaining <= 0:
+            raise asyncio.TimeoutError
+        return remaining
+
+    @staticmethod
+    def _mqtt_string(value: str) -> bytes:
+        data = value.encode()
+        return len(data).to_bytes(2, "big") + data
+
+    @staticmethod
+    def _mqtt_remaining_length(length: int) -> bytes:
+        encoded = bytearray()
+        while True:
+            digit = length % 128
+            length //= 128
+            if length > 0:
+                digit |= 0x80
+            encoded.append(digit)
+            if length == 0:
+                return bytes(encoded)
+
+    @classmethod
+    def _mqtt_packet(cls, packet_type: int, payload: bytes) -> bytes:
+        return bytes([packet_type]) + cls._mqtt_remaining_length(len(payload)) + payload
+
+    @classmethod
+    def _mqtt_connect_packet(cls, client_id: str, username: str) -> bytes:
+        variable_header = (
+            cls._mqtt_string("MQTT")
+            + b"\x04"  # MQTT 3.1.1
+            + b"\x82"  # username + clean session
+            + (30).to_bytes(2, "big")
+        )
+        payload = cls._mqtt_string(client_id) + cls._mqtt_string(username)
+        return cls._mqtt_packet(0x10, variable_header + payload)
+
+    @classmethod
+    def _mqtt_subscribe_packet(cls, topic: str) -> bytes:
+        payload = (1).to_bytes(2, "big") + cls._mqtt_string(topic) + b"\x00"
+        return cls._mqtt_packet(0x82, payload)
+
+    @staticmethod
+    def _validate_mqtt_connack(payload: bytes) -> None:
+        if len(payload) < 2:
+            raise aiohttp.ClientConnectionError("MQTT CONNACK payload was incomplete")
+        return_code = payload[1]
+        if return_code:
+            raise aiohttp.ClientConnectionError(
+                f"MQTT CONNECT was rejected with return code {return_code}"
+            )
+
+    @staticmethod
+    def _validate_mqtt_suback(payload: bytes) -> None:
+        if len(payload) < 3:
+            raise aiohttp.ClientConnectionError("MQTT SUBACK payload was incomplete")
+        granted_qos = payload[2:]
+        if not granted_qos or any(qos == 0x80 for qos in granted_qos):
+            raise aiohttp.ClientConnectionError("MQTT subscription was rejected")
+
+    @classmethod
+    def _mqtt_packets(cls, data: bytes) -> Iterable[tuple[int, bytes]]:
+        offset = 0
+        data_len = len(data)
+        while offset + 2 <= data_len:
+            packet_type = data[offset]
+            offset += 1
+            multiplier = 1
+            remaining = 0
+            while offset < data_len:
+                digit = data[offset]
+                offset += 1
+                remaining += (digit & 127) * multiplier
+                if (digit & 128) == 0:
+                    break
+                multiplier *= 128
+            end = offset + remaining
+            if end > data_len:
+                return
+            yield packet_type, data[offset:end]
+            offset = end
+
+    @classmethod
+    async def _wait_for_mqtt_packet(
+        cls,
+        ws: aiohttp.ClientWebSocketResponse,
+        packet_prefixes: set[int],
+        *,
+        deadline: float,
+    ) -> tuple[int, bytes]:
+        while True:
+            msg = await ws.receive(timeout=cls._mqtt_remaining_timeout(deadline))
+            if msg.type == aiohttp.WSMsgType.BINARY:
+                for packet_type, payload in cls._mqtt_packets(msg.data):
+                    if packet_type & 0xF0 in packet_prefixes:
+                        return packet_type, payload
+            elif msg.type in (
+                aiohttp.WSMsgType.CLOSED,
+                aiohttp.WSMsgType.CLOSE,
+                aiohttp.WSMsgType.ERROR,
+            ):
+                raise aiohttp.ClientConnectionError("MQTT WebSocket closed")
+
+    @staticmethod
+    def _mqtt_publish_payload(packet_type: int, payload: bytes) -> bytes:
+        if len(payload) < 2:
+            return b""
+        topic_len = int.from_bytes(payload[:2], "big")
+        offset = 2 + topic_len
+        qos = (packet_type & 0x06) >> 1
+        if qos:
+            offset += 2
+        return payload[offset:]
+
+    @staticmethod
+    def _decode_json_mqtt_payload(payload: bytes) -> object | None:
+        text = payload.decode("utf-8", "ignore").strip(" \t\r\n\0")
+        if not text:
+            return None
+        try:
+            return json.loads(text)
+        except ValueError:
+            start = text.find("{")
+            end = text.rfind("}")
+            if start == -1 or end <= start:
+                return None
+            try:
+                return json.loads(text[start : end + 1])
+            except ValueError:
+                return None
+
+    @classmethod
+    def _decode_site_livestream_payload(
+        cls, payload: bytes
+    ) -> dict[str, object] | None:
+        decoded = cls._decode_json_mqtt_payload(payload)
+        if isinstance(decoded, dict):
+            return decoded
+        grid_relay = cls._decode_live_status_grid_relay(payload)
+        if grid_relay is None:
+            return None
+        return {"meters": {"gridRelay": grid_relay}}
+
+    @staticmethod
+    def _protobuf_varint(data: bytes, offset: int) -> tuple[int, int] | None:
+        value = 0
+        for shift in range(0, 70, 7):
+            if offset >= len(data):
+                return None
+            byte = data[offset]
+            offset += 1
+            value |= (byte & 0x7F) << shift
+            if not byte & 0x80:
+                return value, offset
+        return None
+
+    @classmethod
+    def _protobuf_field(
+        cls,
+        data: bytes,
+        field_number: int,
+        wire_type: int,
+    ) -> int | bytes | None:
+        offset = 0
+        while offset < len(data):
+            key_result = cls._protobuf_varint(data, offset)
+            if key_result is None:
+                return None
+            key, offset = key_result
+            current_field = key >> 3
+            current_wire = key & 0x07
+            if current_field == 0:
+                return None
+
+            if current_wire == 0:
+                value_result = cls._protobuf_varint(data, offset)
+                if value_result is None:
+                    return None
+                value, offset = value_result
+            elif current_wire == 1:
+                end = offset + 8
+                if end > len(data):
+                    return None
+                value = data[offset:end]
+                offset = end
+            elif current_wire == 2:
+                length_result = cls._protobuf_varint(data, offset)
+                if length_result is None:
+                    return None
+                length, offset = length_result
+                end = offset + length
+                if end > len(data):
+                    return None
+                value = data[offset:end]
+                offset = end
+            elif current_wire == 5:
+                end = offset + 4
+                if end > len(data):
+                    return None
+                value = data[offset:end]
+                offset = end
+            else:
+                return None
+
+            if current_field == field_number and current_wire == wire_type:
+                return value
+        return None
+
+    @classmethod
+    def _decode_live_status_grid_relay(cls, payload: bytes) -> str | None:
+        # DataMsg.meters is field 3; MeterSummaryData.grid_relay is field 5.
+        meters = cls._protobuf_field(payload, 3, 2)
+        if not isinstance(meters, bytes):
+            return None
+        grid_relay = cls._protobuf_field(meters, 5, 0)
+        if not isinstance(grid_relay, int):
+            return None
+        return _LIVE_STATUS_GRID_RELAY_ENUM.get(grid_relay)
 
     @staticmethod
     def _normalize_evse_timeseries_serial(value: object) -> str | None:

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -51,6 +51,8 @@ from .const import (
     FAST_TOGGLE_POLL_HOLD_S,
     GRID_CONTROL_CHECK_CACHE_TTL,
     GRID_CONTROL_CHECK_STALE_AFTER_S,
+    GRID_MODE_STATUS_CACHE_TTL,
+    GRID_MODE_STATUS_STALE_AFTER_S,
     GRID_OUTAGE_CONTEXT_CACHE_TTL,
     GRID_OUTAGE_CONTEXT_STALE_AFTER_S,
     SAVINGS_OPERATION_MODE_SUBTYPE,
@@ -716,6 +718,33 @@ class BatteryRuntime:
         if not callable(fetcher):
             return state_present
         family = "grid_control_check"
+        if coord._endpoint_family_should_run(family, force=force):
+            return True
+        return (
+            state_present
+            and coord._endpoint_family_state(family).cooldown_active
+            and not coord._endpoint_family_can_use_stale(family)
+        )
+
+    def grid_mode_status_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        if not force and state._grid_mode_status_cache_until:
+            if now < state._grid_mode_status_cache_until:
+                return False
+        state_present = any(
+            getattr(state, attr, None) is not None
+            for attr in (
+                "_grid_mode_status_supported",
+                "_grid_mode_status",
+                "_grid_mode_status_raw",
+            )
+        )
+        fetcher = getattr(coord.client, "site_livestream_payload", None)
+        if not callable(fetcher):
+            return state_present
+        family = "grid_mode_status"
         if coord._endpoint_family_should_run(family, force=force):
             return True
         return (
@@ -3395,6 +3424,71 @@ class BatteryRuntime:
             payload.get("userInitiatedGridToggle")
         )
 
+    def _normalize_grid_mode_status_value(self, value: object) -> str | None:
+        text = self._coerce_optional_text(value)
+        if text is None:
+            return None
+        token = text.strip().upper()
+        if token in {
+            "OPER_RELAY_OPEN",
+            "OPER_RELAY_OFFGRID_AC_GRID_PRESENT",
+            "OPER_RELAY_OFFGRID_READY_FOR_RESYNC_CMD",
+        }:
+            return "off_grid"
+        if token in {
+            "OPER_RELAY_CLOSED",
+            "OPER_RELAY_WAITING_TO_INITIALIZE_ON_GRID",
+        }:
+            return "on_grid"
+        return None
+
+    def _grid_relay_candidates(self, payload: object) -> list[object]:
+        if isinstance(payload, dict):
+            candidates: list[object] = []
+            for key in ("gridRelay", "grid_relay"):
+                if key in payload:
+                    candidates.append(payload.get(key))
+            meters = payload.get("meters")
+            if isinstance(meters, dict):
+                candidates.extend(self._grid_relay_candidates(meters))
+            elif isinstance(meters, list):
+                for item in meters:
+                    candidates.extend(self._grid_relay_candidates(item))
+            for key in ("data", "payload", "message"):
+                nested = payload.get(key)
+                if isinstance(nested, (dict, list)):
+                    candidates.extend(self._grid_relay_candidates(nested))
+            return candidates
+        if isinstance(payload, list):
+            candidates = []
+            for item in payload:
+                candidates.extend(self._grid_relay_candidates(item))
+            return candidates
+        return []
+
+    def parse_grid_mode_status_payload(self, payload: object) -> bool:
+        state = self.battery_state
+        if not isinstance(payload, dict):
+            state._grid_mode_status_supported = False
+            state._grid_mode_status = None
+            state._grid_mode_status_raw = None
+            return False
+
+        for value in self._grid_relay_candidates(payload):
+            raw = self._coerce_optional_text(value)
+            mode = self._normalize_grid_mode_status_value(raw)
+            if mode is None:
+                continue
+            state._grid_mode_status_supported = True
+            state._grid_mode_status = mode
+            state._grid_mode_status_raw = raw
+            return True
+
+        state._grid_mode_status_supported = False
+        state._grid_mode_status = None
+        state._grid_mode_status_raw = None
+        return False
+
     def parse_grid_outage_context_payload(self, payload: object) -> None:
         state = self.battery_state
         keys = (
@@ -3681,6 +3775,81 @@ class BatteryRuntime:
         state._grid_control_check_failures = 0
         state._grid_control_check_last_success_mono = now
         state._grid_control_check_cache_until = now + GRID_CONTROL_CHECK_CACHE_TTL
+        coord._note_endpoint_family_success(family)
+
+    async def async_refresh_grid_mode_status(self, *, force: bool = False) -> None:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        family = "grid_mode_status"
+        if not force and state._grid_mode_status_cache_until:
+            if now < state._grid_mode_status_cache_until:
+                return
+        if not coord._endpoint_family_should_run(family, force=force):
+            if state._grid_mode_status_supported is not None and (
+                coord._endpoint_family_state(family).cooldown_active
+                and not coord._endpoint_family_can_use_stale(family)
+            ):
+                state._grid_mode_status_supported = None
+                state._grid_mode_status = None
+                state._grid_mode_status_raw = None
+            return
+        envoy_serial = self.grid_envoy_serial()
+        fetcher = getattr(coord.client, "site_livestream_payload", None)
+        if envoy_serial is None or not callable(fetcher):
+            state._grid_mode_status_supported = None
+            state._grid_mode_status = None
+            state._grid_mode_status_raw = None
+            return
+        try:
+            payload = await fetcher(envoy_serial)
+        except Exception as err:  # noqa: BLE001
+            coord._note_endpoint_family_failure(family, err)
+            state._grid_mode_status_failures = max(
+                state._grid_mode_status_failures + 1,
+                coord._endpoint_family_state(family).consecutive_failures,
+            )
+            last_success = getattr(state, "_grid_mode_status_last_success_mono", None)
+            if (
+                not isinstance(last_success, (int, float))
+                or (now - float(last_success)) >= GRID_MODE_STATUS_STALE_AFTER_S
+            ):
+                state._grid_mode_status_supported = None
+                state._grid_mode_status = None
+                state._grid_mode_status_raw = None
+            state._grid_mode_status_cache_until = now + 15.0
+            return
+        redacted_payload = coord.redact_battery_payload(payload)
+        if isinstance(redacted_payload, dict):
+            state._grid_mode_status_payload = redacted_payload
+        else:
+            state._grid_mode_status_payload = {"value": redacted_payload}
+        previous_status_supported = state._grid_mode_status_supported
+        previous_status = state._grid_mode_status
+        previous_status_raw = state._grid_mode_status_raw
+        previous_last_success = state._grid_mode_status_last_success_mono
+        if not self.parse_grid_mode_status_payload(payload):
+            coord._note_endpoint_family_failure(
+                family,
+                ValueError("Live grid relay payload did not include meters.gridRelay"),
+            )
+            state._grid_mode_status_failures = max(
+                state._grid_mode_status_failures + 1,
+                coord._endpoint_family_state(family).consecutive_failures,
+            )
+            if (
+                isinstance(previous_last_success, (int, float))
+                and (now - float(previous_last_success))
+                < GRID_MODE_STATUS_STALE_AFTER_S
+            ):
+                state._grid_mode_status_supported = previous_status_supported
+                state._grid_mode_status = previous_status
+                state._grid_mode_status_raw = previous_status_raw
+            state._grid_mode_status_cache_until = now + 15.0
+            return
+        state._grid_mode_status_failures = 0
+        state._grid_mode_status_last_success_mono = now
+        state._grid_mode_status_cache_until = now + GRID_MODE_STATUS_CACHE_TTL
         coord._note_endpoint_family_success(family)
 
     async def async_refresh_grid_outage_context(self, *, force: bool = False) -> None:

--- a/custom_components/enphase_ev/const.py
+++ b/custom_components/enphase_ev/const.py
@@ -120,11 +120,13 @@ STORM_GUARD_CACHE_TTL = 300.0
 STORM_ALERT_CACHE_TTL = 300.0
 STORM_GUARD_PENDING_HOLD_S = 90.0
 GRID_CONTROL_CHECK_CACHE_TTL = 60.0
+GRID_MODE_STATUS_CACHE_TTL = 300.0
 GRID_OUTAGE_CONTEXT_CACHE_TTL = 60.0
 # Keep the last confirmed grid-control state valid across the initial
 # endpoint-family cooldown window after a transient failure. This avoids
 # spurious ready/unknown flapping while the retry is intentionally deferred.
 GRID_CONTROL_CHECK_STALE_AFTER_S = 360.0
+GRID_MODE_STATUS_STALE_AFTER_S = 360.0
 GRID_OUTAGE_CONTEXT_STALE_AFTER_S = 360.0
 DRY_CONTACT_SETTINGS_CACHE_TTL = 300.0
 DRY_CONTACT_SETTINGS_FAILURE_CACHE_TTL = 15.0

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -86,6 +86,8 @@ from .const import (
     DRY_CONTACT_SETTINGS_STALE_AFTER_S,
     DOMAIN,
     GRID_CONTROL_CHECK_STALE_AFTER_S,
+    GRID_MODE_STATUS_CACHE_TTL,
+    GRID_MODE_STATUS_STALE_AFTER_S,
     GRID_OUTAGE_CONTEXT_CACHE_TTL,
     GRID_OUTAGE_CONTEXT_STALE_AFTER_S,
     HEMS_AUTH_BACKOFF_STEPS_S,
@@ -903,6 +905,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             "grid_control_check": EndpointFamilyPolicy(
                 success_ttl_s=300.0,
                 stale_after_s=GRID_CONTROL_CHECK_STALE_AFTER_S,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+            "grid_mode_status": EndpointFamilyPolicy(
+                success_ttl_s=GRID_MODE_STATUS_CACHE_TTL,
+                stale_after_s=GRID_MODE_STATUS_STALE_AFTER_S,
                 failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
                 max_backoff_s=3600.0,
                 optional=True,
@@ -2353,6 +2364,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             "status_payload": getattr(self, "_battery_status_payload", None),
             "grid_control_check_payload": getattr(
                 self, "_grid_control_check_payload", None
+            ),
+            "grid_mode_status_payload": getattr(
+                self, "_grid_mode_status_payload", None
             ),
             "grid_outage_context_payload": getattr(
                 self, "_grid_outage_context_payload", None
@@ -6285,6 +6299,39 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return None
         return getattr(self, "_grid_control_user_initiated_toggle", None)
 
+    def _grid_mode_status_is_stale(self) -> bool:
+        raw_supported = getattr(self, "_grid_mode_status_supported", None)
+        if raw_supported is None:
+            return True
+        last_success = getattr(self, "_grid_mode_status_last_success_mono", None)
+        if not isinstance(last_success, (int, float)):
+            return False
+        age = time.monotonic() - float(last_success)
+        if age < 0:
+            return False
+        return age >= GRID_MODE_STATUS_STALE_AFTER_S
+
+    @property
+    def grid_mode_status_supported(self) -> bool | None:
+        raw_supported = getattr(self, "_grid_mode_status_supported", None)
+        if raw_supported is None:
+            return None
+        if self._grid_mode_status_is_stale():
+            return None
+        return raw_supported
+
+    @property
+    def grid_mode_status(self) -> str | None:
+        if self.grid_mode_status_supported is not True:
+            return None
+        return getattr(self, "_grid_mode_status", None)
+
+    @property
+    def grid_mode_status_raw(self) -> str | None:
+        if self.grid_mode_status_supported is not True:
+            return None
+        return getattr(self, "_grid_mode_status_raw", None)
+
     def _grid_outage_context_is_stale(self) -> bool:
         raw_supported = getattr(self, "_grid_outage_context_supported", None)
         if raw_supported is None:
@@ -6422,20 +6469,41 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @property
     def grid_mode_raw_states(self) -> list[str]:
+        states: list[str] = []
+        status_raw = self.grid_mode_status_raw
+        if status_raw is not None:
+            states.append(f"grid_relay:{status_raw}")
         outage_state = self.grid_outage_is_grid_outage
         if outage_state is True:
-            return ["is_grid_outage:true"]
-        if outage_state is False:
-            return ["is_grid_outage:false"]
-        return []
+            states.append("is_grid_outage:true")
+        elif outage_state is False:
+            states.append("is_grid_outage:false")
+        show_connect = self.grid_outage_show_grid_connect
+        if show_connect is True:
+            states.append("show_grid_connect:true")
+        elif show_connect is False:
+            states.append("show_grid_connect:false")
+        return states
 
     @property
     def grid_mode(self) -> str | None:
+        status_mode = self.grid_mode_status
+        if status_mode in {"on_grid", "off_grid"}:
+            return status_mode
         outage_state = self.grid_outage_is_grid_outage
-        if outage_state is True:
+        show_connect = self.grid_outage_show_grid_connect
+        if outage_state is True or show_connect is True:
             return "off_grid"
-        if outage_state is False:
+        if show_connect is False or outage_state is False:
             return "on_grid"
+        return None
+
+    @property
+    def grid_mode_source(self) -> str | None:
+        if self.grid_mode_status in {"on_grid", "off_grid"}:
+            return "livestream_grid_relay"
+        if self.grid_outage_context_supported is True:
+            return "grid_outage_context"
         return None
 
     def _raise_grid_validation(

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -864,6 +864,13 @@ class CoordinatorDiagnostics:
                 coord, "_grid_control_check_failures", 0
             ),
             "grid_control_data_stale": coord.grid_control_supported is None,
+            "grid_mode_source": coord.grid_mode_source,
+            "grid_mode_status_supported": coord.grid_mode_status_supported,
+            "grid_mode_status_raw": coord.grid_mode_status_raw,
+            "grid_mode_status_fetch_failures": getattr(
+                coord, "_grid_mode_status_failures", 0
+            ),
+            "grid_mode_status_data_stale": coord.grid_mode_status_supported is None,
             "grid_outage_context_supported": coord.grid_outage_context_supported,
             "grid_outage_is_grid_outage": coord.grid_outage_is_grid_outage,
             "grid_outage_show_grid_connect": coord.grid_outage_show_grid_connect,
@@ -899,6 +906,14 @@ class CoordinatorDiagnostics:
             age = time.monotonic() - float(grid_last_success)
             if age >= 0:
                 metrics["grid_control_last_success_age_s"] = round(age, 1)
+
+        grid_mode_last_success = getattr(
+            coord, "_grid_mode_status_last_success_mono", None
+        )
+        if isinstance(grid_mode_last_success, (int, float)):
+            age = time.monotonic() - float(grid_mode_last_success)
+            if age >= 0:
+                metrics["grid_mode_status_last_success_age_s"] = round(age, 1)
 
         grid_outage_last_success = getattr(
             coord, "_grid_outage_context_last_success_mono", None

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -16,6 +16,7 @@ REFRESH_TASK_ENDPOINT_FAMILIES: dict[str, str] = {
     "storm_alert_s": "storm_alert",
     "tariff_s": "tariff",
     "grid_control_check_s": "grid_control_check",
+    "grid_mode_status_s": "grid_mode_status",
     "grid_outage_context_s": "grid_outage_context",
     "dry_contact_settings_s": "dry_contact_settings",
     "battery_status_s": "battery_status",
@@ -232,6 +233,12 @@ WARMUP_STATE_STAGE = RefreshStage(
             "async_refresh_grid_control_check",
         ),
         object_method_task(
+            "grid_mode_status_s",
+            "grid mode status",
+            "battery_runtime",
+            "async_refresh_grid_mode_status",
+        ),
+        object_method_task(
             "grid_outage_context_s",
             "grid outage context",
             "battery_runtime",
@@ -291,6 +298,12 @@ SITE_ONLY_FOLLOWUP_STAGE = RefreshStage(
             "grid control",
             "battery_runtime",
             "async_refresh_grid_control_check",
+        ),
+        object_method_task(
+            "grid_mode_status_s",
+            "grid mode status",
+            "battery_runtime",
+            "async_refresh_grid_mode_status",
         ),
         object_method_task(
             "grid_outage_context_s",
@@ -612,6 +625,15 @@ def build_followup_plan(owner: object, *, force_full: bool = False) -> RefreshPl
                 "grid control",
                 "battery_runtime",
                 "async_refresh_grid_control_check",
+            )
+        )
+    if battery.grid_mode_status_refresh_due():
+        parallel.append(
+            object_method_task(
+                "grid_mode_status_s",
+                "grid mode status",
+                "battery_runtime",
+                "async_refresh_grid_mode_status",
             )
         )
     if battery.grid_outage_context_refresh_due():

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -8872,8 +8872,12 @@ class EnphaseGridModeSensor(_SiteBaseEntity):
     @property
     def extra_state_attributes(self):
         return {
-            "source": "grid_outage_context",
+            "source": getattr(self._coord, "grid_mode_source", None),
             "raw_states": getattr(self._coord, "grid_mode_raw_states", []),
+            "grid_mode_status_supported": getattr(
+                self._coord, "grid_mode_status_supported", None
+            ),
+            "grid_relay": getattr(self._coord, "grid_mode_status_raw", None),
             "grid_outage_context_supported": getattr(
                 self._coord, "grid_outage_context_supported", None
             ),

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -322,6 +322,13 @@ class BatteryState:
     _grid_control_grid_outage_check: bool | None = None
     _grid_control_user_initiated_toggle: bool | None = None
     _grid_control_supported: bool | None = None
+    _grid_mode_status_cache_until: float | None = None
+    _grid_mode_status_last_success_mono: float | None = None
+    _grid_mode_status_failures: int = 0
+    _grid_mode_status_payload: PayloadMap | None = None
+    _grid_mode_status_supported: bool | None = None
+    _grid_mode_status: str | None = None
+    _grid_mode_status_raw: str | None = None
     _grid_outage_context_cache_until: float | None = None
     _grid_outage_context_last_success_mono: float | None = None
     _grid_outage_context_failures: int = 0

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -107,7 +107,7 @@ Status labels:
 | Site bootstrap payload | `GET` | `/app-api/<site_id>/data.json?app=<id>&device_status=non_retired&is_mobile=<id>` | authenticated session cookies + `e-auth-token` | Browser capture only |
 | Filtered site-device inventory | `POST` | `/service/site-device/api/v2/devices/list` | `e-auth-token` + cookies | Browser capture only |
 | Site live-stream flags | `GET` | `/app-api/<site_id>/show_livestream` | authenticated session cookies | Runtime |
-| Site live-status MQTT authorizer | `GET` | `/pv/aws_sigv4/livestream.json?serial_num=<gateway_sn>` | authenticated Enlighten session cookies + `e-auth-token`; browser capture used `Accept: */*`, `Referer: /web/<site_id>/today/graph/hours?v=3.4.0`, `X-Requested-With: XMLHttpRequest` | Browser capture only |
+| Site live-status MQTT authorizer | `GET` | `/pv/aws_sigv4/livestream.json?serial_num=<gateway_sn>` | authenticated Enlighten session cookies + `e-auth-token`; browser capture used `Accept: */*`, `Referer: /web/<site_id>/today/graph/hours?v=3.4.0`, `X-Requested-With: XMLHttpRequest` | Runtime |
 | Site live-vitals MQTT authorizer | `GET` | `/pv/aws_sigv4/livestream.json?serial_num=<gateway_sn>&live_debug=true` | authenticated Enlighten session cookies + `e-auth-token`; same browser XHR shape as the live-status authorizer | Browser capture only |
 | Site latest power | `GET` | `/app-api/<site_id>/get_latest_power` | `e-auth-token` + cookies | Runtime |
 | Site currency conversion settings | `GET` | `/app-api/<site_id>/get_currency_conversion.json` | authenticated session cookies + `e-auth-token` | Browser capture only |
@@ -1302,9 +1302,11 @@ Observed MQTT usage:
 - In a 60-second local capture, the topic emitted one binary message per second after successful subscribe.
 
 Observed payload format:
-- Payloads are binary and protobuf-like, not JSON.
-- The 60-second capture used 168-byte frames.
-- Numeric power values are signed varints scaled by `1_000_000` to kW.
+- The web-app live grid-status chip is driven from the MQTT payload field `meters.gridRelay`.
+- `meters.gridRelay=OPER_RELAY_CLOSED` maps to UI type `onGrid` and displays "On Grid".
+- `meters.gridRelay=OPER_RELAY_OPEN` maps to UI type `offGrid` and displays "Off Grid".
+- Production Live Status frames use the `DataMsg` protobuf schema. `DataMsg.meters` is field 3 and `MeterSummaryData.grid_relay` is nested field 5; the frontend converts that enum to the `OPER_RELAY_*` strings above.
+- Numeric power values in the binary shape are signed varints scaled by `1_000_000` to kW.
 - The first subfield in each repeated power group matched the visible web-app Live Status values. The second subfield often held a nearby related value; its meaning is not confirmed.
 
 Decoded field mapping from two web-app screenshot comparisons:
@@ -1318,7 +1320,8 @@ Decoded field mapping from two web-app screenshot comparisons:
 | EV charger consuming | root `field3.field4.field2` | divide by `1_000_000` | Candidate mapping. During an active charging capture, early frames were around `7.10-7.12` kW while the Live Status charger card showed `7.1` kW. A later labeled 30-second capture saw this path fluctuate from roughly `7.25` to `9.45` kW while the EVSE MQTT topic remained silent. |
 | Battery state of charge | root `field3.field6` | integer percent | Matched the battery charge percentage. |
 | System profile / mode | root `field3.field5` | enum/integer | Observed value `2` while the UI showed Self-Consumption; mapping needs more modes. |
-| Grid status | root `field3.field8` | enum/integer | Observed value `6` while UI showed On Grid; mapping needs more states. |
+| Grid status | root `field3.field5` | enum | `1` open, `2` closed, `3` off-grid with AC present, `4` off-grid ready for resync, `5` waiting to initialize on-grid |
+| Generator relay | root `field3.field8` | enum | Uses generator relay enum values beginning at `6` |
 | Battery reserve/limit hint | root `field3.field11.field1`, `field3.field11.field2` | integer / scaled integer | Observed values aligned with charge percentage and a `9900`-style value, likely a percent scaled by 100; exact semantics unconfirmed. |
 
 Implementation notes:
@@ -2458,6 +2461,7 @@ Observed structure:
 - `inverters` returns a summary object with `total`, `not_reporting`, `plc_comm`, `items[]`, and `device_link` rather than per-device rows.
 - Fields are family-specific and often localized (`statusText`, `channel_type`, meter labels, modem plan text).
 - `encharges` and `enpowers` both expose RF/link-health fields (`rssi_subghz`, `rssi_24ghz`, `rssi_dbm`) plus family-specific operating-state strings.
+- `enpowers[].operation_mode` can describe System Controller operating state, but the live web grid-status chip is driven by the site live-stream `meters.gridRelay` value instead.
 - `meters` expose configuration labels (`config_type`, `meter_type`) rather than firmware/network details.
 - `modems` expose provisioning state (`status`, `plan_end`, `part_number_with_sku`) instead of the gateway-style network payload.
 - These endpoints expose sensitive infrastructure details such as IP addresses, MAC-derived identifiers, and direct dashboard links; redact aggressively before sharing traces.
@@ -3521,6 +3525,7 @@ Example response (anonymized):
   "has_battery": true
 }
 ```
+`is_grid_outage=true` identifies an outage-driven off-grid state. When `show_grid_connect=true`, the Enphase UI is offering a reconnect action, which indicates the site is currently off grid even when `is_grid_outage=false`. This endpoint is useful fallback context; prefer the live-stream `meters.gridRelay` value when available.
 
 ### 2.12.6 Grid Toggle Request Sequence
 Both directions use a confirmation + OTP gate before the relay command is sent.

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -8175,6 +8175,376 @@ async def test_show_livestream_returns_none_for_non_mapping_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_site_livestream_authorizer_returns_payload() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"live_stream_topic": "v1/live-stream/abc"})
+
+    payload = await client.site_livestream_authorizer("GW-1")
+
+    assert payload == {"live_stream_topic": "v1/live-stream/abc"}
+    client._json.assert_awaited_once_with(
+        "GET",
+        f"{api.BASE_URL}/pv/aws_sigv4/livestream.json?serial_num=GW-1",
+        headers={
+            **client._today_headers(),
+            "X-Requested-With": "XMLHttpRequest",
+        },
+        allow_reauth=True,
+    )
+
+    await client.site_livestream_authorizer("GW-1", live_debug=True)
+    assert "live_debug=true" in client._json.await_args.args[1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        api.Unauthorized(),
+        _make_optional_payload_error("/pv/aws_sigv4/livestream.json"),
+        _make_cre(404),
+    ],
+)
+async def test_site_livestream_authorizer_optional_errors_return_none(error) -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=error)
+
+    assert await client.site_livestream_authorizer("GW-1") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [api.Unauthorized(), _make_cre(403)])
+async def test_site_livestream_authorizer_auth_errors_reraise_when_disabled(
+    error,
+) -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=error)
+
+    with pytest.raises((api.Unauthorized, aiohttp.ClientResponseError)):
+        await client.site_livestream_authorizer("GW-1", allow_reauth=False)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    [
+        api.InvalidPayloadError(
+            "bad json",
+            status=200,
+            content_type="application/json",
+            endpoint="/pv/aws_sigv4/livestream.json",
+        ),
+        _make_cre(500),
+    ],
+)
+async def test_site_livestream_authorizer_reraises_unexpected_errors(error) -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=error)
+
+    with pytest.raises((api.InvalidPayloadError, aiohttp.ClientResponseError)):
+        await client.site_livestream_authorizer("GW-1")
+
+
+@pytest.mark.asyncio
+async def test_site_livestream_payload_reads_json_mqtt_message() -> None:
+    client = _make_client()
+    client.site_livestream_authorizer = AsyncMock(
+        return_value={
+            "live_stream_topic": "v1/live-stream/abc",
+            "aws_iot_endpoint": "mqtt.example.test",
+            "aws_authorizer": "authorizer",
+            "aws_token_key": "enph_token",
+            "aws_token_value": "session",
+            "aws_digest": "sig+/=",
+        }
+    )
+    client._read_mqtt_websocket_payload = AsyncMock(
+        return_value=b'{"meters":{"gridRelay":"OPER_RELAY_OPEN"}}'
+    )
+
+    payload = await client.site_livestream_payload("GW-1", timeout_s=5)
+
+    assert payload == {"meters": {"gridRelay": "OPER_RELAY_OPEN"}}
+    client.site_livestream_authorizer.assert_awaited_once_with(
+        "GW-1",
+        live_debug=False,
+        allow_reauth=True,
+    )
+    args, kwargs = client._read_mqtt_websocket_payload.await_args
+    assert args[:2] == ("mqtt.example.test", "v1/live-stream/abc")
+    assert "x-amz-customauthorizer-name=authorizer" in args[2]
+    assert "enph_token=session" in args[2]
+    assert "x-amz-customauthorizer-signature=sig%2B%2F%3D" in args[2]
+    assert kwargs == {"timeout_s": 5}
+
+
+@pytest.mark.asyncio
+async def test_site_livestream_payload_reads_protobuf_mqtt_message() -> None:
+    client = _make_client()
+    client.site_livestream_authorizer = AsyncMock(
+        return_value={
+            "live_stream_topic": "v1/live-stream/abc",
+            "aws_iot_endpoint": "mqtt.example.test",
+            "aws_authorizer": "authorizer",
+            "aws_token_key": "enph_token",
+            "aws_token_value": "session",
+            "aws_digest": "sig",
+        }
+    )
+    # DataMsg.protocol_ver=1, DataMsg.meters.grid_relay=OPER_RELAY_OPEN.
+    client._read_mqtt_websocket_payload = AsyncMock(
+        return_value=b"\x08\x01\x1a\x02\x28\x01"
+    )
+
+    payload = await client.site_livestream_payload("GW-1")
+
+    assert payload == {"meters": {"gridRelay": "OPER_RELAY_OPEN"}}
+
+
+@pytest.mark.asyncio
+async def test_site_livestream_payload_returns_none_for_missing_authorizer_fields() -> (
+    None
+):
+    client = _make_client()
+    client.site_livestream_authorizer = AsyncMock(
+        side_effect=[
+            None,
+            {"live_stream_topic": "v1/live-stream/abc"},
+            {
+                "live_stream_topic": "v1/live-stream/abc",
+                "aws_iot_endpoint": "mqtt.example.test",
+                "aws_authorizer": "authorizer",
+                "aws_token_key": "enph_token",
+                "aws_token_value": "session",
+                "aws_digest": "sig",
+            },
+        ]
+    )
+    client._read_mqtt_websocket_payload = AsyncMock(return_value=b"not-json")
+
+    assert await client.site_livestream_payload("GW-1") is None
+    assert await client.site_livestream_payload("GW-1") is None
+    assert await client.site_livestream_payload("GW-1") is None
+
+
+def test_mqtt_packet_helpers_extract_publish_payload() -> None:
+    payload = b'{"meters":{"gridRelay":"OPER_RELAY_CLOSED"}}'
+    publish = api.EnphaseEVClient._mqtt_packet(
+        0x30,
+        api.EnphaseEVClient._mqtt_string("v1/live-stream/abc") + payload,
+    )
+
+    packets = list(api.EnphaseEVClient._mqtt_packets(publish))
+
+    assert packets == [
+        (
+            0x30,
+            api.EnphaseEVClient._mqtt_string("v1/live-stream/abc") + payload,
+        )
+    ]
+    assert api.EnphaseEVClient._mqtt_publish_payload(*packets[0]) == payload
+    assert api.EnphaseEVClient._decode_json_mqtt_payload(payload) == {
+        "meters": {"gridRelay": "OPER_RELAY_CLOSED"}
+    }
+    assert api.EnphaseEVClient._decode_json_mqtt_payload(b'xx {"ok": true} yy') == {
+        "ok": True
+    }
+    assert api.EnphaseEVClient._decode_json_mqtt_payload(b"not-json") is None
+    assert api.EnphaseEVClient._decode_json_mqtt_payload(b"xx {bad} yy") is None
+
+    large_packet = api.EnphaseEVClient._mqtt_packet(0x30, b"x" * 128)
+    assert len(large_packet) == 131
+    assert list(api.EnphaseEVClient._mqtt_packets(large_packet)) == [(0x30, b"x" * 128)]
+    assert list(api.EnphaseEVClient._mqtt_packets(b"\x30\x02\x00")) == []
+    assert api.EnphaseEVClient._mqtt_publish_payload(0x30, b"") == b""
+    qos_payload = api.EnphaseEVClient._mqtt_string("topic") + b"\x00\x01data"
+    assert api.EnphaseEVClient._mqtt_publish_payload(0x32, qos_payload) == b"data"
+
+
+def test_mqtt_validation_helpers_reject_incomplete_acks() -> None:
+    with pytest.raises(aiohttp.ClientConnectionError, match="CONNACK.*incomplete"):
+        api.EnphaseEVClient._validate_mqtt_connack(b"\x00")
+    with pytest.raises(aiohttp.ClientConnectionError, match="SUBACK.*incomplete"):
+        api.EnphaseEVClient._validate_mqtt_suback(b"\x00\x01")
+
+
+@pytest.mark.asyncio
+async def test_mqtt_wait_rejects_closed_socket_and_expired_deadline() -> None:
+    closed_ws = SimpleNamespace(
+        receive=AsyncMock(
+            side_effect=[
+                SimpleNamespace(type=aiohttp.WSMsgType.TEXT, data="ignored"),
+                SimpleNamespace(type=aiohttp.WSMsgType.CLOSED, data=None),
+            ]
+        )
+    )
+    deadline = asyncio.get_running_loop().time() + 5
+
+    with pytest.raises(aiohttp.ClientConnectionError, match="WebSocket closed"):
+        await api.EnphaseEVClient._wait_for_mqtt_packet(
+            closed_ws, {0x30}, deadline=deadline
+        )
+
+    with pytest.raises(asyncio.TimeoutError):
+        api.EnphaseEVClient._mqtt_remaining_timeout(
+            asyncio.get_running_loop().time() - 1
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (0, "OPER_RELAY_UNKNOWN"),
+        (1, "OPER_RELAY_OPEN"),
+        (2, "OPER_RELAY_CLOSED"),
+        (3, "OPER_RELAY_OFFGRID_AC_GRID_PRESENT"),
+        (4, "OPER_RELAY_OFFGRID_READY_FOR_RESYNC_CMD"),
+        (5, "OPER_RELAY_WAITING_TO_INITIALIZE_ON_GRID"),
+    ],
+)
+def test_decode_site_livestream_protobuf_grid_relay(value: int, expected: str) -> None:
+    # Include unknown fixed-width fields to verify they are skipped safely.
+    meters = b"\x09" + (b"\x00" * 8) + b"\x1d" + (b"\x00" * 4)
+    meters += b"\x28" + bytes([value])
+    payload = b"\x08\x01\x1a" + bytes([len(meters)]) + meters
+
+    assert api.EnphaseEVClient._decode_site_livestream_payload(payload) == {
+        "meters": {"gridRelay": expected}
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"",
+        b"\x00",
+        b"\x80" * 10,
+        b"\x08",
+        b"\x09\x00",
+        b"\x12\x80",
+        b"\x12\x02\x00",
+        b"\x1d\x00",
+        b"\x0b",
+        b"\x08\x01",
+        b"\x1a\x02\x28\x06",
+        b"\x1a\x01\x28",
+    ],
+)
+def test_decode_site_livestream_rejects_invalid_protobuf(payload: bytes) -> None:
+    assert api.EnphaseEVClient._decode_site_livestream_payload(payload) is None
+
+
+@pytest.mark.asyncio
+async def test_read_mqtt_websocket_payload_reads_publish_frame() -> None:
+    client = _make_client()
+    payload = b'{"meters":{"gridRelay":"OPER_RELAY_OPEN"}}'
+
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.sent: list[bytes] = []
+            self.messages = [
+                SimpleNamespace(
+                    type=aiohttp.WSMsgType.BINARY, data=b"\x20\x02\x00\x00"
+                ),
+                SimpleNamespace(
+                    type=aiohttp.WSMsgType.BINARY, data=b"\x90\x03\x00\x01\x00"
+                ),
+                SimpleNamespace(
+                    type=aiohttp.WSMsgType.BINARY,
+                    data=api.EnphaseEVClient._mqtt_packet(
+                        0x30,
+                        api.EnphaseEVClient._mqtt_string("v1/live-stream/abc")
+                        + payload,
+                    ),
+                ),
+            ]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def send_bytes(self, data):
+            self.sent.append(data)
+
+        async def receive(self, *, timeout):
+            return self.messages.pop(0)
+
+    fake_ws = FakeWebSocket()
+    client._s.ws_connect = MagicMock(return_value=fake_ws)
+
+    result = await client._read_mqtt_websocket_payload(
+        "mqtt.example.test",
+        "v1/live-stream/abc",
+        "?username",
+        timeout_s=5,
+    )
+
+    assert result == payload
+    assert len(fake_ws.sent) == 2
+    client._s.ws_connect.assert_called_once()
+    args, kwargs = client._s.ws_connect.call_args
+    assert args == ("wss://mqtt.example.test/mqtt",)
+    assert kwargs["protocols"] == ("mqtt",)
+    assert kwargs["headers"] == {"Origin": api.BASE_URL}
+    assert 0 < kwargs["timeout"] <= 5
+
+
+@pytest.mark.parametrize(
+    ("messages", "match", "sent_count"),
+    [
+        ([b"\x20\x02\x00\x05"], "CONNECT was rejected", 1),
+        (
+            [b"\x20\x02\x00\x00", b"\x90\x03\x00\x01\x80"],
+            "subscription was rejected",
+            2,
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_read_mqtt_websocket_payload_rejects_failed_handshake(
+    messages: list[bytes],
+    match: str,
+    sent_count: int,
+) -> None:
+    client = _make_client()
+
+    class FakeWebSocket:
+        def __init__(self) -> None:
+            self.sent: list[bytes] = []
+            self.messages = [
+                SimpleNamespace(type=aiohttp.WSMsgType.BINARY, data=data)
+                for data in messages
+            ]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def send_bytes(self, data):
+            self.sent.append(data)
+
+        async def receive(self, *, timeout):
+            return self.messages.pop(0)
+
+    fake_ws = FakeWebSocket()
+    client._s.ws_connect = MagicMock(return_value=fake_ws)
+
+    with pytest.raises(aiohttp.ClientConnectionError, match=match):
+        await client._read_mqtt_websocket_payload(
+            "mqtt.example.test",
+            "v1/live-stream/abc",
+            "?username",
+            timeout_s=5,
+        )
+
+    assert len(fake_ws.sent) == sent_count
+
+
+@pytest.mark.asyncio
 async def test_heat_pump_events_json_returns_payload() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value=[{"statusText": "Recommended"}])

--- a/tests/components/enphase_ev/test_battery_runtime_grid_control.py
+++ b/tests/components/enphase_ev/test_battery_runtime_grid_control.py
@@ -215,6 +215,144 @@ async def test_refresh_grid_outage_context_caches_and_redacts(
 
 
 @pytest.mark.asyncio
+async def test_refresh_grid_mode_status_uses_livestream_grid_relay(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    envoy_serial = coord.battery_runtime.grid_envoy_serial()
+    assert envoy_serial is not None
+    coord.client.site_livestream_payload = AsyncMock(
+        return_value={
+            "meters": {
+                "gridRelay": "OPER_RELAY_CLOSED",
+                "serial_number": "secret-meter",
+            }
+        }
+    )
+
+    await coord.battery_runtime.async_refresh_grid_mode_status(force=True)
+
+    coord.client.site_livestream_payload.assert_awaited_once_with(envoy_serial)
+    assert coord.grid_mode_status_supported is True
+    assert coord.grid_mode_status_raw == "OPER_RELAY_CLOSED"
+    assert coord.grid_mode == "on_grid"
+    assert coord.grid_mode_source == "livestream_grid_relay"
+    assert coord._grid_mode_status_payload is not None  # noqa: SLF001
+    assert (
+        coord._grid_mode_status_payload["meters"]["serial_number"] == "[redacted]"
+    )  # noqa: SLF001
+
+    coord._grid_mode_status_cache_until = time.monotonic() + 300  # noqa: SLF001
+    coord.client.site_livestream_payload.reset_mock()
+    await coord.battery_runtime.async_refresh_grid_mode_status()
+    coord.client.site_livestream_payload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_mode_status_requires_gateway_serial(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._grid_mode_status = "on_grid"  # noqa: SLF001
+    coord._grid_mode_status_raw = "OPER_RELAY_CLOSED"  # noqa: SLF001
+    coord.battery_runtime.grid_envoy_serial = lambda: None  # type: ignore[method-assign]
+    coord.client.site_livestream_payload = AsyncMock()
+
+    await coord.battery_runtime.async_refresh_grid_mode_status(force=True)
+
+    coord.client.site_livestream_payload.assert_not_called()
+    assert coord.grid_mode_status_supported is None
+    assert coord.grid_mode_status is None
+    assert coord.grid_mode_status_raw is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_mode_status_missing_relay_uses_failure_retry(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    envoy_serial = coord.battery_runtime.grid_envoy_serial()
+    assert envoy_serial is not None
+    coord.client.site_livestream_payload = AsyncMock(
+        return_value={"meters": {"serial_number": "secret-meter"}}
+    )
+
+    now = time.monotonic()
+    await coord.battery_runtime.async_refresh_grid_mode_status(force=True)
+
+    coord.client.site_livestream_payload.assert_awaited_once_with(envoy_serial)
+    assert coord.grid_mode_status_supported is False
+    assert coord.grid_mode_status is None
+    assert coord.grid_mode_status_raw is None
+    assert coord._grid_mode_status_failures == 1  # noqa: SLF001
+    assert coord._grid_mode_status_last_success_mono is None  # noqa: SLF001
+    assert (
+        now < coord._grid_mode_status_cache_until <= time.monotonic() + 15.0
+    )  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_mode_status_missing_relay_keeps_recent_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    envoy_serial = coord.battery_runtime.grid_envoy_serial()
+    assert envoy_serial is not None
+    coord.battery_runtime.parse_grid_mode_status_payload(
+        {"meters": {"gridRelay": "OPER_RELAY_CLOSED"}}
+    )
+    coord._grid_mode_status_last_success_mono = time.monotonic()  # noqa: SLF001
+    coord.client.site_livestream_payload = AsyncMock(
+        return_value={"meters": {"serial_number": "secret-meter"}}
+    )
+
+    await coord.battery_runtime.async_refresh_grid_mode_status(force=True)
+
+    coord.client.site_livestream_payload.assert_awaited_once_with(envoy_serial)
+    assert coord.grid_mode_status_supported is True
+    assert coord.grid_mode_status == "on_grid"
+    assert coord.grid_mode_status_raw == "OPER_RELAY_CLOSED"
+    assert coord._grid_mode_status_failures == 1  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_mode_status_clears_state_during_stale_cooldown(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    family_state = coord._endpoint_family_state("grid_mode_status")  # noqa: SLF001
+    family_state.cooldown_active = True
+    coord._endpoint_family_should_run = lambda *_args, **_kwargs: False  # type: ignore[method-assign]  # noqa: SLF001
+    coord._endpoint_family_can_use_stale = lambda *_args: False  # type: ignore[method-assign]  # noqa: SLF001
+
+    assert coord.battery_runtime.grid_mode_status_refresh_due() is False
+
+    coord._grid_mode_status_supported = True  # noqa: SLF001
+    coord._grid_mode_status = "on_grid"  # noqa: SLF001
+    coord._grid_mode_status_raw = "OPER_RELAY_CLOSED"  # noqa: SLF001
+    assert coord.battery_runtime.grid_mode_status_refresh_due() is True
+
+    await coord.battery_runtime.async_refresh_grid_mode_status()
+
+    assert coord._grid_mode_status_supported is None  # noqa: SLF001
+    assert coord._grid_mode_status is None  # noqa: SLF001
+    assert coord._grid_mode_status_raw is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_refresh_grid_mode_status_wraps_non_dict_payload(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_livestream_payload = AsyncMock(return_value=None)
+
+    await coord.battery_runtime.async_refresh_grid_mode_status(force=True)
+
+    assert coord._grid_mode_status_payload == {"value": None}  # noqa: SLF001
+    assert coord.grid_mode_status_supported is False
+
+
+@pytest.mark.asyncio
 async def test_refresh_grid_outage_context_family_ttl_matches_cache(
     coordinator_factory,
 ) -> None:
@@ -287,7 +425,7 @@ async def test_refresh_grid_outage_context_keeps_recent_state_on_failure(
     await coord.battery_runtime.async_refresh_grid_outage_context(force=True)
 
     assert coord.grid_outage_context_supported is True
-    assert coord.grid_mode == "on_grid"
+    assert coord.grid_mode == "off_grid"
     assert coord._grid_outage_context_failures == 1  # noqa: SLF001
 
 
@@ -485,6 +623,26 @@ def test_collect_site_metrics_includes_grid_control_last_success_age(
     assert isinstance(metrics["grid_control_last_success_age_s"], float)
 
 
+def test_grid_mode_status_staleness_and_metrics(coordinator_factory) -> None:
+    coord = coordinator_factory()
+
+    assert coord._grid_mode_status_is_stale() is True  # noqa: SLF001
+
+    coord.battery_runtime.parse_grid_mode_status_payload(
+        {"meters": {"gridRelay": "OPER_RELAY_CLOSED"}}
+    )
+    coord._grid_mode_status_last_success_mono = time.monotonic() + 5  # noqa: SLF001
+    assert coord._grid_mode_status_is_stale() is False  # noqa: SLF001
+
+    coord._grid_mode_status_last_success_mono = time.monotonic() - 999  # noqa: SLF001
+    assert coord.grid_mode_status_supported is None
+
+    coord._grid_mode_status_last_success_mono = time.monotonic() - 1  # noqa: SLF001
+    metrics = coord.collect_site_metrics()
+    assert "grid_mode_status_last_success_age_s" in metrics
+    assert isinstance(metrics["grid_mode_status_last_success_age_s"], float)
+
+
 def test_grid_mode_uses_grid_outage_context(coordinator_factory) -> None:
     coord = coordinator_factory()
     assert coord._normalize_grid_mode_value(None) is None  # noqa: SLF001
@@ -497,8 +655,35 @@ def test_grid_mode_uses_grid_outage_context(coordinator_factory) -> None:
             "is_sunlight_backup": False,
         }
     )
+    assert coord.grid_mode_raw_states == [
+        "is_grid_outage:false",
+        "show_grid_connect:true",
+    ]
+    assert coord.grid_mode == "off_grid"
+    assert coord.grid_mode_source == "grid_outage_context"
+
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": False,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
     assert coord.grid_mode_raw_states == ["is_grid_outage:false"]
     assert coord.grid_mode == "on_grid"
+    assert coord.grid_mode_source == "grid_outage_context"
+
+    coord.battery_runtime.parse_grid_mode_status_payload(
+        {
+            "meters": {"gridRelay": "OPER_RELAY_CLOSED"},
+        }
+    )
+    assert coord.grid_mode_raw_states == [
+        "grid_relay:OPER_RELAY_CLOSED",
+        "is_grid_outage:false",
+    ]
+    assert coord.grid_mode == "on_grid"
+    assert coord.grid_mode_source == "livestream_grid_relay"
 
     coord.battery_runtime.parse_grid_outage_context_payload(
         {
@@ -510,8 +695,35 @@ def test_grid_mode_uses_grid_outage_context(coordinator_factory) -> None:
             }
         }
     )
-    assert coord.grid_mode_raw_states == ["is_grid_outage:true"]
+    assert coord.grid_mode_raw_states == [
+        "grid_relay:OPER_RELAY_CLOSED",
+        "is_grid_outage:true",
+        "show_grid_connect:false",
+    ]
+    assert coord.grid_mode == "on_grid"
+
+    coord.battery_runtime.parse_grid_mode_status_payload(
+        {"meters": {"gridRelay": "OPER_RELAY_OPEN"}}
+    )
     assert coord.grid_mode == "off_grid"
+    assert coord.grid_mode_source == "livestream_grid_relay"
+
+    coord.battery_runtime.parse_grid_mode_status_payload({})
+    assert coord.grid_mode_status_supported is False
+
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": False,
+            "show_grid_connect": False,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+    assert coord.grid_mode_raw_states == [
+        "is_grid_outage:false",
+        "show_grid_connect:false",
+    ]
+    assert coord.grid_mode == "on_grid"
 
     coord.battery_runtime.parse_grid_outage_context_payload({})
     assert coord.grid_mode_raw_states == []
@@ -523,6 +735,81 @@ def test_grid_mode_uses_grid_outage_context(coordinator_factory) -> None:
     }
     assert coord.grid_mode is None
     assert coord.grid_mode_raw_states == []
+
+
+def test_grid_mode_keeps_live_relay_status_when_site_lacks_enpower_hint(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.battery_runtime.parse_grid_mode_status_payload(
+        {"meters": {"gridRelay": "OPER_RELAY_CLOSED"}}
+    )
+    coord.battery_runtime.parse_grid_outage_context_payload(
+        {
+            "is_grid_outage": True,
+            "show_grid_connect": False,
+            "has_battery": True,
+            "is_sunlight_backup": False,
+        }
+    )
+
+    coord._battery_has_enpower = False  # noqa: SLF001
+
+    assert coord.grid_mode_status_supported is True
+    assert coord.grid_mode_status == "on_grid"
+    assert coord.grid_mode_status_raw == "OPER_RELAY_CLOSED"
+    assert coord.grid_mode_raw_states == [
+        "grid_relay:OPER_RELAY_CLOSED",
+        "is_grid_outage:true",
+        "show_grid_connect:false",
+    ]
+    assert coord.grid_mode == "on_grid"
+    assert coord.grid_mode_source == "livestream_grid_relay"
+
+
+@pytest.mark.parametrize(
+    ("relay", "expected"),
+    [
+        ("OPER_RELAY_OPEN", "off_grid"),
+        ("OPER_RELAY_OFFGRID_AC_GRID_PRESENT", "off_grid"),
+        ("OPER_RELAY_OFFGRID_READY_FOR_RESYNC_CMD", "off_grid"),
+        ("OPER_RELAY_CLOSED", "on_grid"),
+        ("OPER_RELAY_WAITING_TO_INITIALIZE_ON_GRID", "on_grid"),
+    ],
+)
+def test_grid_mode_maps_live_relay_enum(
+    coordinator_factory,
+    relay: str,
+    expected: str,
+) -> None:
+    coord = coordinator_factory()
+
+    assert coord.battery_runtime.parse_grid_mode_status_payload(
+        {"meters": {"gridRelay": relay}}
+    )
+    assert coord.grid_mode == expected
+
+
+def test_grid_mode_parser_handles_nested_relay_shapes(coordinator_factory) -> None:
+    coord = coordinator_factory()
+
+    assert coord.battery_runtime._grid_relay_candidates("invalid") == []  # noqa: SLF001
+    assert not coord.battery_runtime.parse_grid_mode_status_payload([])
+    assert coord.battery_runtime.parse_grid_mode_status_payload(
+        {
+            "meters": [{"gridRelay": None}, {"gridRelay": "unexpected"}],
+            "data": [
+                {
+                    "payload": {
+                        "message": [
+                            {"grid_relay": "OPER_RELAY_OFFGRID_AC_GRID_PRESENT"}
+                        ]
+                    }
+                }
+            ],
+        }
+    )
+    assert coord.grid_mode == "off_grid"
 
 
 def test_parse_grid_outage_context_payload_tracks_fields(coordinator_factory) -> None:

--- a/tests/components/enphase_ev/test_battery_runtime_grid_control.py
+++ b/tests/components/enphase_ev/test_battery_runtime_grid_control.py
@@ -373,7 +373,8 @@ async def test_refresh_grid_outage_context_family_ttl_matches_cache(
     assert family_state.next_retry_mono is not None
     assert (
         family_state.next_retry_mono - family_state.last_success_mono
-    ) == GRID_OUTAGE_CONTEXT_CACHE_TTL
+        == pytest.approx(GRID_OUTAGE_CONTEXT_CACHE_TTL)
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -294,6 +294,7 @@ class _RefreshOwner:
         )
         self.battery_runtime = SimpleNamespace(
             async_refresh_grid_control_check=self._async_refresh_grid_control_check,
+            async_refresh_grid_mode_status=self._async_refresh_grid_mode_status,
             async_refresh_grid_outage_context=self._async_refresh_grid_outage_context,
             async_refresh_battery_status=self._async_refresh_battery_status,
             battery_site_settings_refresh_due=lambda: True,
@@ -303,6 +304,7 @@ class _RefreshOwner:
             storm_guard_refresh_due=lambda: True,
             storm_alert_refresh_due=lambda: True,
             grid_control_check_refresh_due=lambda: True,
+            grid_mode_status_refresh_due=lambda: True,
             grid_outage_context_refresh_due=lambda: True,
             dry_contact_settings_refresh_due=lambda: True,
             battery_status_refresh_due=lambda: True,
@@ -367,6 +369,10 @@ class _RefreshOwner:
     def _async_refresh_grid_control_check(self) -> str:
         self.calls.append("grid_control")
         return "grid-control"
+
+    def _async_refresh_grid_mode_status(self) -> str:
+        self.calls.append("grid_mode_status")
+        return "grid-mode-status"
 
     def _async_refresh_grid_outage_context(self) -> str:
         self.calls.append("grid_outage_context")
@@ -455,6 +461,7 @@ def test_followup_refresh_stage_binds_zero_arg_calls() -> None:
         "storm_alert_s",
         "tariff_s",
         "grid_control_check_s",
+        "grid_mode_status_s",
         "grid_outage_context_s",
         "dry_contact_settings_s",
         "current_power_s",
@@ -510,6 +517,7 @@ def test_dynamic_followup_plan_skips_up_to_date_tasks() -> None:
     owner.battery_runtime.storm_guard_refresh_due = lambda: False
     owner.battery_runtime.storm_alert_refresh_due = lambda: False
     owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.grid_mode_status_refresh_due = lambda: False
     owner.battery_runtime.grid_outage_context_refresh_due = lambda: False
     owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
     owner.battery_runtime.battery_status_refresh_due = lambda: False
@@ -544,6 +552,7 @@ def test_dynamic_followup_plan_selects_due_subset() -> None:
     assert [task.timing_key for task in stage.parallel_tasks] == [
         "battery_site_settings_s",
         "tariff_s",
+        "grid_mode_status_s",
         "grid_outage_context_s",
     ]
     assert [task.timing_key for task in stage.ordered_tasks] == [
@@ -578,6 +587,7 @@ def test_dynamic_site_only_followup_plan_creates_inverter_stage_without_base_fol
     owner.battery_runtime.storm_guard_refresh_due = lambda: False
     owner.battery_runtime.storm_alert_refresh_due = lambda: False
     owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.grid_mode_status_refresh_due = lambda: False
     owner.battery_runtime.grid_outage_context_refresh_due = lambda: False
     owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
     owner.battery_runtime.battery_status_refresh_due = lambda: False
@@ -609,6 +619,7 @@ def test_dynamic_followup_plan_includes_due_evse_feature_flags() -> None:
     owner.battery_runtime.storm_guard_refresh_due = lambda: False
     owner.battery_runtime.storm_alert_refresh_due = lambda: False
     owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.grid_mode_status_refresh_due = lambda: False
     owner.battery_runtime.grid_outage_context_refresh_due = lambda: False
     owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
     owner.battery_runtime.battery_status_refresh_due = lambda: False
@@ -754,7 +765,7 @@ async def test_coordinator_refresh_plan_runner_executes_each_stage(
     await coord.refresh_runner.async_run_refresh_plan({}, plan=FOLLOWUP_PLAN)
 
     assert seen == [
-        (None, True, 11, 4),
+        (None, True, 12, 4),
     ]
 
 

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -311,6 +311,12 @@ class DummyCoordinator(SimpleNamespace):
             "disableGridControl": False,
             "activeDownload": False,
         }
+        self._grid_mode_status_payload = {
+            "meters": {
+                "gridRelay": "OPER_RELAY_CLOSED",
+                "serial_number": "[redacted]",
+            }
+        }
         self._grid_outage_context_payload = {
             "is_grid_outage": False,
             "show_grid_connect": True,
@@ -668,6 +674,7 @@ class DummyCoordinator(SimpleNamespace):
             "settings_payload": self._battery_settings_payload,
             "status_payload": self._battery_status_payload,
             "grid_control_check_payload": self._grid_control_check_payload,
+            "grid_mode_status_payload": self._grid_mode_status_payload,
             "grid_outage_context_payload": self._grid_outage_context_payload,
             "dry_contacts_payload": self._dry_contact_settings_payload,
             "backup_history_payload": self._battery_backup_history_payload,

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -1756,8 +1756,11 @@ def test_grid_mode_sensor_states_and_attributes():
         site_id="site",
         battery_has_encharge=True,
         has_type=lambda key: key in ("envoy", "enpower"),
-        grid_mode="on_grid",
-        grid_mode_raw_states=["is_grid_outage:false"],
+        grid_mode="off_grid",
+        grid_mode_raw_states=["is_grid_outage:false", "show_grid_connect:true"],
+        grid_mode_source="grid_outage_context",
+        grid_mode_status_supported=None,
+        grid_mode_status_raw=None,
         grid_outage_context_supported=True,
         grid_outage_is_grid_outage=False,
         grid_outage_show_grid_connect=True,
@@ -1770,10 +1773,12 @@ def test_grid_mode_sensor_states_and_attributes():
     )
     sensor = EnphaseGridModeSensor(coord)
     assert sensor.available is True
-    assert sensor.native_value == "on_grid"
+    assert sensor.native_value == "off_grid"
     attrs = sensor.extra_state_attributes
     assert attrs["source"] == "grid_outage_context"
-    assert attrs["raw_states"] == ["is_grid_outage:false"]
+    assert attrs["raw_states"] == ["is_grid_outage:false", "show_grid_connect:true"]
+    assert attrs["grid_mode_status_supported"] is None
+    assert attrs["grid_relay"] is None
     assert attrs["grid_outage_context_supported"] is True
     assert attrs["is_grid_outage"] is False
     assert attrs["show_grid_connect"] is True
@@ -1783,7 +1788,7 @@ def test_grid_mode_sensor_states_and_attributes():
     assert attrs["grid_toggle_allowed"] is True
 
     coord.grid_mode = "off_grid"
-    coord.grid_mode_raw_states = ["is_grid_outage:true"]
+    coord.grid_mode_raw_states = ["is_grid_outage:true", "show_grid_connect:false"]
     coord.grid_outage_is_grid_outage = True
     assert sensor.native_value == "off_grid"
 
@@ -1805,8 +1810,11 @@ def test_grid_mode_sensor_unavailable_without_supported_types():
         site_id="site",
         battery_has_encharge=True,
         has_type=lambda _key: False,
-        grid_mode="on_grid",
-        grid_mode_raw_states=["is_grid_outage:false"],
+        grid_mode="off_grid",
+        grid_mode_raw_states=["is_grid_outage:false", "show_grid_connect:true"],
+        grid_mode_source="grid_outage_context",
+        grid_mode_status_supported=None,
+        grid_mode_status_raw=None,
         grid_outage_context_supported=True,
         grid_outage_is_grid_outage=False,
         grid_outage_show_grid_connect=True,
@@ -1830,8 +1838,11 @@ def test_grid_mode_sensor_unavailable_when_site_not_battery_capable():
         battery_has_encharge=False,
         battery_has_enpower=False,
         has_type=lambda key: key in ("envoy", "enpower"),
-        grid_mode="on_grid",
-        grid_mode_raw_states=["is_grid_outage:false"],
+        grid_mode="off_grid",
+        grid_mode_raw_states=["is_grid_outage:false", "show_grid_connect:true"],
+        grid_mode_source="grid_outage_context",
+        grid_mode_status_supported=None,
+        grid_mode_status_raw=None,
         grid_outage_context_supported=True,
         grid_outage_is_grid_outage=False,
         grid_outage_show_grid_connect=True,


### PR DESCRIPTION
## Summary

- Read Grid Mode from the signed Enphase Live Status MQTT stream instead of inferring it primarily from outage context.
- Decode the production `DataMsg` protobuf payload and map `meters.gridRelay` relay states to on-grid and off-grid values.
- Refresh the live relay state every 300 seconds, retain bounded stale data across transient failures, and expose source/freshness diagnostics.
- Keep outage-context fields as a fallback when live relay data is unavailable.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/const.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_grid_control.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_sensors.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/const.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/refresh_plan.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/state_models.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

- Full repository suite after merging the latest `main`: 3,548 passed.
- Changed production modules: 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid (no translation changes required).
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Diagnostics now report the Grid Mode source, raw relay enum, failure count, freshness, and last-success age.
- The MQTT authorizer payload, username, topic, and raw account data are not exposed in diagnostics.
