### PR TITLE
Reduce recorder-heavy sensor attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### 🚧 Breaking changes
-- None
+- Removed internal calculation and stable charger metadata attributes from the
+  frequently updated IQ EV Charger Power and Last Reported sensors to reduce
+  Recorder growth. Power restore baselines now use private Home Assistant
+  restore data.
 
 ### ✨ New features
 - None

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -1192,6 +1192,58 @@ class _SiteLifetimePowerRestoreData(ExtraStoredData):  # type: ignore[misc]
         )
 
 
+@dataclass
+class _PowerRestoreData(ExtraStoredData):  # type: ignore[misc]
+    """Persist EV charger derived-power state without recorder attributes."""
+
+    last_lifetime_kwh: float | None
+    last_energy_ts: float | None
+    last_sample_ts: float | None
+    last_power_w: int | None
+    last_window_seconds: float | None
+    method: str | None
+    last_reset_at: float | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "last_lifetime_kwh": self.last_lifetime_kwh,
+            "last_energy_ts": self.last_energy_ts,
+            "last_sample_ts": self.last_sample_ts,
+            "last_power_w": self.last_power_w,
+            "last_window_seconds": self.last_window_seconds,
+            "method": self.method,
+            "last_reset_at": self.last_reset_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "_PowerRestoreData":
+        if not isinstance(data, dict):
+            return cls(None, None, None, None, None, None, None)
+
+        def _as_float(value: object) -> float | None:
+            try:
+                return float(value) if value is not None else None  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return None
+
+        def _as_int(value: object) -> int | None:
+            try:
+                return int(float(value)) if value is not None else None  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return None
+
+        method = data.get("method")
+        return cls(
+            last_lifetime_kwh=_as_float(data.get("last_lifetime_kwh")),
+            last_energy_ts=_as_float(data.get("last_energy_ts")),
+            last_sample_ts=_as_float(data.get("last_sample_ts")),
+            last_power_w=_as_int(data.get("last_power_w")),
+            last_window_seconds=_as_float(data.get("last_window_seconds")),
+            method=str(method) if method not in (None, "") else None,
+            last_reset_at=_as_float(data.get("last_reset_at")),
+        )
+
+
 class EnphaseEnergyTodaySensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):  # type: ignore[misc]
     """Expose the last charging session's energy as a sensor."""
 
@@ -1877,29 +1929,51 @@ class EnphasePowerSensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):  # typ
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
+        last_extra = await self.async_get_last_extra_data()
+        restored = _PowerRestoreData.from_dict(
+            last_extra.as_dict() if last_extra is not None else None
+        )
+        self._last_lifetime_kwh = restored.last_lifetime_kwh
+        self._last_energy_ts = restored.last_energy_ts
+        self._last_sample_ts = restored.last_sample_ts
+        if restored.last_power_w is not None:
+            self._last_power_w = restored.last_power_w
+        self._last_window_s = restored.last_window_seconds
+        if restored.method is not None:
+            self._last_method = restored.method
+        self._last_reset_at = restored.last_reset_at
+
         last_state = await self.async_get_last_state()
         if not last_state:
             return
         attrs = last_state.attributes or {}
-        self._last_lifetime_kwh = _restore_optional_float_attribute(
-            attrs, "last_lifetime_kwh"
-        )
-        self._last_energy_ts = _restore_optional_float_attribute(
-            attrs, "last_energy_ts"
-        )
-        self._last_sample_ts = _restore_optional_float_attribute(
-            attrs, "last_sample_ts"
-        )
+        if self._last_lifetime_kwh is None:
+            self._last_lifetime_kwh = _restore_optional_float_attribute(
+                attrs, "last_lifetime_kwh"
+            )
+        if self._last_energy_ts is None:
+            self._last_energy_ts = _restore_optional_float_attribute(
+                attrs, "last_energy_ts"
+            )
+        if self._last_sample_ts is None:
+            self._last_sample_ts = _restore_optional_float_attribute(
+                attrs, "last_sample_ts"
+            )
         restored_power = _restore_optional_int_value(last_state.state)
         if restored_power is None:
             restored_power = _restore_optional_int_value(attrs.get("last_power_w"))
-        self._last_power_w = restored_power if restored_power is not None else 0
-        self._last_window_s = _restore_optional_float_attribute(
-            attrs, "last_window_seconds"
-        )
-        if attrs.get("method"):
+        if restored_power is not None:
+            self._last_power_w = restored_power
+        if self._last_window_s is None:
+            self._last_window_s = _restore_optional_float_attribute(
+                attrs, "last_window_seconds"
+            )
+        if restored.method is None and attrs.get("method"):
             self._last_method = str(attrs.get("method"))
-        self._last_reset_at = _restore_optional_float_attribute(attrs, "last_reset_at")
+        if self._last_reset_at is None:
+            self._last_reset_at = _restore_optional_float_attribute(
+                attrs, "last_reset_at"
+            )
 
         # Legacy restore support (pre-0.7.9 attributes)
         if self._last_lifetime_kwh is None:
@@ -2203,13 +2277,6 @@ class EnphasePowerSensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):  # typ
     def extra_state_attributes(self) -> Any:
         data = self.data
         actual_charging = self._is_actually_charging(data)
-        operating_v = self._as_float(data.get("operating_v"))
-        if operating_v is None or operating_v <= 0:
-            operating_v = self._as_float(data.get("nominal_v"))
-        if operating_v is None or operating_v <= 0:
-            operating_v = float(
-                getattr(self._coord, "nominal_voltage", DEFAULT_NOMINAL_VOLTAGE)
-            )
         return {
             "sampled_at_utc": (
                 data.get("sampled_at_utc")
@@ -2222,28 +2289,22 @@ class EnphasePowerSensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):  # typ
                     else None
                 )
             ),
-            "last_lifetime_kwh": self._last_lifetime_kwh,
-            "last_energy_ts": self._last_energy_ts,
-            "last_sample_ts": self._last_sample_ts,
-            "last_power_w": self._last_power_w,
             "last_window_seconds": self._last_window_s,
             "method": self._last_method,
-            "charging": actual_charging,
             "actual_charging": actual_charging,
-            "operating_v": operating_v,
-            "max_throughput_w": self._max_throughput_w,
-            "max_throughput_unbounded_w": self._max_throughput_unbounded_w,
-            "max_throughput_source": self._max_throughput_source,
-            "max_throughput_amps": self._max_throughput_amps,
-            "max_throughput_voltage": self._max_throughput_voltage,
-            "max_throughput_topology": getattr(
-                self, "_max_throughput_topology", "unknown"
-            ),
-            "max_throughput_phase_multiplier": getattr(
-                self, "_max_throughput_phase_multiplier", 1.0
-            ),
-            "last_reset_at": self._last_reset_at,
         }
+
+    @property
+    def extra_restore_state_data(self) -> ExtraStoredData | None:
+        return _PowerRestoreData(
+            last_lifetime_kwh=self._last_lifetime_kwh,
+            last_energy_ts=self._last_energy_ts,
+            last_sample_ts=self._last_sample_ts,
+            last_power_w=self._last_power_w,
+            last_window_seconds=self._last_window_s,
+            method=self._last_method,
+            last_reset_at=self._last_reset_at,
+        )
 
 
 class EnphaseChargingLevelSensor(EnphaseBaseEntity, SensorEntity):  # type: ignore[misc]
@@ -2423,112 +2484,11 @@ class EnphaseLastReportedSensor(EnphaseBaseEntity, SensorEntity):  # type: ignor
                 return None
             return text or None
 
-        def _localize(value: object) -> str | None:
-            if value in (None, ""):
-                return None
-            try:
-                if isinstance(value, (int, float)):
-                    dt = datetime.fromtimestamp(float(value), tz=timezone.utc)
-                elif isinstance(value, str):
-                    cleaned = value.strip()
-                    if not cleaned:
-                        return None
-                    if cleaned.endswith("[UTC]"):
-                        cleaned = cleaned[:-5]
-                    if cleaned.endswith("Z"):
-                        cleaned = cleaned[:-1] + "+00:00"
-                    dt = datetime.fromisoformat(cleaned)
-                else:
-                    return None
-                if dt.tzinfo is None:
-                    dt = dt.replace(tzinfo=timezone.utc)
-                return dt_util.as_local(dt).isoformat(timespec="seconds")  # type: ignore[no-any-return]
-            except Exception:  # noqa: BLE001
-                return None
-
-        interval_raw = self.data.get("reporting_interval")
-        attrs = {
-            "reporting_interval": _as_int(interval_raw),
+        return {
+            "reporting_interval": _as_int(self.data.get("reporting_interval")),
             "connection": _clean_text(self.data.get("connection")),
-            "ip_address": _clean_text(self.data.get("ip_address")),
-            "mac_address": _clean_text(self.data.get("mac_address")),
-            "network_interface_count": _as_int(
-                self.data.get("network_interface_count")
-            ),
-            "operating_voltage": _as_int(self.data.get("operating_v")),
-            "charger_timezone": _clean_text(self.data.get("charger_timezone")),
-            "firmware_version": _clean_text(self.data.get("firmware_version")),
-            "system_version": _clean_text(self.data.get("system_version")),
-            "application_version": _clean_text(self.data.get("application_version")),
-            "software_version": _clean_text(self.data.get("sw_version")),
-            "hardware_version": _clean_text(self.data.get("hw_version")),
-            "processor_board_version": _clean_text(
-                self.data.get("processor_board_version")
-            ),
-            "power_board_version": _clean_text(self.data.get("power_board_version")),
-            "kernel_version": _clean_text(self.data.get("kernel_version")),
-            "bootloader_version": _clean_text(self.data.get("bootloader_version")),
-            "default_route": _clean_text(self.data.get("default_route")),
-            "wifi_config": _clean_text(self.data.get("wifi_config")),
-            "cellular_config": _clean_text(self.data.get("cellular_config")),
-            "warranty_start_date": _localize(self.data.get("warranty_start_date")),
-            "warranty_due_date": _localize(self.data.get("warranty_due_date")),
-            "warranty_period_years": _as_int(self.data.get("warranty_period_years")),
-            "created_at": _localize(self.data.get("created_at")),
-            "breaker_rating": _as_int(self.data.get("breaker_rating")),
-            "rated_current": _as_int(self.data.get("rated_current")),
-            "grid_type": _as_int(self.data.get("grid_type")),
-            "phase_count": _as_int(self.data.get("phase_count")),
-            "phase_switch_config": _clean_text(self.data.get("phase_switch_config")),
-            "default_charge_level": _clean_text(self.data.get("default_charge_level")),
-            "commissioning_status": _as_int(self.data.get("commissioning_status")),
             "is_connected": _as_bool(self.data.get("is_connected")),
-            "is_locally_connected": _as_bool(self.data.get("is_locally_connected")),
-            "ho_control": _as_bool(self.data.get("ho_control")),
-            "gateway_connection_count": _as_int(
-                self.data.get("gateway_connection_count")
-            ),
-            "gateway_connected_count": _as_int(
-                self.data.get("gateway_connected_count")
-            ),
-            "gateway_last_connection_at": _localize(
-                self.data.get("gateway_last_connection_at")
-            ),
-            "functional_validation_state": _as_int(
-                self.data.get("functional_validation_state")
-            ),
-            "functional_validation_updated_at": _localize(
-                self.data.get("functional_validation_updated_at")
-            ),
         }
-        gateway_details = self.data.get("gateway_connectivity_details")
-        if isinstance(gateway_details, list):
-            attrs["gateway_connectivity_details"] = [  # type: ignore[assignment]
-                {
-                    **(
-                        {"status": _as_int(detail.get("status"))}
-                        if _as_int(detail.get("status")) is not None
-                        else {}
-                    ),
-                    **(
-                        {"failure_reason": _as_int(detail.get("failure_reason"))}
-                        if _as_int(detail.get("failure_reason")) is not None
-                        else {}
-                    ),
-                    **(
-                        {
-                            "last_connection_at": _localize(
-                                detail.get("last_connection_at")
-                            )
-                        }
-                        if _localize(detail.get("last_connection_at")) is not None
-                        else {}
-                    ),
-                }
-                for detail in gateway_details
-                if isinstance(detail, dict)
-            ]
-        return attrs
 
 
 class EnphaseChargeModeSensor(EnphaseBaseEntity, SensorEntity):  # type: ignore[misc]

--- a/tests/components/enphase_ev/test_power_and_lifetime_edges.py
+++ b/tests/components/enphase_ev/test_power_and_lifetime_edges.py
@@ -100,7 +100,7 @@ def test_power_resolve_max_throughput_uses_nominal_fallback(coordinator_factory)
     assert unbounded == 1920
     assert topology == "unknown"
     assert phase_multiplier == pytest.approx(1.0)
-    assert sensor.extra_state_attributes["operating_v"] == pytest.approx(120.0)
+    assert sensor._max_throughput_voltage == pytest.approx(120.0)
 
     watts, source, amps, voltage, unbounded, topology, phase_multiplier = (
         sensor._resolve_max_throughput({"nominal_v": 230, "session_charge_level": 16})
@@ -188,7 +188,6 @@ def test_power_actual_charging_attribute_prefers_precomputed_flag(coordinator_fa
 
     assert sensor.native_value == 0
     attrs = sensor.extra_state_attributes
-    assert attrs["charging"] is False
     assert attrs["actual_charging"] is False
 
 
@@ -294,9 +293,7 @@ def test_power_snapshot_uses_nominal_voltage_fallback_when_missing(
     sensor = EnphasePowerSensor(coord, RANDOM_SERIAL)
 
     assert sensor.native_value == 0
-    assert sensor.extra_state_attributes["max_throughput_voltage"] == pytest.approx(
-        208.0
-    )
+    assert sensor._max_throughput_voltage == pytest.approx(208.0)
 
 
 def test_power_native_value_suspended_connector_resets_power(coordinator_factory):
@@ -338,7 +335,6 @@ def test_power_native_value_suspended_ev_resets_power(coordinator_factory):
     assert sensor.native_value == 0
     assert sensor._last_method == "idle"
     attrs = sensor.extra_state_attributes
-    assert attrs["charging"] is False
     assert attrs["actual_charging"] is False
 
 

--- a/tests/components/enphase_ev/test_power_restore.py
+++ b/tests/components/enphase_ev/test_power_restore.py
@@ -59,6 +59,11 @@ async def test_power_restore_continues_from_last_sample(monkeypatch):
     monkeypatch.setattr(
         EnphasePowerSensor, "async_get_last_state", _fake_get_last_state
     )
+    monkeypatch.setattr(
+        EnphasePowerSensor,
+        "async_get_last_extra_data",
+        lambda self: _async_none(),
+    )
     monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", _noop)
 
     await ent.async_added_to_hass()
@@ -69,3 +74,110 @@ async def test_power_restore_continues_from_last_sample(monkeypatch):
     coord.data[sn]["lifetime_kwh"] = 10.6
 
     assert ent.native_value == 6000
+
+
+async def _async_none():
+    return None
+
+
+def test_power_restore_data_rejects_invalid_values():
+    """Private restore payload parsing tolerates stale or corrupt data."""
+    from custom_components.enphase_ev.sensor import _PowerRestoreData
+
+    empty = _PowerRestoreData.from_dict(None)
+    assert empty.as_dict() == {
+        "last_lifetime_kwh": None,
+        "last_energy_ts": None,
+        "last_sample_ts": None,
+        "last_power_w": None,
+        "last_window_seconds": None,
+        "method": None,
+        "last_reset_at": None,
+    }
+
+    invalid = _PowerRestoreData.from_dict(
+        {
+            "last_lifetime_kwh": object(),
+            "last_energy_ts": object(),
+            "last_sample_ts": object(),
+            "last_power_w": object(),
+            "last_window_seconds": object(),
+            "method": "",
+            "last_reset_at": object(),
+        }
+    )
+    assert invalid == empty
+
+
+@pytest.mark.asyncio
+async def test_power_restore_uses_private_extra_data(monkeypatch):
+    """Derived power baselines survive restart without public attributes."""
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.sensor import EnphasePowerSensor
+
+    sn = "555555555555"
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.data = {
+        sn: {
+            "sn": sn,
+            "name": "Garage EV",
+            "lifetime_kwh": 10.6,
+            "last_reported_at": "2025-09-09T10:01:00Z",
+            "charging": True,
+        }
+    }
+    coord.serials = {sn}
+    coord.site_id = "1234567"
+    coord.last_update_success = True
+
+    sensor = EnphasePowerSensor(coord, sn)
+
+    class _LastExtra:
+        def as_dict(self):
+            return {
+                "last_lifetime_kwh": 10.5,
+                "last_energy_ts": 1_757_412_000.0,
+                "last_sample_ts": 1_757_412_000.0,
+                "last_power_w": 3600,
+                "last_window_seconds": 300.0,
+                "method": "lifetime_energy_window",
+                "last_reset_at": None,
+            }
+
+    class _LastState:
+        state = "3600"
+        attributes = {}
+
+    async def _last_extra():
+        return _LastExtra()
+
+    async def _last_state():
+        return _LastState()
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(sensor, "async_get_last_extra_data", _last_extra)
+    monkeypatch.setattr(sensor, "async_get_last_state", _last_state)
+    monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", _noop)
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.native_value == 6000
+    assert sensor.extra_state_attributes == {
+        "sampled_at_utc": "2025-09-09T10:01:00+00:00",
+        "last_window_seconds": pytest.approx(60.0),
+        "method": "lifetime_energy_window",
+        "actual_charging": True,
+    }
+    assert sensor.extra_restore_state_data.as_dict() == {
+        "last_lifetime_kwh": 10.6,
+        "last_energy_ts": 1_757_412_060.0,
+        "last_sample_ts": 1_757_412_060.0,
+        "last_power_w": 6000,
+        "last_window_seconds": 60.0,
+        "method": "lifetime_energy_window",
+        "last_reset_at": None,
+    }

--- a/tests/components/enphase_ev/test_power_sensor_dynamic_max.py
+++ b/tests/components/enphase_ev/test_power_sensor_dynamic_max.py
@@ -41,11 +41,10 @@ async def test_power_sensor_clamps_to_session_amps():
 
     assert sensor.native_value == 7680
 
-    attrs = sensor.extra_state_attributes
-    assert attrs["max_throughput_w"] == 7680
-    assert attrs["max_throughput_source"] == "session_charge_level"
-    assert attrs["max_throughput_amps"] == 32
-    assert attrs["max_throughput_voltage"] == 240
+    assert sensor._max_throughput_w == 7680
+    assert sensor._max_throughput_source == "session_charge_level"
+    assert sensor._max_throughput_amps == 32
+    assert sensor._max_throughput_voltage == 240
 
 
 @pytest.mark.asyncio
@@ -63,11 +62,10 @@ async def test_power_sensor_falls_back_to_max_amp():
 
     assert sensor.native_value == 8320
 
-    attrs = sensor.extra_state_attributes
-    assert attrs["max_throughput_w"] == 8320
-    assert attrs["max_throughput_source"] == "max_amp"
-    assert attrs["max_throughput_amps"] == 40
-    assert attrs["max_throughput_voltage"] == 208
+    assert sensor._max_throughput_w == 8320
+    assert sensor._max_throughput_source == "max_amp"
+    assert sensor._max_throughput_amps == 40
+    assert sensor._max_throughput_voltage == 208
 
 
 @pytest.mark.asyncio
@@ -86,14 +84,13 @@ async def test_power_sensor_three_phase_cap_uses_phase_count():
 
     assert sensor.native_value == 6374
 
-    attrs = sensor.extra_state_attributes
-    assert attrs["max_throughput_w"] == 6374
-    assert attrs["max_throughput_unbounded_w"] == 6374
-    assert attrs["max_throughput_source"] == "charging_level"
-    assert attrs["max_throughput_amps"] == 16
-    assert attrs["max_throughput_voltage"] == 230
-    assert attrs["max_throughput_topology"] == "three_phase"
-    assert attrs["max_throughput_phase_multiplier"] == pytest.approx(1.7320508075688772)
+    assert sensor._max_throughput_w == 6374
+    assert sensor._max_throughput_unbounded_w == 6374
+    assert sensor._max_throughput_source == "charging_level"
+    assert sensor._max_throughput_amps == 16
+    assert sensor._max_throughput_voltage == 230
+    assert sensor._max_throughput_topology == "three_phase"
+    assert sensor._max_throughput_phase_multiplier == pytest.approx(1.7320508075688772)
 
 
 @pytest.mark.asyncio
@@ -113,11 +110,10 @@ async def test_power_sensor_three_phase_neutral_wiring_uses_phase_voltage():
 
     assert sensor.native_value == 11040
 
-    attrs = sensor.extra_state_attributes
-    assert attrs["max_throughput_w"] == 11040
-    assert attrs["max_throughput_unbounded_w"] == 11040
-    assert attrs["max_throughput_topology"] == "three_phase"
-    assert attrs["max_throughput_phase_multiplier"] == 3.0
+    assert sensor._max_throughput_w == 11040
+    assert sensor._max_throughput_unbounded_w == 11040
+    assert sensor._max_throughput_topology == "three_phase"
+    assert sensor._max_throughput_phase_multiplier == 3.0
 
 
 @pytest.mark.asyncio
@@ -137,8 +133,7 @@ async def test_power_sensor_split_phase_does_not_apply_phase_multiplier():
 
     assert sensor.native_value == 7680
 
-    attrs = sensor.extra_state_attributes
-    assert attrs["max_throughput_w"] == 7680
-    assert attrs["max_throughput_source"] == "charging_level"
-    assert attrs["max_throughput_topology"] == "split_phase"
-    assert attrs["max_throughput_phase_multiplier"] == 1.0
+    assert sensor._max_throughput_w == 7680
+    assert sensor._max_throughput_source == "charging_level"
+    assert sensor._max_throughput_topology == "split_phase"
+    assert sensor._max_throughput_phase_multiplier == 1.0

--- a/tests/components/enphase_ev/test_sensor_coverage_last_session.py
+++ b/tests/components/enphase_ev/test_sensor_coverage_last_session.py
@@ -280,7 +280,11 @@ async def test_power_sensor_restore_parses_legacy_and_resets(monkeypatch):
     async def _fake_last_state():
         return _State()
 
+    async def _fake_last_extra_data():
+        return None
+
     monkeypatch.setattr(sensor, "async_get_last_state", _fake_last_state)
+    monkeypatch.setattr(sensor, "async_get_last_extra_data", _fake_last_extra_data)
     await sensor.async_added_to_hass()
 
     coord.data[RANDOM_SERIAL]["charging"] = False

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -252,7 +252,7 @@ def test_electrical_phase_sensor_formats_state_and_attributes():
     assert attrs["dlb_active"] is None
 
 
-def test_last_reported_sensor_exposes_charger_config_attributes():
+def test_last_reported_sensor_exposes_only_compact_status_attributes():
     from custom_components.enphase_ev.sensor import EnphaseLastReportedSensor
 
     sn = RANDOM_SERIAL
@@ -262,6 +262,9 @@ def test_last_reported_sensor_exposes_charger_config_attributes():
             "sn": sn,
             "name": "Garage EV",
             "last_reported_at": "2025-09-09T09:00:00Z[UTC]",
+            "reporting_interval": "300",
+            "connection": "wifi",
+            "is_connected": True,
             "default_charge_level": "disabled",
             "phase_switch_config": "auto",
         },
@@ -270,8 +273,11 @@ def test_last_reported_sensor_exposes_charger_config_attributes():
     sensor = EnphaseLastReportedSensor(coord, sn)
     attrs = sensor.extra_state_attributes
 
-    assert attrs["default_charge_level"] == "disabled"
-    assert attrs["phase_switch_config"] == "auto"
+    assert attrs == {
+        "reporting_interval": 300,
+        "connection": "wifi",
+        "is_connected": True,
+    }
 
 
 def test_power_sensor_uses_lifetime_delta():
@@ -296,7 +302,12 @@ def test_power_sensor_uses_lifetime_delta():
     coord.data[sn]["last_reported_at"] = "2025-09-09T10:05:00Z[UTC]"
     val = sensor.native_value
     assert val == 7200
-    assert sensor.extra_state_attributes["last_window_seconds"] == pytest.approx(300)
+    assert sensor.extra_state_attributes == {
+        "sampled_at_utc": "2025-09-09T10:05:00+00:00",
+        "last_window_seconds": pytest.approx(300),
+        "method": "lifetime_energy_window",
+        "actual_charging": True,
+    }
 
     coord.data[sn]["lifetime_kwh"] = 10.6
     coord.data[sn]["last_reported_at"] = "2025-09-09T10:06:00Z[UTC]"
@@ -2283,9 +2294,8 @@ def test_last_session_restore_data_roundtrip():
     assert empty.session_key is None
 
 
-def test_last_reported_sensor_exposes_reporting_interval(monkeypatch):
+def test_last_reported_sensor_exposes_compact_connectivity_context():
     from custom_components.enphase_ev.sensor import EnphaseLastReportedSensor
-    from homeassistant.util import dt as dt_util
 
     sn = RANDOM_SERIAL
     coord = _mk_coord_with(
@@ -2345,36 +2355,17 @@ def test_last_reported_sensor_exposes_reporting_interval(monkeypatch):
             "charger_timezone": "Region/City",
         },
     )
-    monkeypatch.setattr(dt_util, "as_local", lambda dt: dt)
-
     sensor = EnphaseLastReportedSensor(coord, sn)
     assert sensor.entity_registry_enabled_default is True
     assert sensor.native_value is not None
     assert sensor.available is True
 
     attrs = sensor.extra_state_attributes
-    assert attrs["reporting_interval"] == 300
-    assert attrs["connection"] == "wifi"
-    assert attrs["ip_address"] == "192.0.2.10"
-    assert attrs["mac_address"] == "00:11:22:33:44:55"
-    assert attrs["network_interface_count"] == 2
-    assert attrs["operating_voltage"] == 240
-    assert attrs["is_connected"] is True
-    assert attrs["is_locally_connected"] is False
-    assert attrs["gateway_last_connection_at"] is not None
-    assert attrs["gateway_connectivity_details"] == [
-        {
-            "status": 0,
-            "failure_reason": 0,
-            "last_connection_at": "2024-05-01T07:53:20+00:00",
-        },
-        {
-            "status": 1,
-            "failure_reason": 7,
-            "last_connection_at": "2024-05-01T08:03:20+00:00",
-        },
-    ]
-    assert attrs["functional_validation_updated_at"] is not None
+    assert attrs == {
+        "reporting_interval": 300,
+        "connection": "wifi",
+        "is_connected": True,
+    }
 
     coord.data[sn]["reporting_interval"] = 150
     assert sensor.extra_state_attributes["reporting_interval"] == 150
@@ -2405,9 +2396,8 @@ def test_last_reported_sensor_handles_missing_and_invalid_values():
     assert sensor.available is False
 
 
-def test_last_reported_sensor_attribute_edge_cases(monkeypatch):
+def test_last_reported_sensor_attribute_edge_cases():
     from custom_components.enphase_ev.sensor import EnphaseLastReportedSensor
-    from homeassistant.util import dt as dt_util
 
     class BadStr:
         def __str__(self):
@@ -2421,6 +2411,7 @@ def test_last_reported_sensor_attribute_edge_cases(monkeypatch):
             "name": "Garage EV",
             "last_reported_at": "2025-09-07T11:38:31Z[UTC]",
             "reporting_interval": None,
+            "connection": BadStr(),
             "is_connected": "off",
             "is_locally_connected": None,
             "created_at": None,
@@ -2430,23 +2421,27 @@ def test_last_reported_sensor_attribute_edge_cases(monkeypatch):
             "wifi_config": BadStr(),
         },
     )
-    monkeypatch.setattr(dt_util, "as_local", lambda dt: dt)
-
     sensor = EnphaseLastReportedSensor(coord, sn)
     attrs = sensor.extra_state_attributes
-    assert attrs["reporting_interval"] is None
-    assert attrs["is_connected"] is False
-    assert attrs["is_locally_connected"] is None
-    assert attrs["created_at"] is None
-    assert attrs["warranty_start_date"] is None
-    assert attrs["warranty_due_date"] == "2025-01-01T00:00:00+00:00"
-    assert attrs["functional_validation_updated_at"] is None
-    assert attrs["wifi_config"] is None
+    assert attrs == {
+        "reporting_interval": None,
+        "connection": None,
+        "is_connected": False,
+    }
 
-    coord.data[sn]["created_at"] = "invalid"
-    assert sensor.extra_state_attributes["created_at"] is None
     coord.data[sn]["is_connected"] = "maybe"
     assert sensor.extra_state_attributes["is_connected"] is None
+
+    coord.data[sn]["connection"] = None
+    coord.data[sn]["is_connected"] = None
+    assert sensor.extra_state_attributes == {
+        "reporting_interval": None,
+        "connection": None,
+        "is_connected": None,
+    }
+
+    coord.data[sn]["is_connected"] = 1
+    assert sensor.extra_state_attributes["is_connected"] is True
 
 
 def test_power_sensor_caps_max_output():


### PR DESCRIPTION
## Summary

Move high-churn and large session details out of recorder-visible state attributes while preserving the existing sensor states and user-facing behavior.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/sensor.py tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Result: 3,567 tests passed; strict typing succeeds across all 68 integration source files, and `sensor.py` has 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This reduces recorder churn; no entity states or supported features are removed.
