### PR TITLE
Translate charger and inverter entity names

### DIFF
--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -1020,12 +1020,9 @@ async def async_setup_entry(
 
 
 class _BaseEVSensor(EnphaseBaseEntity, SensorEntity):  # type: ignore[misc]
-    def __init__(
-        self, coord: EnphaseCoordinator, sn: str, name_suffix: str, key: str
-    ) -> None:
+    def __init__(self, coord: EnphaseCoordinator, sn: str, key: str) -> None:
         super().__init__(coord, sn)
         self._key = key
-        self._attr_name = name_suffix
         self._attr_unique_id = f"{DOMAIN}_{sn}_{key}"
 
     @property
@@ -1857,7 +1854,7 @@ class EnphaseConnectorStatusSensor(_BaseEVSensor):
     _attr_translation_key = "connector_status"
 
     def __init__(self, coord: EnphaseCoordinator, sn: str) -> None:
-        super().__init__(coord, sn, "Connector Status", "connector_status")
+        super().__init__(coord, sn, "connector_status")
 
     @property
     def icon(self) -> str | None:
@@ -3067,12 +3064,13 @@ class EnphaseInverterLifetimeEnergySensor(CoordinatorEntity, RestoreSensor):  # 
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_suggested_display_precision = 2
+    _attr_translation_key = "inverter_lifetime_energy"
 
     def __init__(self, coord: EnphaseCoordinator, serial: str) -> None:
         super().__init__(coord)
         self._coord = coord
         self._sn = str(serial)
-        self._attr_name = f"{self._sn} Lifetime Energy"
+        self._attr_translation_placeholders = {"serial": self._sn}
         self._attr_unique_id = f"{DOMAIN}_inverter_{self._sn}_lifetime_energy"
         self._last_good_native_value: float | None = None
 

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -1046,6 +1046,9 @@
       "schedule_end": {
         "name": "Schedule End"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Lifetime Energy"
+      },
       "lifetime_energy": {
         "name": "Lifetime Energy",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Край на графика"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Обща енергия"
+      },
       "lifetime_energy": {
         "name": "Обща енергия",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Konec rozvrhu"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Celková energie"
+      },
       "lifetime_energy": {
         "name": "Celková energie",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Tidsplan slut"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Livstidsenergi"
+      },
       "lifetime_energy": {
         "name": "Livstidsenergi",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Zeitplan-Ende"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Gesamtenergie"
+      },
       "lifetime_energy": {
         "name": "Gesamtenergie",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Λήξη προγράμματος"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Συνολική ενέργεια"
+      },
       "lifetime_energy": {
         "name": "Συνολική ενέργεια",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -1046,6 +1046,9 @@
       "schedule_end": {
         "name": "Schedule End"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Lifetime Energy"
+      },
       "lifetime_energy": {
         "name": "Lifetime Energy",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -1046,6 +1046,9 @@
       "schedule_end": {
         "name": "Schedule End"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Lifetime Energy"
+      },
       "lifetime_energy": {
         "name": "Lifetime Energy",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -1046,6 +1046,9 @@
       "schedule_end": {
         "name": "Schedule End"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Lifetime Energy"
+      },
       "lifetime_energy": {
         "name": "Lifetime Energy",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -1046,6 +1046,9 @@
       "schedule_end": {
         "name": "Schedule End"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Lifetime Energy"
+      },
       "lifetime_energy": {
         "name": "Lifetime Energy",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -1046,6 +1046,9 @@
       "schedule_end": {
         "name": "Schedule End"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Lifetime Energy"
+      },
       "lifetime_energy": {
         "name": "Lifetime Energy",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -1046,6 +1046,9 @@
       "schedule_end": {
         "name": "Schedule End"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Lifetime Energy"
+      },
       "lifetime_energy": {
         "name": "Lifetime Energy",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Fin de programación"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Energía acumulada"
+      },
       "lifetime_energy": {
         "name": "Energía acumulada",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Ajakava lõpp"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Kogukulunud energia"
+      },
       "lifetime_energy": {
         "name": "Kogukulunud energia",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Aikataulu päättyy"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Elinikäinen energia"
+      },
       "lifetime_energy": {
         "name": "Elinikäinen energia",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Fin planifiée"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Énergie totale"
+      },
       "lifetime_energy": {
         "name": "Énergie totale",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Ütemezés vége"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Élettartam energia"
+      },
       "lifetime_energy": {
         "name": "Élettartam energia",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Fine programma"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Energia totale"
+      },
       "lifetime_energy": {
         "name": "Energia totale",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Tvarkaraščio pabaiga"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Viso energijos"
+      },
       "lifetime_energy": {
         "name": "Viso energijos",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Grafika beigas"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Mūža enerģija"
+      },
       "lifetime_energy": {
         "name": "Mūža enerģija",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Tidsplan slutt"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Levetidsenergi"
+      },
       "lifetime_energy": {
         "name": "Levetidsenergi",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Einde schema"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Levensduurenergie"
+      },
       "lifetime_energy": {
         "name": "Levensduurenergie",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Koniec harmonogramu"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Energia całkowita"
+      },
       "lifetime_energy": {
         "name": "Energia całkowita",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Fim da programação"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Energia acumulada"
+      },
       "lifetime_energy": {
         "name": "Energia acumulada",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Sfârșit program"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Energie totală"
+      },
       "lifetime_energy": {
         "name": "Energie totală",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -930,6 +930,9 @@
       "schedule_end": {
         "name": "Schema slut"
       },
+      "inverter_lifetime_energy": {
+        "name": "{serial} Livstidsenergi"
+      },
       "lifetime_energy": {
         "name": "Livstidsenergi",
         "state_attributes": {

--- a/tests/components/enphase_ev/test_entity_wiring.py
+++ b/tests/components/enphase_ev/test_entity_wiring.py
@@ -49,6 +49,55 @@ def test_entity_naming_and_availability():
     assert ent.unique_id.endswith(f"{RANDOM_SERIAL}_energy_today")
 
 
+def test_connector_status_uses_translated_entity_name():
+    """Connector status should not override its translated entity name."""
+    from custom_components.enphase_ev.sensor import EnphaseConnectorStatusSensor
+
+    coord = _with_inventory_view(
+        SimpleNamespace(
+            data={RANDOM_SERIAL: {"connector_status": "AVAILABLE"}},
+            serials={RANDOM_SERIAL},
+            site_id=RANDOM_SITE_ID,
+            last_update_success=True,
+        )
+    )
+
+    entity = EnphaseConnectorStatusSensor(coord, RANDOM_SERIAL)
+    translation_key = "component.enphase_ev.entity.sensor.connector_status.name"
+    entity.platform_data = SimpleNamespace(
+        platform_name="enphase_ev",
+        domain="sensor",
+        platform_translations={translation_key: "Translated connector status"},
+        component_translations={},
+    )
+
+    assert "_attr_name" not in entity.__dict__
+    assert entity.translation_key == "connector_status"
+    assert entity.name == "Translated connector status"
+
+
+def test_inverter_lifetime_energy_uses_translated_name_with_serial(
+    coordinator_factory,
+):
+    """Per-inverter names should use a translated serial placeholder."""
+    from custom_components.enphase_ev.sensor import EnphaseInverterLifetimeEnergySensor
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    entity = EnphaseInverterLifetimeEnergySensor(coord, "INV-A")
+    translation_key = "component.enphase_ev.entity.sensor.inverter_lifetime_energy.name"
+    entity.platform_data = SimpleNamespace(
+        platform_name="enphase_ev",
+        domain="sensor",
+        platform_translations={translation_key: "{serial} Translated lifetime energy"},
+        component_translations={},
+    )
+
+    assert "_attr_name" not in entity.__dict__
+    assert entity.translation_key == "inverter_lifetime_energy"
+    assert entity.translation_placeholders == {"serial": "INV-A"}
+    assert entity.name == "INV-A Translated lifetime energy"
+
+
 def test_device_info_includes_model_name_when_available():
     from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
 

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -58,6 +58,23 @@ def test_service_display_text_lives_in_translations() -> None:
                 ].strip(), f"{service_key}.{nested_key}"
 
 
+def test_inverter_lifetime_energy_name_is_localized_for_all_locales() -> None:
+    """Ensure per-inverter names retain their placeholder in every locale."""
+    strings = json.loads((ROOT / "strings.json").read_text(encoding="utf-8"))
+    path = "entity.sensor.inverter_lifetime_energy.name"
+    catalog_name = _at_path(strings, path)
+    assert catalog_name == "{serial} Lifetime Energy"
+
+    translations_dir = ROOT / "translations"
+    english = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
+    english_name = _at_path(english, path)
+    for locale in translations_dir.glob("*.json"):
+        name = _at_path(json.loads(locale.read_text(encoding="utf-8")), path)
+        assert "{serial}" in name, f"{locale.name} missing {{serial}} placeholder"
+        if locale.name != "en.json" and not locale.name.startswith("en-"):
+            assert name != english_name, f"{locale.name} should localize {path}"
+
+
 def test_try_reauth_now_strings_exist_for_all_locales() -> None:
     """Ensure manual reauth service and repair text are translated."""
 


### PR DESCRIPTION
## Summary

Give charger and inverter sensors translated entity names, including complete translations across all maintained locales.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_entity_wiring.py tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Result: 3,570 tests and all 37 translation tests passed; strict typing succeeds across all 68 integration source files, and `sensor.py` has 100% coverage.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

All 27 maintained locale files include localized charger and inverter entity names.
