### PR TITLE
Validate device automation configurations

### DIFF
--- a/custom_components/enphase_ev/device_action.py
+++ b/custom_components/enphase_ev/device_action.py
@@ -5,7 +5,7 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.const import CONF_DEVICE_ID, CONF_TYPE
 from homeassistant.core import Context, HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
@@ -13,7 +13,25 @@ from .runtime_data import iter_coordinators
 
 ACTION_START = "start_charging"
 ACTION_STOP = "stop_charging"
-## Removed set_charging_amps action since amps are read-only now
+CONF_CHARGING_LEVEL = "charging_level"
+CONF_CONNECTOR_ID = "connector_id"
+
+ACTION_SCHEMA = vol.Any(
+    cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_TYPE): ACTION_START,
+            vol.Optional(CONF_CHARGING_LEVEL): vol.All(int, vol.Range(min=6, max=40)),
+            vol.Optional(CONF_CONNECTOR_ID, default=1): vol.All(
+                int, vol.Range(min=1, max=2)
+            ),
+        }
+    ),
+    cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+        {
+            vol.Required(CONF_TYPE): ACTION_STOP,
+        }
+    ),
+)
 
 
 async def async_get_actions(
@@ -74,8 +92,8 @@ async def async_call_action_from_config(
         return
 
     if typ == ACTION_START:
-        level = config.get("charging_level")
-        connector_id = int(config.get("connector_id", 1))
+        level = config.get(CONF_CHARGING_LEVEL)
+        connector_id = config.get(CONF_CONNECTOR_ID, 1)
         await coord.async_start_charging(
             sn, requested_amps=level, connector_id=connector_id
         )
@@ -94,11 +112,11 @@ async def async_get_action_capabilities(
     typ = config[CONF_TYPE]
     fields: dict[object, object] = {}
     if typ in (ACTION_START,):
-        fields[vol.Optional("charging_level", default=32)] = vol.All(
+        fields[vol.Optional(CONF_CHARGING_LEVEL, default=32)] = vol.All(
             int, vol.Range(min=6, max=40)
         )
     if typ == ACTION_START:
-        fields[vol.Optional("connector_id", default=1)] = vol.All(
+        fields[vol.Optional(CONF_CONNECTOR_ID, default=1)] = vol.All(
             int, vol.Range(min=1, max=2)
         )
     return {"extra_fields": vol.Schema(fields) if fields else vol.Schema({})}

--- a/custom_components/enphase_ev/device_trigger.py
+++ b/custom_components/enphase_ev/device_trigger.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
+import voluptuous as vol
+
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+
 try:
     from homeassistant.components.automation.triggers import state as state_trigger
 except ModuleNotFoundError:
     from homeassistant.components.homeassistant.triggers import state as state_trigger
-from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.const import CONF_ENTITY_ID, CONF_TYPE, STATE_OFF, STATE_ON
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 
 from .const import DOMAIN
 
@@ -20,6 +25,13 @@ TRIGGER_MAP: dict[str, dict[str, Any]] = {
     "plugged_in": {"tkey": "plugged_in", "to": STATE_ON},
     "unplugged": {"tkey": "plugged_in", "to": STATE_OFF},
 }
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_MAP),
+        vol.Optional(CONF_ENTITY_ID): cv.entity_id_or_uuid,
+    }
+)
 
 
 async def async_get_triggers(
@@ -61,11 +73,10 @@ async def async_attach_trigger(
     """Attach a state trigger for the selected device trigger type."""
     ent_reg = er.async_get(hass)
     device_id = config["device_id"]
-    trig_type = config.get("type")
-    meta = TRIGGER_MAP.get(str(trig_type))
+    trig_type = config[CONF_TYPE]
+    meta = TRIGGER_MAP.get(trig_type)
     if not meta:
-        # No-op for unknown type
-        return lambda: None
+        raise HomeAssistantError(f"Unhandled trigger type {trig_type}")
     # Find matching entity again in case it changed
     entity_id = None
     for ent in er.async_entries_for_device(ent_reg, device_id):

--- a/tests/components/enphase_ev/test_device_action.py
+++ b/tests/components/enphase_ev/test_device_action.py
@@ -9,8 +9,9 @@ from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+import voluptuous as vol
 
-from homeassistant.const import CONF_DEVICE_ID
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN
 from homeassistant.helpers import device_registry as dr
 
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
@@ -329,3 +330,56 @@ async def test_async_get_action_capabilities() -> None:
     )
     assert validated["charging_level"] == 24
     assert validated["connector_id"] == 1
+
+
+@pytest.mark.parametrize(
+    "action_type, extra",
+    [
+        ("unknown", {}),
+        (device_action.ACTION_START, {"charging_level": 5}),
+        (device_action.ACTION_START, {"charging_level": 41}),
+        (device_action.ACTION_START, {"charging_level": "not-an-integer"}),
+        (device_action.ACTION_START, {"connector_id": 0}),
+        (device_action.ACTION_START, {"connector_id": 3}),
+        (device_action.ACTION_START, {"connector_id": "not-an-integer"}),
+    ],
+)
+def test_action_schema_rejects_invalid_config(action_type, extra) -> None:
+    """Invalid device action types and fields should fail validation."""
+    with pytest.raises(vol.Invalid):
+        device_action.ACTION_SCHEMA(
+            {
+                CONF_DEVICE_ID: "device-id",
+                CONF_DOMAIN: DOMAIN,
+                CONF_TYPE: action_type,
+                **extra,
+            }
+        )
+
+
+def test_action_schema_validates_start_defaults() -> None:
+    """The action schema should validate and default a start action."""
+    validated = device_action.ACTION_SCHEMA(
+        {
+            CONF_DEVICE_ID: "device-id",
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: device_action.ACTION_START,
+            "charging_level": 24,
+        }
+    )
+
+    assert validated["charging_level"] == 24
+    assert validated["connector_id"] == 1
+
+
+def test_action_schema_rejects_start_fields_on_stop() -> None:
+    """Start-only options should not be accepted by the stop action."""
+    with pytest.raises(vol.Invalid):
+        device_action.ACTION_SCHEMA(
+            {
+                CONF_DEVICE_ID: "device-id",
+                CONF_DOMAIN: DOMAIN,
+                CONF_TYPE: device_action.ACTION_STOP,
+                "connector_id": 1,
+            }
+        )

--- a/tests/components/enphase_ev/test_device_trigger.py
+++ b/tests/components/enphase_ev/test_device_trigger.py
@@ -8,7 +8,10 @@ from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import voluptuous as vol
 
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
@@ -199,11 +202,36 @@ async def test_async_attach_trigger_handles_missing_entity(hass, device_entry):
 
 
 @pytest.mark.asyncio
-async def test_async_attach_trigger_unknown_type_returns_noop(hass, device_entry):
-    """Unknown trigger types should produce a no-op detach callback."""
+async def test_async_attach_trigger_rejects_unknown_type(hass, device_entry):
+    """Unknown trigger types should be rejected instead of becoming a no-op."""
     device, _ = device_entry
-    detach = await device_trigger.async_attach_trigger(
-        hass, {"device_id": device.id, "type": "unknown"}, None, {}
-    )
-    assert callable(detach)
-    assert detach() is None
+    with pytest.raises(HomeAssistantError, match="Unhandled trigger type unknown"):
+        await device_trigger.async_attach_trigger(
+            hass, {"device_id": device.id, "type": "unknown"}, None, {}
+        )
+
+
+def test_trigger_schema_validates_known_trigger() -> None:
+    """Known device triggers and their optional entity should validate."""
+    config = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DOMAIN,
+        CONF_DEVICE_ID: "device-id",
+        CONF_TYPE: "charging_started",
+        "entity_id": "binary_sensor.charging",
+    }
+
+    assert device_trigger.TRIGGER_SCHEMA(config) == config
+
+
+def test_trigger_schema_rejects_unknown_trigger() -> None:
+    """Unknown device trigger types should fail validation."""
+    with pytest.raises(vol.Invalid):
+        device_trigger.TRIGGER_SCHEMA(
+            {
+                CONF_PLATFORM: "device",
+                CONF_DOMAIN: DOMAIN,
+                CONF_DEVICE_ID: "device-id",
+                CONF_TYPE: "unknown",
+            }
+        )


### PR DESCRIPTION
## Summary

Validate device action and trigger configurations against Home Assistant's device automation schemas before use.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/device_action.py custom_components/enphase_ev/device_trigger.py tests/components/enphase_ev/test_device_action.py tests/components/enphase_ev/test_device_trigger.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/device_action.py,custom_components/enphase_ev/device_trigger.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Result: 3,586 tests passed; strict typing succeeds across all 68 integration source files, both quality validator modes report Platinum, and both touched integration modules have 100% coverage.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots are required for this schema-validation change.
