### PR TITLE
Fix background task cleanup on unload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed config-entry unload and entity removal leaving delayed backoff, schedule,
+  battery-profile recovery, or firmware refresh work running against retired
+  integration objects.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1540,6 +1540,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if self._warmup_task is not None:
             self._warmup_task.cancel()
             self._warmup_task = None
+        if self._battery_profile_recovery_restore_task is not None:
+            if not _task_done(self._battery_profile_recovery_restore_task):
+                self._battery_profile_recovery_restore_task.cancel()
+            self._battery_profile_recovery_restore_task = None
         for task in list(self._amp_restart_tasks.values()):
             if task is not None and not _task_done(task):
                 task.cancel()
@@ -1552,6 +1556,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             if not _task_done(self._auth_refresh_task):
                 self._auth_refresh_task.cancel()
             self._auth_refresh_task = None
+        self._clear_backoff_timer()
+        for task in list(self._backoff_refresh_tasks):
+            if not _task_done(task):
+                task.cancel()
+        self._backoff_refresh_tasks.clear()
+        self._backoff_until = None
         clear_streaming_state = getattr(self, "_clear_streaming_state", None)
         if callable(clear_streaming_state):
             clear_streaming_state()
@@ -6815,14 +6825,25 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def sync_battery_profile_pending_issue(self) -> None:
         self._sync_battery_profile_pending_issue()
 
+    def _start_backoff_refresh(self) -> None:
+        task = self.hass.async_create_task(
+            self.async_request_refresh(), name=f"{DOMAIN}_backoff_refresh"
+        )
+        if task is None:
+            return
+        tasks = getattr(self, "_backoff_refresh_tasks", None)
+        if tasks is None:
+            tasks = set()
+            self._backoff_refresh_tasks = tasks
+        tasks.add(task)
+        task.add_done_callback(tasks.discard)
+
     def _schedule_backoff_timer(self, delay: float) -> None:
         if delay <= 0:
             self._clear_backoff_timer()
             self._backoff_until = None
             self.backoff_ends_utc = None
-            self.hass.async_create_task(
-                self.async_request_refresh(), name=f"{DOMAIN}_backoff_refresh"
-            )
+            self._start_backoff_refresh()
             return
         self._clear_backoff_timer()
         try:
@@ -6830,14 +6851,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         except Exception:
             self.backoff_ends_utc = None
 
-        async def _resume(_now: datetime) -> None:
+        @callback
+        def _resume(_now: datetime) -> None:
             # Home Assistant should recover from cloud throttling on its own;
             # the timer clears diagnostic state and triggers one refresh when
             # the backoff window ends.
             self._backoff_cancel = None
             self._backoff_until = None
             self.backoff_ends_utc = None
-            await self.async_request_refresh()
+            self._start_backoff_refresh()
 
         self._backoff_cancel = async_call_later(self.hass, delay, _resume)
 

--- a/custom_components/enphase_ev/schedule_sync.py
+++ b/custom_components/enphase_ev/schedule_sync.py
@@ -74,6 +74,8 @@ class ScheduleSync:
         self._last_error: str | None = None
         self._last_status: str | None = None
         self._pending_patch_refresh: set[str] = set()
+        self._pending_patch_refresh_cancels: dict[str, Callable[[], None]] = {}
+        self._pending_patch_refresh_tasks: dict[str, asyncio.Future[None]] = {}
 
     async def async_start(self) -> None:
         self._disabled_cleanup_done = False
@@ -99,6 +101,16 @@ class ScheduleSync:
         if self._unsub_coordinator is not None:
             self._unsub_coordinator()
             self._unsub_coordinator = None
+        for cancel in self._pending_patch_refresh_cancels.values():
+            cancel()
+        self._pending_patch_refresh_cancels.clear()
+        tasks = tuple(self._pending_patch_refresh_tasks.values())
+        for task in tasks:
+            task.cancel()
+        self._pending_patch_refresh_tasks.clear()
+        self._pending_patch_refresh.clear()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
 
     def diagnostics(self) -> dict[str, Any]:
         return {
@@ -152,20 +164,33 @@ class ScheduleSync:
 
         @callback
         def _run(_now) -> None:
-            self._pending_patch_refresh.discard(sn)
+            self._pending_patch_refresh_cancels.pop(sn, None)
             coro = self.async_refresh(reason="patch", serials=[sn])
             try:
-                self.hass.async_create_task(
+                task = self.hass.async_create_task(
                     coro,
                     name=f"{DOMAIN}_schedule_patch_refresh_{redact_identifier(sn)}",
                 )
             except TypeError:
                 coro.close()
-                self.hass.async_create_task(
+                task = self.hass.async_create_task(
                     self.async_refresh(reason="patch", serials=[sn])
                 )
+            if task is None:
+                self._pending_patch_refresh.discard(sn)
+                return
+            self._pending_patch_refresh_tasks[sn] = task
 
-        async_call_later(self.hass, PATCH_REFRESH_DELAY_S, _run)
+            def _clear(completed: asyncio.Future[None]) -> None:
+                if self._pending_patch_refresh_tasks.get(sn) is completed:
+                    self._pending_patch_refresh_tasks.pop(sn, None)
+                    self._pending_patch_refresh.discard(sn)
+
+            task.add_done_callback(_clear)
+
+        self._pending_patch_refresh_cancels[sn] = async_call_later(
+            self.hass, PATCH_REFRESH_DELAY_S, _run
+        )
 
     def _scheduler_backoff_active(self) -> bool:
         backoff_active = getattr(self._coordinator, "scheduler_backoff_active", None)

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -100,6 +100,7 @@ class RefreshHealthState:
     _cloud_issue_reported: bool = False
     _backoff_until: float | None = None
     _backoff_cancel: Any = None
+    _backoff_refresh_tasks: set[Any] = field(default_factory=set)
     _last_error: str | None = None
     _streaming: bool = False
     _streaming_until: float | None = None

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -335,6 +335,12 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
         await super().async_added_to_hass()
         await self._async_refresh_catalog()
 
+    async def async_will_remove_from_hass(self) -> None:
+        if self._refresh_task is not None and not self._refresh_task.done():
+            self._refresh_task.cancel()
+        self._refresh_task = None
+        await super().async_will_remove_from_hass()
+
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:
@@ -543,6 +549,12 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         await self._async_refresh_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._refresh_task is not None and not self._refresh_task.done():
+            self._refresh_task.cancel()
+        self._refresh_task = None
+        await super().async_will_remove_from_hass()
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1810,11 +1810,51 @@ async def test_backoff_timer_requests_refresh(hass, monkeypatch):
     assert coord.backoff_ends_utc == now + timedelta(seconds=2.5)
     assert callable(coord._backoff_cancel)
 
-    await captured["callback"](now + timedelta(seconds=3))
+    captured["callback"](now + timedelta(seconds=3))
+    task = next(iter(coord._backoff_refresh_tasks))  # noqa: SLF001
+    await task
+    await asyncio.sleep(0)
 
     assert coord.async_request_refresh.await_count == 1
     assert coord.backoff_ends_utc is None
     assert coord._backoff_cancel is None
+    assert coord._backoff_refresh_tasks == set()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_cleanup_cancels_fired_backoff_refresh(hass, monkeypatch) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = _make_coordinator(hass, monkeypatch)
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    captured: dict[str, object] = {}
+
+    async def _refresh() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    def _fake_call_later(_hass, _delay, action):
+        captured["callback"] = action
+        return lambda: None
+
+    coord.async_request_refresh = _refresh  # type: ignore[method-assign]
+    monkeypatch.setattr(coord_mod, "async_call_later", _fake_call_later)
+
+    coord._schedule_backoff_timer(1)  # noqa: SLF001
+    captured["callback"](dt_util.utcnow())
+    task = next(iter(coord._backoff_refresh_tasks))  # noqa: SLF001
+    await started.wait()
+
+    coord.cleanup_runtime_state()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert cancelled.is_set()
+    assert coord._backoff_refresh_tasks == set()  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -1578,6 +1578,9 @@ async def test_async_unload_entry_cancels_background_lifecycle_tasks(
     completed_amp_task = _RecordingTask(done=True)
     stream_stop_task = _RecordingTask()
     auth_refresh_task = _RecordingTask()
+    battery_restore_task = _RecordingTask()
+    backoff_refresh_task = _RecordingTask()
+    backoff_cancel = Mock()
     schedule_sync = SimpleNamespace(async_stop=AsyncMock())
     session_history = SimpleNamespace(_enrichment_tasks={session_task})
 
@@ -1601,6 +1604,11 @@ async def test_async_unload_entry_cancels_background_lifecycle_tasks(
             }
             self._streaming_stop_task = stream_stop_task
             self._auth_refresh_task = auth_refresh_task
+            self._battery_profile_recovery_restore_task = battery_restore_task
+            self._backoff_cancel = backoff_cancel
+            self._backoff_refresh_tasks = {backoff_refresh_task}
+            self._backoff_until = 123.0
+            self.backoff_ends_utc = datetime.now(timezone.utc)
             self.discovery_snapshot = SimpleNamespace(cancel_pending_save=Mock())
             self.session_history = session_history
             self._session_history_cache_shim = {("EV123", "2026-04-24"): (1.0, [])}
@@ -1609,6 +1617,9 @@ async def test_async_unload_entry_cancels_background_lifecycle_tasks(
             self.evse_runtime = SimpleNamespace(
                 prune_runtime_caches=Mock(),
             )
+
+        def _clear_backoff_timer(self) -> None:
+            EnphaseCoordinator._clear_backoff_timer(self)
 
         def _prune_runtime_caches(self, *, active_serials, keep_day_keys) -> None:
             self.evse_runtime.prune_runtime_caches(
@@ -1630,10 +1641,17 @@ async def test_async_unload_entry_cancels_background_lifecycle_tasks(
     assert not completed_amp_task.cancelled
     assert stream_stop_task.cancelled
     assert auth_refresh_task.cancelled
+    assert battery_restore_task.cancelled
+    assert backoff_refresh_task.cancelled
+    backoff_cancel.assert_called_once_with()
     assert coord._warmup_task is None
     assert coord._amp_restart_tasks == {}
     assert coord._streaming_stop_task is None
     assert coord._auth_refresh_task is None
+    assert coord._battery_profile_recovery_restore_task is None
+    assert coord._backoff_cancel is None
+    assert coord._backoff_refresh_tasks == set()
+    assert coord._backoff_until is None
     assert coord._session_history_cache_shim == {}
     assert coord._topology_listeners == []
     session_history.clear.assert_called_once_with()

--- a/tests/components/enphase_ev/test_schedule_sync.py
+++ b/tests/components/enphase_ev/test_schedule_sync.py
@@ -668,6 +668,7 @@ async def test_schedule_sync_post_patch_refresh_dedupes(hass, monkeypatch) -> No
     assert RANDOM_SERIAL not in str(names[0])
     assert "..." in str(names[0])
     assert RANDOM_SERIAL not in sync._pending_patch_refresh
+    assert sync._pending_patch_refresh_tasks == {}  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -1922,10 +1923,57 @@ async def test_schedule_sync_async_stop_clears_interval_and_coordinator_handlers
     called: list[str] = []
     sync._unsub_interval = lambda *_args: called.append("interval")
     sync._unsub_coordinator = lambda: called.append("coord")
+    sync._pending_patch_refresh.add(RANDOM_SERIAL)
+    sync._pending_patch_refresh_cancels[RANDOM_SERIAL] = lambda: called.append(
+        "patch"
+    )  # noqa: SLF001
 
     await sync.async_stop()
 
-    assert called == ["interval", "coord"]
+    assert called == ["interval", "coord", "patch"]
+    assert sync._pending_patch_refresh == set()
+    assert sync._pending_patch_refresh_cancels == {}  # noqa: SLF001
+    assert sync._pending_patch_refresh_tasks == {}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_schedule_sync_stop_cancels_fired_post_patch_refresh(
+    hass, monkeypatch
+) -> None:
+    sync = ScheduleSync(hass, SimpleNamespace(), None)
+    callbacks: list[callable] = []
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    def _fake_call_later(_hass, _delay, action):
+        callbacks.append(action)
+        return lambda: None
+
+    async def _refresh(*, reason, serials) -> None:
+        assert reason == "patch"
+        assert serials == [RANDOM_SERIAL]
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    monkeypatch.setattr(schedule_sync_mod, "async_call_later", _fake_call_later)
+    sync.async_refresh = _refresh
+
+    sync._schedule_post_patch_refresh(RANDOM_SERIAL)
+    callbacks[0](None)
+    task = sync._pending_patch_refresh_tasks[RANDOM_SERIAL]  # noqa: SLF001
+    await started.wait()
+
+    await sync.async_stop()
+
+    assert cancelled.is_set()
+    assert task.cancelled()
+    assert sync._pending_patch_refresh == set()
+    assert sync._pending_patch_refresh_cancels == {}  # noqa: SLF001
+    assert sync._pending_patch_refresh_tasks == {}  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -1040,6 +1040,8 @@ async def test_entity_refresh_and_scheduler_branches(hass, monkeypatch) -> None:
         "async_added_to_hass",
         AsyncMock(return_value=None),
     )
+    remove = AsyncMock(return_value=None)
+    monkeypatch.setattr(CoordinatorEntity, "async_will_remove_from_hass", remove)
     monkeypatch.setattr(
         CoordinatorEntity, "_handle_coordinator_update", lambda self: None
     )
@@ -1056,6 +1058,15 @@ async def test_entity_refresh_and_scheduler_branches(hass, monkeypatch) -> None:
         await running
     except asyncio.CancelledError:
         pass
+
+    pending_removal = hass.async_create_task(asyncio.sleep(60))
+    entity._refresh_task = pending_removal
+    await entity.async_will_remove_from_hass()
+    with pytest.raises(asyncio.CancelledError):
+        await pending_removal
+    assert pending_removal.cancelled()
+    assert entity._refresh_task is None
+    remove.assert_awaited_once_with()
 
     entity.hass = None
     entity._schedule_catalog_refresh()
@@ -1100,6 +1111,8 @@ async def test_charger_entity_refresh_branches(hass, monkeypatch) -> None:
         "async_added_to_hass",
         AsyncMock(return_value=None),
     )
+    remove = AsyncMock(return_value=None)
+    monkeypatch.setattr(CoordinatorEntity, "async_will_remove_from_hass", remove)
     monkeypatch.setattr(
         CoordinatorEntity, "_handle_coordinator_update", lambda self: None
     )
@@ -1117,6 +1130,15 @@ async def test_charger_entity_refresh_branches(hass, monkeypatch) -> None:
         await running
     except asyncio.CancelledError:
         pass
+
+    pending_removal = hass.async_create_task(asyncio.sleep(60))
+    entity._refresh_task = pending_removal
+    await entity.async_will_remove_from_hass()
+    with pytest.raises(asyncio.CancelledError):
+        await pending_removal
+    assert pending_removal.cancelled()
+    assert entity._refresh_task is None
+    remove.assert_awaited_once_with()
 
     entity.hass = None
     entity._schedule_details_refresh()


### PR DESCRIPTION
## Summary

- Cancel pending and fired coordinator backoff refresh work during config-entry unload.
- Cancel battery-profile recovery and firmware entity refresh tasks when their owners unload.
- Cancel and await delayed EVSE schedule refresh tasks during schedule-sync shutdown.
- Add regression coverage for timers firing immediately before cleanup.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/schedule_sync.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_schedule_sync.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/schedule_sync.py --select ASYNC --output-format concise"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_schedule_sync.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/schedule_sync.py,custom_components/enphase_ev/state_models.py,custom_components/enphase_ev/update.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc "python -m pre_commit run --all-files"
```

Results:

- 343 targeted tests passed.
- 3,378 integration tests passed with 100% coverage for every touched runtime module.
- 3,499 repository tests passed.
- Black, Ruff, async-specific Ruff, Codespell, and pre-commit passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No API schema, configuration option, entity string, or translation changes. GitHub Actions results were not yet available when the PR was created.
