### PR TITLE
Reuse Home Assistant-managed cookie session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
 ### 🔧 Improvements
 - Documented the IQ EV Charger device automation triggers and the integration's
   use of standard Home Assistant conditions.
+- Reused a Home Assistant-managed stateless HTTP session for cookie-authenticated
+  BatteryConfig writes instead of creating a new connection pool per request.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -7,6 +7,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any, Coroutine, cast
 
+import aiohttp
 from homeassistant.config_entries import ConfigEntryState, OperationNotAllowed
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import (
@@ -14,6 +15,7 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
 )
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import CONF_INCLUDE_INVERTERS, CONF_SELECTED_TYPE_KEYS, DOMAIN
 from .device_info_helpers import (
@@ -1504,7 +1506,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     from .firmware_catalog import FirmwareCatalogManager
     from .labels import async_prime_label_translations
 
-    coord = EnphaseCoordinator(hass, entry.data, config_entry=entry)
+    coord = EnphaseCoordinator(
+        hass,
+        entry.data,
+        config_entry=entry,
+        cookie_header_session=async_create_clientsession(
+            hass,
+            auto_cleanup=True,
+            cookie_jar=aiohttp.DummyCookieJar(),
+        ),
+    )
     firmware_catalog = FirmwareCatalogManager(hass)
     evse_firmware_details = EvseFirmwareDetailsManager(lambda: coord.client)
     battery_schedule_editor = BatteryScheduleEditorManager(coord)
@@ -1627,6 +1638,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> 
             await coord.schedule_sync.async_stop()
         if coord is not None and hasattr(coord, "cleanup_runtime_state"):
             coord.cleanup_runtime_state()
+        if coord is not None and hasattr(coord, "async_close"):
+            await coord.async_close()
         entry.runtime_data = None
         loaded_state = getattr(ConfigEntryState, "LOADED", None)
         has_loaded_entries = any(

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2017,9 +2017,11 @@ class EnphaseEVClient:
         cookie: str | None,
         timeout: int = 15,
         reauth_callback: Callable[[], Awaitable[bool]] | None = None,
+        cookie_header_session: aiohttp.ClientSession | None = None,
     ):
         self._timeout = int(timeout)
         self._s = session
+        self._cookie_header_session = cookie_header_session
         self._site = site_id
         # Cache working API variant indexes per action to avoid retries once discovered
         self._start_variant_idx: int | None = None
@@ -2054,6 +2056,14 @@ class EnphaseEVClient:
         """Register coroutine used to refresh credentials on 401."""
 
         self._reauth_cb = callback
+
+    async def async_close(self) -> None:
+        """Detach the private session while preserving Home Assistant's connector."""
+
+        session = self._cookie_header_session
+        self._cookie_header_session = None
+        if session is not None and not session.closed:
+            session.detach()
 
     @staticmethod
     def _is_hems_api_endpoint(endpoint: str | None) -> bool:
@@ -4488,17 +4498,25 @@ class EnphaseEVClient:
         """Yield the HTTP session to use for a request.
 
         Cookie-backed BatteryConfig writes need the explicit raw Cookie header to be
-        sent without any session-jar merging. A short-lived stateless session avoids
-        hidden cookie mutations from the shared client while preserving the normal
-        shared session for all other requests.
+        sent without any session-jar merging. The injected stateless session avoids
+        hidden cookie mutations from the shared client while preserving connection
+        reuse across writes.
         """
 
         if not cookie_header_only:
             yield self._s
             return
 
-        async with aiohttp.ClientSession(cookie_jar=aiohttp.DummyCookieJar()) as s:
-            yield s
+        session = self._cookie_header_session
+        if session is None and isinstance(
+            getattr(self._s, "cookie_jar", None), aiohttp.DummyCookieJar
+        ):
+            session = self._s
+        if session is None:
+            raise RuntimeError(
+                "Cookie-header-only requests require an injected stateless session"
+            )
+        yield session
 
     async def _text_response(
         self,

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -563,6 +563,8 @@ class EnphaseCoordinator(
         hass: HomeAssistant,
         config: Mapping[str, Any],
         config_entry: EnphaseConfigEntry | None = None,
+        *,
+        cookie_header_session: aiohttp.ClientSession | None = None,
     ) -> None:
         self.hass = hass
         self.config_entry = config_entry
@@ -680,6 +682,7 @@ class EnphaseCoordinator(
             self._tokens.access_token,
             self._tokens.cookie,
             timeout=timeout,
+            cookie_header_session=cookie_header_session,
         )
         set_reauth_cb = getattr(self.client, "set_reauth_callback", None)
         if callable(set_reauth_cb):
@@ -868,6 +871,11 @@ class EnphaseCoordinator(
         self.diagnostics = CoordinatorDiagnostics(self)
         self.refresh_runner = RefreshRunner(self)
         self._endpoint_family_policies = self._build_endpoint_family_policies()
+
+    async def async_close(self) -> None:
+        """Release config-entry-owned HTTP resources."""
+
+        await self.client.async_close()
 
     def __setattr__(self, name: str, value: object) -> None:
         if name == "_async_fetch_sessions_today" and hasattr(self, "session_history"):

--- a/tests/components/enphase_ev/conftest.py
+++ b/tests/components/enphase_ev/conftest.py
@@ -324,6 +324,15 @@ def mock_issue_registry(monkeypatch) -> SimpleNamespace:
 def mock_clientsession(monkeypatch):
     """Stub out aiohttp client session factory used by the integration."""
     session = object()
+
+    class StatelessSession:
+        closed = False
+
+        def detach(self) -> None:
+            self.closed = True
+
+    stateless_session = StatelessSession()
+    create_calls = []
     for target in (
         "custom_components.enphase_ev.coordinator.async_get_clientsession",
         "custom_components.enphase_ev.config_flow.async_get_clientsession",
@@ -333,7 +342,16 @@ def mock_clientsession(monkeypatch):
             lambda *args, **kwargs: session,
             raising=False,
         )
-    return session
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.async_create_clientsession",
+        lambda *args, **kwargs: create_calls.append((args, kwargs))
+        or stateless_session,
+    )
+    return SimpleNamespace(
+        shared=session,
+        stateless=stateless_session,
+        create_calls=create_calls,
+    )
 
 
 @pytest.fixture

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -5480,21 +5480,114 @@ async def test_battery_config_write_request_uses_cookie_header_only_for_cookie_a
 
 
 @pytest.mark.asyncio
-async def test_request_session_cookie_header_only_uses_ephemeral_client_session() -> (
-    None
-):
-    client = _make_client()
+async def test_request_session_reuses_injected_cookie_header_session() -> None:
+    shared_session = _DefaultSession()
+    stateless_session = _DefaultSession()
+    stateless_session.cookie_jar = aiohttp.DummyCookieJar()
+    client = api.EnphaseEVClient(
+        shared_session,
+        "SITE",
+        "EAUTH",
+        "COOKIE",
+        cookie_header_session=stateless_session,
+    )
 
     async with client._request_session(
         cookie_header_only=False
     ) as shared:  # noqa: SLF001
-        assert shared is client._s  # noqa: SLF001
+        assert shared is shared_session
 
     async with client._request_session(
         cookie_header_only=True
-    ) as isolated:  # noqa: SLF001
-        assert isinstance(isolated, aiohttp.ClientSession)
-        assert isolated is not client._s  # noqa: SLF001
+    ) as first:  # noqa: SLF001
+        assert first is stateless_session
+    async with client._request_session(
+        cookie_header_only=True
+    ) as second:  # noqa: SLF001
+        assert second is first
+
+
+@pytest.mark.asyncio
+async def test_request_session_accepts_stateless_primary_session() -> None:
+    stateless_session = _DefaultSession()
+    stateless_session.cookie_jar = aiohttp.DummyCookieJar()
+    client = api.EnphaseEVClient(stateless_session, "SITE", "EAUTH", "COOKIE")
+
+    async with client._request_session(  # noqa: SLF001
+        cookie_header_only=True
+    ) as request_session:
+        assert request_session is stateless_session
+
+
+@pytest.mark.asyncio
+async def test_cookie_header_only_request_preserves_raw_cookie_header() -> None:
+    shared_session = _DefaultSession()
+    shared_session.cookie_jar = SimpleNamespace(
+        filter_cookies=lambda _url: SimpleCookie("hidden=jar-cookie")
+    )
+    stateless_session = _FakeSession(
+        [
+            _FakeResponse(status=200, json_body={"attempt": 1}),
+            _FakeResponse(status=200, json_body={"attempt": 2}),
+        ]
+    )
+    stateless_session.cookie_jar = aiohttp.DummyCookieJar()
+    client = api.EnphaseEVClient(
+        shared_session,
+        "SITE",
+        None,
+        "session=raw; BP-XSRF-Token=raw-token",
+        cookie_header_session=stateless_session,
+    )
+
+    for expected_attempt in (1, 2):
+        payload = await client._json(  # noqa: SLF001
+            "PUT",
+            "https://example.test/battery-settings",
+            headers={"Cookie": "session=raw; BP-XSRF-Token=raw-token"},
+            use_cookie_header_only=True,
+        )
+        assert payload == {"attempt": expected_attempt}
+
+    assert len(stateless_session.calls) == 2
+    assert all(
+        kwargs["headers"]["Cookie"] == "session=raw; BP-XSRF-Token=raw-token"
+        for _method, _url, kwargs in stateless_session.calls
+    )
+    assert all(
+        "hidden=jar-cookie" not in kwargs["headers"]["Cookie"]
+        for _method, _url, kwargs in stateless_session.calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_cookie_header_only_request_requires_stateless_session() -> None:
+    client = _make_client()
+
+    with pytest.raises(
+        RuntimeError,
+        match="require an injected stateless session",
+    ):
+        async with client._request_session(cookie_header_only=True):  # noqa: SLF001
+            pass
+
+
+@pytest.mark.asyncio
+async def test_async_close_detaches_private_session_once() -> None:
+    stateless_session = MagicMock(closed=False)
+    client = api.EnphaseEVClient(
+        _DefaultSession(),
+        "SITE",
+        "EAUTH",
+        "COOKIE",
+        cookie_header_session=stateless_session,
+    )
+
+    await client.async_close()
+    await client.async_close()
+
+    stateless_session.detach.assert_called_once_with()
+    assert client._cookie_header_session is None  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -98,6 +98,35 @@ def _client_response_error(status: int, *, message: str = "", headers=None):
 
 
 @pytest.mark.asyncio
+async def test_coordinator_injects_and_closes_stateless_cookie_session(
+    hass, mock_clientsession
+) -> None:
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    config = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+    }
+
+    coordinator = EnphaseCoordinator(
+        hass,
+        config,
+        cookie_header_session=mock_clientsession.stateless,
+    )
+
+    assert coordinator.client._s is mock_clientsession.shared  # noqa: SLF001
+    assert (  # noqa: SLF001
+        coordinator.client._cookie_header_session is mock_clientsession.stateless
+    )
+
+    await coordinator.async_close()
+
+    assert mock_clientsession.stateless.closed is True
+
+
+@pytest.mark.asyncio
 async def test_coordinator_init_normalizes_serials_and_options(hass, monkeypatch):
     from custom_components.enphase_ev import coordinator as coord_mod
     from custom_components.enphase_ev.coordinator import EnphaseCoordinator

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, call
 
+import aiohttp
 import pytest
 import voluptuous as vol
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -431,7 +432,7 @@ def test_migrate_orphaned_update_entities_to_type_devices_handles_edge_paths(
 
 @pytest.mark.asyncio
 async def test_async_setup_entry_updates_existing_device(
-    hass: HomeAssistant, config_entry, monkeypatch
+    hass: HomeAssistant, config_entry, monkeypatch, mock_clientsession
 ) -> None:
     """Ensure charger devices are refreshed when registry data drifts."""
     site_id = config_entry.data[CONF_SITE_ID]
@@ -496,13 +497,17 @@ async def test_async_setup_entry_updates_existing_device(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
 
     assert await async_setup_entry(hass, config_entry)
     await hass.async_block_till_done()
+    args, kwargs = mock_clientsession.create_calls[-1]
+    assert args == (hass,)
+    assert kwargs["auto_cleanup"] is True
+    assert isinstance(kwargs["cookie_jar"], aiohttp.DummyCookieJar)
     dummy_coord.schedule_sync.async_start.assert_awaited_once()
     forward.assert_awaited_once()
 
@@ -591,7 +596,7 @@ async def test_async_setup_entry_restores_discovery_before_first_refresh(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
 
@@ -623,7 +628,7 @@ async def test_async_setup_entry_uses_background_task_for_schedule_sync_start(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
@@ -678,7 +683,7 @@ async def test_async_setup_entry_registers_evse_schedule_editor_runtime(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     monkeypatch.setattr(
         "custom_components.enphase_ev.battery_schedule_editor.BatteryScheduleEditorManager",
@@ -727,7 +732,7 @@ async def test_async_setup_entry_uses_background_task_for_startup_warmup(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
@@ -779,7 +784,7 @@ async def test_async_setup_entry_records_startup_migration_version(
     migrate_updates = MagicMock()
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     monkeypatch.setattr(
         "custom_components.enphase_ev._migrate_legacy_gateway_type_devices",
@@ -831,7 +836,7 @@ async def test_async_setup_entry_skips_startup_migrations_when_version_current(
     migrate_cloud = MagicMock()
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     monkeypatch.setattr(
         "custom_components.enphase_ev._migrate_legacy_gateway_type_devices",
@@ -895,7 +900,7 @@ async def test_async_setup_entry_removes_legacy_site_device_when_migration_curre
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
 
@@ -1145,7 +1150,7 @@ async def test_async_setup_entry_schedule_sync_falls_back_to_hass_background_tas
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
     monkeypatch.setattr(config_entry, "async_create_background_task", None)
@@ -1190,7 +1195,7 @@ async def test_async_setup_entry_schedule_sync_falls_back_to_hass_create_task(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
     monkeypatch.setattr(config_entry, "async_create_background_task", None)
@@ -1238,7 +1243,7 @@ async def test_async_setup_entry_updates_title_to_prefixed_site_id(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
@@ -1289,7 +1294,7 @@ async def test_async_setup_entry_migrates_selected_type_keys_for_microinverters_
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
@@ -1347,7 +1352,7 @@ async def test_async_setup_entry_does_not_add_heatpump_without_gateway_selection
 
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: _with_inventory_view(
+        lambda hass_, entry_data, config_entry=None, **kwargs: _with_inventory_view(
             DummyCoordinator()
         ),
     )
@@ -1402,7 +1407,7 @@ async def test_async_setup_entry_model_display_variants(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
@@ -1463,7 +1468,7 @@ async def test_async_setup_entry_uses_fallback_name_for_model(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
@@ -1519,7 +1524,7 @@ async def test_async_setup_entry_registry_sync_listener_handles_exceptions(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
@@ -1542,7 +1547,9 @@ async def test_async_unload_entry_stops_schedule_sync(
 ) -> None:
     schedule_sync = SimpleNamespace(async_stop=AsyncMock())
     coord = SimpleNamespace(
-        schedule_sync=schedule_sync, cleanup_runtime_state=MagicMock()
+        schedule_sync=schedule_sync,
+        cleanup_runtime_state=MagicMock(),
+        async_close=AsyncMock(),
     )
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
@@ -1552,6 +1559,7 @@ async def test_async_unload_entry_stops_schedule_sync(
     assert await async_unload_entry(hass, config_entry)
     schedule_sync.async_stop.assert_awaited_once()
     coord.cleanup_runtime_state.assert_called_once()
+    coord.async_close.assert_awaited_once()
     assert unload.await_count == len(PLATFORMS)
     assert config_entry.runtime_data is None
 
@@ -4962,7 +4970,7 @@ async def test_async_setup_entry_registry_sync_listener_only_resyncs_devices_on_
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
@@ -5055,7 +5063,7 @@ async def test_async_setup_entry_registry_sync_listener_swallows_sync_errors(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
-        lambda hass_, entry_data, config_entry=None: dummy_coord,
+        lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
     monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Reuse Home Assistant's managed web session for cookie-backed Enphase requests instead of creating a separate client session.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/api.py custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/conftest.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_init_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Result: 3,565 tests passed; strict typing succeeds across all 68 integration source files, and all three touched integration modules have 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Tests cover session reuse, ownership, cleanup, and the cookie request path.
