### PR TITLE
Track current Home Assistant quality scale rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,8 @@ All notable changes to this project will be documented in this file.
   integration objects.
 
 ### 🔧 Improvements
-- None
+- Documented the IQ EV Charger device automation triggers and the integration's
+  use of standard Home Assistant conditions.
 
 ### 🔄 Other changes
 - None

--- a/README.md
+++ b/README.md
@@ -114,4 +114,7 @@ Sign in with your Enlighten credentials; MFA is supported. See the wiki for deta
 
 ## Documentation
 
+See [device automation triggers and conditions](docs/device_automations.md) for the
+automation features provided directly by the integration.
+
 Refer to the [Wiki](https://github.com/barneyonline/ha-enphase-energy/wiki), including [Envoy History Migration](https://github.com/barneyonline/ha-enphase-energy/wiki/Envoy-History-Migration) for preserving Energy dashboard history when migrating from Enphase Envoy.

--- a/docs/device_automations.md
+++ b/docs/device_automations.md
@@ -1,0 +1,112 @@
+# Device automations
+
+The Enphase Energy integration provides device triggers for IQ EV Chargers.
+They are available in Home Assistant's automation editor when the charger has
+the matching charging or plugged-in binary sensor.
+
+## Triggers
+
+| Trigger | Fires when |
+| --- | --- |
+| `charging_started` | The charger charging sensor changes from off to on. |
+| `charging_stopped` | The charger charging sensor changes from on to off. |
+| `plugged_in` | The charger plugged-in sensor changes to on. |
+| `unplugged` | The charger plugged-in sensor changes to off. |
+
+The charging triggers require an actual transition between `off` and `on`:
+`charging_started` does not fire when an unavailable sensor first becomes
+available as `on`, and `charging_stopped` does not fire when an unavailable
+sensor first becomes available as `off`. The plug triggers fire whenever their
+sensor changes to the named state.
+
+### Use a trigger in the automation editor
+
+To use one of these triggers:
+
+1. In Home Assistant, go to **Settings** > **Automations & scenes**.
+2. Create or edit an automation and add a trigger.
+3. Select **Device**, select the IQ EV Charger, and choose the required charging
+   or cable trigger.
+
+Home Assistant stores the selected device and entity identifiers in the
+automation. If a charger is removed and added again as a different device,
+review automations that refer to the old device.
+
+### Use the triggers in YAML
+
+The automation editor generates the installation-specific `device_id` and
+`entity_id`. The four trigger configurations have the same fields:
+
+| Field | Description |
+| --- | --- |
+| `platform` | Required. Must be `device`. |
+| `domain` | Required. Must be `enphase_ev`. |
+| `device_id` | Required. The IQ EV Charger device-registry identifier. |
+| `entity_id` | Required. The matching charging or plugged-in binary sensor. |
+| `type` | Required. One of the four trigger types documented below. |
+
+Prefer creating the trigger in the automation editor and then switching to
+YAML so Home Assistant fills in the correct identifiers.
+
+#### Charging started
+
+`charging_started` fires when the charger's charging binary sensor changes
+from `off` to `on`.
+
+```yaml
+triggers:
+  - platform: device
+    domain: enphase_ev
+    device_id: YOUR_CHARGER_DEVICE_ID
+    entity_id: binary_sensor.iq_ev_charger_charging
+    type: charging_started
+```
+
+#### Charging stopped
+
+`charging_stopped` fires when the charger's charging binary sensor changes
+from `on` to `off`.
+
+```yaml
+triggers:
+  - platform: device
+    domain: enphase_ev
+    device_id: YOUR_CHARGER_DEVICE_ID
+    entity_id: binary_sensor.iq_ev_charger_charging
+    type: charging_stopped
+```
+
+#### Plugged in
+
+`plugged_in` fires when the charger's plugged-in binary sensor changes to
+`on`.
+
+```yaml
+triggers:
+  - platform: device
+    domain: enphase_ev
+    device_id: YOUR_CHARGER_DEVICE_ID
+    entity_id: binary_sensor.iq_ev_charger_plugged_in
+    type: plugged_in
+```
+
+#### Unplugged
+
+`unplugged` fires when the charger's plugged-in binary sensor changes to
+`off`.
+
+```yaml
+triggers:
+  - platform: device
+    domain: enphase_ev
+    device_id: YOUR_CHARGER_DEVICE_ID
+    entity_id: binary_sensor.iq_ev_charger_plugged_in
+    type: unplugged
+```
+
+## Conditions
+
+The integration does not provide custom automation conditions. Use Home
+Assistant's standard device or entity state conditions with the charger
+entities, such as requiring the plugged-in binary sensor to be on before a
+charging action runs.

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -1,3 +1,7 @@
+official_rule_catalog:
+  source: https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/
+  reviewed_on: 2026-07-10
+
 levels:
   bronze:
     required:
@@ -9,6 +13,8 @@ levels:
       - config-flow
       - dependency-transparency
       - docs-actions
+      - docs-triggers
+      - docs-conditions
       - docs-high-level-description
       - docs-installation-instructions
       - docs-removal-instructions
@@ -142,6 +148,21 @@ rules:
         - tests/components/enphase_ev/test_service_translations.py
       docs:
         - README.md
+  docs-triggers:
+    status: done
+    references:
+      code:
+        - custom_components/enphase_ev/device_trigger.py
+      tests:
+        - tests/components/enphase_ev/test_device_trigger.py
+      docs:
+        - docs/device_automations.md
+  docs-conditions:
+    status: n/a
+    comment: The integration does not provide custom automation conditions; users can apply Home Assistant's standard device and entity state conditions to its entities.
+    references:
+      docs:
+        - docs/device_automations.md
   docs-high-level-description:
     status: done
     references:

--- a/scripts/validate_quality_scale.py
+++ b/scripts/validate_quality_scale.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import ast
 import argparse
+from datetime import date
 import json
 from http import HTTPStatus
 import sys
@@ -19,6 +20,16 @@ except Exception:  # pragma: no cover - exercised only when dev deps are missing
     raise
 
 QUALITY_LEVEL_ORDER = ("bronze", "silver", "gold", "platinum")
+OFFICIAL_RULE_CATALOG_SOURCE = (
+    "https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/"
+)
+REQUIRED_DEVICE_TRIGGER_DOC_SNIPPETS = (
+    "platform: device",
+    "domain: enphase_ev",
+    "device_id:",
+    "entity_id:",
+    "type:",
+)
 OFFICIAL_REQUIRED_RULES: dict[str, tuple[str, ...]] = {
     "bronze": (
         "action-setup",
@@ -29,6 +40,8 @@ OFFICIAL_REQUIRED_RULES: dict[str, tuple[str, ...]] = {
         "config-flow",
         "dependency-transparency",
         "docs-actions",
+        "docs-triggers",
+        "docs-conditions",
         "docs-high-level-description",
         "docs-installation-instructions",
         "docs-removal-instructions",
@@ -81,7 +94,7 @@ OFFICIAL_REQUIRED_RULES: dict[str, tuple[str, ...]] = {
         "strict-typing",
     ),
 }
-NA_ALLOWED_RULES = {"discovery", "discovery-update-info"}
+NA_ALLOWED_RULES = {"discovery", "discovery-update-info", "docs-conditions"}
 STRICT_CONFIG_ENTRY_ALIASES = (
     "EnphaseConfigEntry: TypeAlias = ConfigEntry[EnphaseRuntimeData]",
     "type EnphaseConfigEntry = ConfigEntry[EnphaseRuntimeData]",
@@ -98,6 +111,32 @@ OPTIONAL_BRAND_ASSETS = ("logo.png",)
 
 def _load_yaml(path: Path) -> dict:
     return yaml.safe_load(path.read_text()) or {}
+
+
+def _validate_rule_catalog_metadata(data: dict) -> list[str]:
+    """Record a review against the canonical Home Assistant rule list."""
+
+    metadata = data.get("official_rule_catalog")
+    if not isinstance(metadata, dict):
+        return ["official_rule_catalog metadata is missing"]
+
+    messages: list[str] = []
+    source = str(metadata.get("source") or "").strip()
+    if source != OFFICIAL_RULE_CATALOG_SOURCE:
+        messages.append(
+            "official_rule_catalog.source must reference the canonical Home "
+            "Assistant rule list"
+        )
+
+    raw_reviewed = metadata.get("reviewed_on")
+    if not isinstance(raw_reviewed, date):
+        try:
+            date.fromisoformat(str(raw_reviewed or ""))
+        except ValueError:
+            messages.append("official_rule_catalog.reviewed_on must be an ISO date")
+            return messages
+
+    return messages
 
 
 def _status_for_rule(entry: object) -> str:
@@ -145,6 +184,65 @@ def _reference_path_exists(root: Path, reference: str) -> bool:
     if not path_text:
         return False
     return (root / path_text).exists()
+
+
+def _device_trigger_types(root: Path) -> set[str]:
+    """Return trigger type keys declared by the integration's TRIGGER_MAP."""
+
+    path = root / "custom_components" / "enphase_ev" / "device_trigger.py"
+    if not path.exists():
+        return set()
+    try:
+        tree = ast.parse(path.read_text(), filename=str(path))
+    except SyntaxError:
+        return set()
+    for node in tree.body:
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        if not any(
+            isinstance(target, ast.Name) and target.id == "TRIGGER_MAP"
+            for target in targets
+        ):
+            continue
+        value = node.value
+        if not isinstance(value, ast.Dict):
+            return set()
+        return {
+            key.value
+            for key in value.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+    return set()
+
+
+def _validate_trigger_documentation(root: Path, doc_references: list[str]) -> list[str]:
+    """Ensure every implemented device trigger is named in referenced docs."""
+
+    trigger_types = _device_trigger_types(root)
+    if not trigger_types:
+        return ["docs-triggers could not find any declared device trigger types"]
+    docs_text: list[str] = []
+    for reference in doc_references:
+        path = root / reference.split("#", 1)[0].strip()
+        if path.is_file():
+            docs_text.append(path.read_text())
+    combined = "\n".join(docs_text).casefold()
+    missing = sorted(trigger for trigger in trigger_types if trigger not in combined)
+    if missing:
+        return [
+            "docs-triggers references do not document trigger type " + trigger
+            for trigger in missing
+        ]
+    missing_yaml = [
+        snippet
+        for snippet in REQUIRED_DEVICE_TRIGGER_DOC_SNIPPETS
+        if snippet not in combined
+    ]
+    return [
+        "docs-triggers references do not document YAML field " + snippet
+        for snippet in missing_yaml
+    ]
 
 
 def _manifest_domain(root: Path) -> str:
@@ -354,6 +452,7 @@ def validate_quality_scale(
     rules = data.get("rules") or {}
 
     messages: list[str] = []
+    rule_catalog_errors = _validate_rule_catalog_metadata(data)
     missing: list[str] = []
     missing_official_rules: list[tuple[str, str]] = []
     not_accepted: list[tuple[str, str]] = []
@@ -361,6 +460,8 @@ def validate_quality_scale(
     missing_references: list[str] = []
     missing_comments: list[str] = []
     bad_references: list[tuple[str, str]] = []
+    missing_doc_references: list[str] = []
+    incomplete_rule_docs: list[str] = []
 
     for level in _required_levels_for_claim(claimed_level):
         required = (levels.get(level) or {}).get("required") or []
@@ -394,10 +495,16 @@ def validate_quality_scale(
             if not any(references.values()):
                 missing_references.append(rule)
                 continue
+            if str(rule).startswith("docs-") and not references.get("docs"):
+                missing_doc_references.append(str(rule))
             for refs in references.values():
                 for reference in refs:
                     if not _reference_path_exists(root, reference):
                         bad_references.append((rule, reference))
+            if rule == "docs-triggers" and references.get("docs"):
+                incomplete_rule_docs.extend(
+                    _validate_trigger_documentation(root, references["docs"])
+                )
 
     if (
         missing
@@ -407,6 +514,9 @@ def validate_quality_scale(
         or missing_references
         or missing_comments
         or bad_references
+        or missing_doc_references
+        or incomplete_rule_docs
+        or rule_catalog_errors
     ):
         messages.append(
             f"Integration Quality Scale check failed for manifest level "
@@ -437,6 +547,15 @@ def validate_quality_scale(
             messages.extend(
                 f"  - {rule}: {reference}" for rule, reference in bad_references
             )
+        if missing_doc_references:
+            messages.append("- Documentation rules missing docs references:")
+            messages.extend(f"  - {rule}" for rule in missing_doc_references)
+        if incomplete_rule_docs:
+            messages.append("- Incomplete rule documentation:")
+            messages.extend(f"  - {detail}" for detail in incomplete_rule_docs)
+        if rule_catalog_errors:
+            messages.append("- Official rule catalog metadata errors:")
+            messages.extend(f"  - {detail}" for detail in rule_catalog_errors)
         return 1, messages
 
     brand_errors = _validate_brands_support(root, remote=validate_remote_brands)

--- a/tests/scripts/test_validate_quality_scale.py
+++ b/tests/scripts/test_validate_quality_scale.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+from datetime import date
 import json
 from pathlib import Path
 import sys
@@ -68,6 +69,174 @@ def test_repository_quality_scale_matches_manifest_claim() -> None:
     exit_code, messages = validate_quality_scale.validate_quality_scale(root)
 
     assert exit_code == 0, "\n".join(messages)
+
+
+def test_official_bronze_catalog_tracks_automation_documentation_rules() -> None:
+    bronze_rules = set(validate_quality_scale.OFFICIAL_REQUIRED_RULES["bronze"])
+
+    assert {"docs-triggers", "docs-conditions"} <= bronze_rules
+    assert "docs-conditions" in validate_quality_scale.NA_ALLOWED_RULES
+
+
+def test_rule_catalog_metadata_records_canonical_review() -> None:
+    valid = {
+        "official_rule_catalog": {
+            "source": validate_quality_scale.OFFICIAL_RULE_CATALOG_SOURCE,
+            "reviewed_on": date(2026, 7, 10),
+        }
+    }
+
+    assert validate_quality_scale._validate_rule_catalog_metadata(valid) == []
+    assert validate_quality_scale._validate_rule_catalog_metadata({}) == [
+        "official_rule_catalog metadata is missing"
+    ]
+
+    wrong_source = {
+        "official_rule_catalog": {
+            "source": "https://example.test/rules",
+            "reviewed_on": "not-a-date",
+        }
+    }
+    assert validate_quality_scale._validate_rule_catalog_metadata(wrong_source) == [
+        "official_rule_catalog.source must reference the canonical Home Assistant rule list",
+        "official_rule_catalog.reviewed_on must be an ISO date",
+    ]
+
+
+def test_trigger_documentation_must_name_every_implemented_trigger(
+    tmp_path: Path,
+) -> None:
+    integration_dir = tmp_path / "custom_components" / "enphase_ev"
+    integration_dir.mkdir(parents=True)
+    (integration_dir / "device_trigger.py").write_text(
+        "TRIGGER_MAP = {'charging_started': {}, 'charging_stopped': {}}\n"
+    )
+    _write_reference(tmp_path, "docs/device_automations.md")
+    (tmp_path / "docs" / "device_automations.md").write_text(
+        "The `charging_started` trigger starts an automation.\n"
+    )
+
+    messages = validate_quality_scale._validate_trigger_documentation(
+        tmp_path, ["docs/device_automations.md"]
+    )
+
+    assert messages == [
+        "docs-triggers references do not document trigger type charging_stopped"
+    ]
+
+
+def test_trigger_documentation_handles_missing_and_invalid_declarations(
+    tmp_path: Path,
+) -> None:
+    integration_dir = tmp_path / "custom_components" / "enphase_ev"
+    trigger_path = integration_dir / "device_trigger.py"
+
+    assert validate_quality_scale._device_trigger_types(tmp_path) == set()
+    assert validate_quality_scale._validate_trigger_documentation(tmp_path, []) == [
+        "docs-triggers could not find any declared device trigger types"
+    ]
+
+    integration_dir.mkdir(parents=True)
+    trigger_path.write_text("def broken(:\n")
+    assert validate_quality_scale._device_trigger_types(tmp_path) == set()
+
+    trigger_path.write_text("OTHER = {}\n")
+    assert validate_quality_scale._device_trigger_types(tmp_path) == set()
+
+    trigger_path.write_text("OTHER = {}\nTRIGGER_MAP = make_map()\n")
+    assert validate_quality_scale._device_trigger_types(tmp_path) == set()
+
+    trigger_path.write_text("TRIGGER_MAP: dict = {'valid': {}, 1: {}}\n")
+    assert validate_quality_scale._device_trigger_types(tmp_path) == {"valid"}
+
+
+def test_trigger_documentation_requires_yaml_fields(tmp_path: Path) -> None:
+    integration_dir = tmp_path / "custom_components" / "enphase_ev"
+    integration_dir.mkdir(parents=True)
+    (integration_dir / "device_trigger.py").write_text(
+        "TRIGGER_MAP = {'charging_started': {}}\n"
+    )
+    _write_reference(tmp_path, "docs/device_automations.md")
+    (tmp_path / "docs" / "device_automations.md").write_text(
+        "The charging_started trigger uses type: charging_started.\n"
+    )
+
+    messages = validate_quality_scale._validate_trigger_documentation(
+        tmp_path, ["docs/device_automations.md"]
+    )
+
+    assert messages == [
+        "docs-triggers references do not document YAML field platform: device",
+        "docs-triggers references do not document YAML field domain: enphase_ev",
+        "docs-triggers references do not document YAML field device_id:",
+        "docs-triggers references do not document YAML field entity_id:",
+    ]
+
+
+def test_documentation_rules_require_docs_references(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _write_manifest(tmp_path, "bronze")
+    _write_reference(tmp_path, "custom_components/enphase_ev/device_trigger.py")
+    _write_quality_scale(
+        tmp_path,
+        """
+levels:
+  bronze:
+    required: [docs-triggers]
+rules:
+  docs-triggers:
+    status: done
+    references:
+      code: [custom_components/enphase_ev/device_trigger.py]
+""",
+    )
+    monkeypatch.setitem(
+        validate_quality_scale.OFFICIAL_REQUIRED_RULES,
+        "bronze",
+        ("docs-triggers",),
+    )
+
+    exit_code, messages = validate_quality_scale.validate_quality_scale(tmp_path)
+
+    assert exit_code == 1
+    assert "Documentation rules missing docs references" in "\n".join(messages)
+
+
+def test_validator_reports_incomplete_trigger_documentation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _write_manifest(tmp_path, "bronze")
+    _write_reference(tmp_path, "docs/device_automations.md")
+    integration_dir = tmp_path / "custom_components" / "enphase_ev"
+    (integration_dir / "device_trigger.py").write_text(
+        "TRIGGER_MAP = {'charging_started': {}}\n"
+    )
+    _write_quality_scale(
+        tmp_path,
+        """
+levels:
+  bronze:
+    required: [docs-triggers]
+rules:
+  docs-triggers:
+    status: done
+    references:
+      docs: [docs/device_automations.md]
+""",
+    )
+    monkeypatch.setitem(
+        validate_quality_scale.OFFICIAL_REQUIRED_RULES,
+        "bronze",
+        ("docs-triggers",),
+    )
+
+    exit_code, messages = validate_quality_scale.validate_quality_scale(tmp_path)
+
+    joined = "\n".join(messages)
+    assert exit_code == 1
+    assert "Incomplete rule documentation" in joined
+    assert "charging_started" in joined
 
 
 def test_gold_claim_requires_bronze_silver_and_gold_rules(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Update the repository's quality-scale rules and validator for the current Home Assistant Integration Quality Scale, including remote-brand validation and documentation alignment.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black scripts/validate_quality_scale.py tests/scripts/test_validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/scripts/test_validate_quality_scale.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=scripts/validate_quality_scale.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Result: 3,555 tests passed; the validator has 100% coverage and reports Platinum for local and remote-brand checks.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Both quality validator modes pass at Platinum against the current rule set.
