### PR TITLE
Fix Enlighten session authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
+- Fixed Enlighten authentication after Enphase retired the Entrez token mint by
+  using the first-party session token endpoint and retaining rotated session
+  cookies, and aligned BatteryConfig reads with the current cookie-session web
+  request shape. (#758)
 - Fixed Grid Mode so it reads the live-stream `meters.gridRelay` value and
   falls back to outage-context fields such as `show_grid_connect` only when the
   live relay state is unavailable.

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -40,6 +40,7 @@ from .const import (
     LOGIN_URL,
     MFA_RESEND_URL,
     MFA_VALIDATE_URL,
+    SELF_TOKEN_URL,
     SITE_SEARCH_URL,
 )
 from . import api_parsers
@@ -67,6 +68,7 @@ _BATTERY_CONFIG_BROWSER_USER_AGENT = (
 )
 _BATTERY_CONFIG_VARIANT_PRIMARY = "official_web_primary"
 _BATTERY_CONFIG_VARIANT_LEAN = "official_web_lean"
+_BATTERY_CONFIG_VARIANT_SESSION_COOKIE = "official_web_session_cookie"
 _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH = "cookie_eauth_compatible"
 _BATTERY_CONFIG_VARIANT_MIXED = "mixed_auth_compatible"
 _ENLIGHTEN_READ_CONCURRENCY_LIMIT = 2
@@ -1408,7 +1410,7 @@ def _normalize_chargers(payload: Any) -> list[ChargerInfo]:
 
 async def _build_tokens_and_sites(
     session: aiohttp.ClientSession,
-    email: str,
+    _email: str,
     session_id: str | None,
     *,
     timeout: int,
@@ -1424,17 +1426,23 @@ async def _build_tokens_and_sites(
         raw_cookies=cookie_map,
     )
 
-    # Attempt to obtain a bearer/e-auth token. If not available, proceed with cookie-only mode.
+    # Obtain the bearer/e-auth token from the same session-backed route used by
+    # the Enlighten web application. If it is temporarily unavailable, retain
+    # cookie-only mode so core site discovery can still proceed.
     token_payload: Any | None = None
-    if tokens.session_id:
+    if tokens.session_id or tokens.cookie:
         try:
             token_payload = await _request_json(
                 session,
-                "POST",
-                f"{ENTREZ_URL}/tokens",
+                "GET",
+                SELF_TOKEN_URL,
                 timeout=timeout,
-                headers={"Accept": "application/json"},
-                json_data={"session_id": tokens.session_id, "email": email},
+                headers={
+                    "Accept": "application/json, text/plain, */*",
+                    "Referer": f"{BASE_URL}/",
+                    "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
+                    "X-Requested-With": "XMLHttpRequest",
+                },
             )
         except aiohttp.ClientResponseError as err:  # noqa: BLE001
             if err.status in (401, 403):
@@ -1464,6 +1472,15 @@ async def _build_tokens_and_sites(
                 "Token endpoint client error: %s",
                 safe_error,
             )
+
+    # Enlighten may rotate the session cookie while minting the token. Persist
+    # the post-mint cookie jar and use it for site discovery rather than the
+    # snapshot captured immediately after login.
+    cookie_header, cookie_map = _serialize_cookie_jar(
+        session.cookie_jar, (BASE_URL, ENTREZ_URL)
+    )
+    tokens.cookie = cookie_header
+    tokens.raw_cookies = cookie_map
 
     if isinstance(token_payload, dict):
         token = (
@@ -2583,13 +2600,23 @@ class EnphaseEVClient:
             "X-CSRF-Token": None,
             "requestid": (
                 str(uuid.uuid4())
-                if variant == _BATTERY_CONFIG_VARIANT_PRIMARY
+                if variant
+                in {
+                    _BATTERY_CONFIG_VARIANT_PRIMARY,
+                    _BATTERY_CONFIG_VARIANT_SESSION_COOKIE,
+                }
                 else None
             ),
         }
         token, user_id = self._battery_config_auth_context()
         if variant == _BATTERY_CONFIG_VARIANT_PRIMARY:
             headers["e-auth-token"] = token
+        elif variant == _BATTERY_CONFIG_VARIANT_SESSION_COOKIE:
+            headers["Cookie"] = self._battery_config_cookie(
+                include_xsrf=include_xsrf,
+                preserve_existing_xsrf=True,
+            )
+            headers["e-auth-token"] = None
         else:
             headers["e-auth-token"] = None
         if user_id:
@@ -2657,7 +2684,12 @@ class EnphaseEVClient:
                 headers["X-XSRF-Token"] = None
         return headers
 
-    def _battery_config_cookie(self, *, include_xsrf: bool = False) -> str | None:
+    def _battery_config_cookie(
+        self,
+        *,
+        include_xsrf: bool = False,
+        preserve_existing_xsrf: bool = False,
+    ) -> str | None:
         """Return a normalized BatteryConfig cookie header value."""
 
         cookies: dict[str, str] = {}
@@ -2681,11 +2713,12 @@ class EnphaseEVClient:
             )
             cookies.update(jar_cookies)
 
-        cookies = {
-            name: value
-            for name, value in cookies.items()
-            if name.strip().lower() not in _XSRF_COOKIE_NAMES
-        }
+        if not preserve_existing_xsrf:
+            cookies = {
+                name: value
+                for name, value in cookies.items()
+                if name.strip().lower() not in _XSRF_COOKIE_NAMES
+            }
 
         if include_xsrf:
             xsrf = self._xsrf_token()
@@ -2822,8 +2855,10 @@ class EnphaseEVClient:
         """Return the ordered variants to try for a BatteryConfig family."""
 
         cached = self._battery_config_cached_variant(endpoint_family)
+        has_session_cookie = bool(self._battery_config_cookie())
         variants = [
             cached,
+            (_BATTERY_CONFIG_VARIANT_SESSION_COOKIE if has_session_cookie else None),
             _BATTERY_CONFIG_VARIANT_PRIMARY,
             _BATTERY_CONFIG_VARIANT_LEAN,
         ]
@@ -2831,7 +2866,15 @@ class EnphaseEVClient:
             variant
             for variant in dict.fromkeys(variants)
             if variant
-            in {_BATTERY_CONFIG_VARIANT_PRIMARY, _BATTERY_CONFIG_VARIANT_LEAN}
+            in {
+                _BATTERY_CONFIG_VARIANT_SESSION_COOKIE,
+                _BATTERY_CONFIG_VARIANT_PRIMARY,
+                _BATTERY_CONFIG_VARIANT_LEAN,
+            }
+            and not (
+                variant == _BATTERY_CONFIG_VARIANT_SESSION_COOKIE
+                and not has_session_cookie
+            )
         ]
 
     def _battery_config_write_attempt_cache_key(
@@ -3539,6 +3582,17 @@ class EnphaseEVClient:
                         params=params,
                         debug_auth_source=variant,
                     )
+                except EnphaseLoginWallUnauthorized:
+                    if index == len(variants) - 1:
+                        raise
+                    _LOGGER.debug(
+                        "Retrying BatteryConfig request for %s with %s variant "
+                        "after login wall (cached_variant=%s)",
+                        _request_label(method, url),
+                        variants[index + 1],
+                        self._battery_config_cached_variant(family),
+                    )
+                    continue
                 except aiohttp.ClientResponseError as err:
                     if err.status == HTTPStatus.UNAUTHORIZED:
                         raise

--- a/custom_components/enphase_ev/const.py
+++ b/custom_components/enphase_ev/const.py
@@ -62,6 +62,7 @@ ISSUE_BATTERY_PROFILE_PENDING = "battery_profile_pending"
 
 BASE_URL = "https://enlighten.enphaseenergy.com"
 ENTREZ_URL = "https://entrez.enphaseenergy.com"
+SELF_TOKEN_URL = f"{BASE_URL}/users/self/token"
 LOGIN_URL = f"{BASE_URL}/login/login.json"
 LOGIN_FORM_URL = f"{BASE_URL}/login/login"
 MFA_VALIDATE_URL = f"{BASE_URL}/app-api/validate_login_otp"

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -6,7 +6,7 @@ _This reference consolidates observed Enlighten mobile/web APIs across EV chargi
 
 ## 1. Overview
 - **Base URL:** `https://enlighten.enphaseenergy.com`
-- **Auth:** The current implementation is cookie-first. Login establishes an Enlighten session cookie jar, then the client best-effort fetches an access token from Entrez and adds endpoint-specific headers on top. Many read endpoints work with cookies plus `e-auth-token`; scheduler, HEMS, and timeseries families prefer or require `Authorization: Bearer <jwt>`. BatteryConfig is now the main exception: it follows the homeowner web app request shape instead of the bearer/e-auth/cookie overlay used elsewhere.
+- **Auth:** The current implementation is cookie-first. Login establishes an Enlighten session cookie jar, then the client best-effort fetches an access token from `/users/self/token` and adds endpoint-specific headers on top. Many read endpoints work with cookies plus `e-auth-token`; scheduler, HEMS, and timeseries families prefer or require `Authorization: Bearer <jwt>`. BatteryConfig is now the main exception: reads prefer the homeowner web app's session-cookie request shape, while compatibility variants remain for sites that still accept token-backed shapes.
 - **Privacy:** Example identifiers, account details, LAN metadata, and credentials in this document use placeholders. Raw browser-export request headers often contain JWTs, cookies, email addresses, user IDs, LAN IPs, MAC addresses, and serial numbers; those values must be redacted before captures are shared or committed. When this spec lists "observed values", it intentionally preserves non-sensitive enum/flag values so newly seen behavior is not lost.
 - **Evidence date:** Implementation statements reflect `origin/main` at `0c71ed03`, synced locally on 2026-05-12. New browser/mobile captures should record the capture date, client surface, and endpoint family near the affected section.
 - **Payload examples:** Examples should be minimal shape excerpts. Prefer fields that drive parsing, auth, controls, or diagnostics, and omit long arrays or app-shell metadata unless those details affect implementation.
@@ -92,7 +92,8 @@ Status labels:
 | Domain | Method | Endpoint | Auth | Status |
 | --- | --- | --- | --- | --- |
 | Site discovery | `GET` | `/app-api/search_sites.json` | authenticated session cookies; implementation also sends `X-CSRF-Token` and, when available, `Authorization: Bearer <token>` + `e-auth-token: <token>` | Runtime |
-| Entrez token bootstrap | `POST` | `https://entrez.enphaseenergy.com/tokens` | authenticated session cookies + JSON body `{session_id,email}` | Runtime |
+| Enlighten session token bootstrap | `GET` | `/users/self/token` | authenticated Enlighten session cookies; optional `client_id` is not required by the current runtime | Runtime |
+| Entrez token bootstrap (retired) | `POST` | `https://entrez.enphaseenergy.com/tokens` | formerly authenticated session cookies + JSON body `{session_id,email}` | Documented only |
 | JWT token bootstrap (legacy / documented capture) | `GET` | `/app-api/jwt_token.json` | authenticated Enlighten session cookies | Documented only |
 | JWT token fallback (legacy / documented capture) | `GET` | `/service/auth_ms_enho/api/v1/session/token` | session cookies + `_enlighten_4_session` echoed as `e-auth-token` | Browser capture only |
 | Mobile/web shared constants | `GET` | `https://enlighten-mobile-38d22.firebaseio.com/enho_constants.json` | none observed | Browser capture only |
@@ -157,10 +158,10 @@ Status labels:
 | Stop charging | `PUT` | `/service/evse_controller/<site_id>/ev_chargers/<sn>/stop_charging` | `e-auth-token` + cookies | Runtime |
 | EV charger config read/write | `POST/PUT` | `/service/evse_controller/api/v1/<site_id>/ev_chargers/<sn>/ev_charger_config` | `Authorization: Bearer <token>` overlay on top of session cookies / base EV headers | Runtime |
 | Charge mode preference | `GET/PUT` | `/service/evse_scheduler/api/v1/iqevc/charging-mode/<site_id>/<sn>/preference` | bearer token + session headers | Runtime |
-| BatteryConfig site settings | `GET` | `/service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Chrome-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | Runtime |
+| BatteryConfig site settings | `GET` | `/service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` | current web shape: fresh session `Cookie`, `Username`, `requestid`, battery-profile `Origin`/`Referer`, and no `Authorization` or `e-auth-token`; token-backed primary and lean fallbacks remain for compatibility | Runtime |
 | BatteryConfig MQTT authorizer bootstrap | `GET` | `/service/batteryConfig/api/v1/mqttSignedUrl/<site_id>` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Chrome-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | Browser capture only |
 | BatteryConfig third-party settings | `GET` | `/service/batteryConfig/api/v1/<site_id>/thirdPartyControlSettings` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Chrome-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | Browser capture only |
-| BatteryConfig schedules | `GET` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | official-web BatteryConfig read shape: `Accept`, `Origin`, `Referer`, Chrome-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | Runtime |
+| BatteryConfig schedules | `GET` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | current web shape: fresh session `Cookie`, `Username`, `requestid`, battery-profile `Origin`/`Referer`, and no `Authorization` or `e-auth-token`; token-backed primary and lean fallbacks remain for compatibility | Runtime |
 | BatteryConfig schedule create | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | BatteryConfig write shape plus `X-XSRF-Token`; live verification on the affected site showed create should send explicit `isEnabled`; on affected sites the verified working shape is the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) sent from a stateless client session so aiohttp does not merge cookie-jar state; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | Runtime |
 | BatteryConfig schedule validation / XSRF bootstrap | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid` | explicit validation first acquires `X-XSRF-Token` from `GET /siteSettings/<site_id>?userId=<user_id>`, then uses the official-web BatteryConfig write shape with that token and without `Authorization`, `Cookie`, `X-CSRF-Token`, or `X-Requested-With`; success shape is `{"isValid": true}`; the internal XSRF-bootstrap helper also prefers `GET /siteSettings/<site_id>?userId=<user_id>` and falls back to this route where it may include the currently held `X-XSRF-Token` while harvesting a fresh token from the response header, `Set-Cookie`, response cookies, or the session cookie jar; when this route returns `4xx`, the client still checks error-response cookies/session cookies, then tries a final cookie-based `GET /siteSettings/<site_id>` bootstrap before keeping the existing token; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | Runtime |
 | BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | BatteryConfig write shape plus `X-XSRF-Token`; ordinary time/limit edits can omit `isEnabled`, while explicit schedule-entry toggle writes may include it; verified working update uses the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) from a stateless client session; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | Runtime |
@@ -174,7 +175,7 @@ Status labels:
 ### 1.5 Current Runtime Surface
 
 The integration currently implements these feature groups:
-- Auth and discovery: cookie login, MFA/resend handling, Entrez token bootstrap, site discovery, runtime auth refresh, and manual site-id fallback.
+- Auth and discovery: cookie login, MFA/resend handling, Enlighten session-token bootstrap, site discovery, runtime auth refresh, and manual site-id fallback.
 - EV charging: status, summary, firmware details, feature flags, daily/lifetime EVSE energy, start/stop controls, charge-level configuration, and scheduler preference writes.
 - Site energy and inventory: latest power, today snapshot, lifetime energy, battery backup/grid eligibility, device inventory, microinverter inventory, live-stream capability flags, tariff reads/writes, dry contacts, and system dashboard summary/tree/details.
 - HEMS: inventory, heat-pump runtime state, HEMS daily energy split metadata, HEMS lifetime merge, and heat-pump power derivation from site-today heat-pump deltas.
@@ -6021,15 +6022,10 @@ The server rotates `login_otp_nonce` via `Set-Cookie` but does not return `sessi
 The config flow sends one OTP automatically when entering the MFA step and locally throttles user-triggered resends for 30 seconds. An empty resend response is accepted as success, and existing cookies are reused if no updated cookie map is returned.
 
 ### 6.4 Token Retrieval Used by the Current Client
-Current implementation path:
+Current first-party implementation path:
 ```
-POST https://entrez.enphaseenergy.com/tokens
-Content-Type: application/json
-
-{
-  "session_id": "<session_id>",
-  "email": "<email>"
-}
+GET https://enlighten.enphaseenergy.com/users/self/token
+Accept: application/json, text/plain, */*
 ```
 
 Observed response:
@@ -6041,10 +6037,18 @@ Observed response:
 ```
 
 Observed behavior:
-- This is the token bootstrap path used by the integration today.
+- This is the token bootstrap path used by the current Enlighten web application and the integration.
+- The endpoint uses the authenticated Enlighten session cookie. A `client_id` query parameter is optional and is omitted by the integration.
+- Enlighten can rotate `_enlighten_4_session` during this request, so the client serializes and persists cookies after token minting.
 - The token is stored as both the access token and `e-auth-token` value for cookie-backed site discovery and many EV endpoints.
 - If `expires_at` is absent, the client decodes the JWT `exp` claim locally.
-- `401` and `403` from Entrez are treated as invalid credentials. Other failures, including `404`, `422`, `429`, auth unavailability, and generic client errors, are logged/debugged and cookie-only site discovery continues where possible.
+- `401` and `403` are treated as invalid credentials. Other failures, including `404`, `422`, `429`, auth unavailability, and generic client errors, are logged/debugged and cookie-only site discovery continues where possible.
+
+Retired path:
+```
+POST https://entrez.enphaseenergy.com/tokens
+```
+Enphase stopped honoring this token mint in July 2026 and returned HTTP 400 for otherwise valid authenticated sessions.
 
 Legacy/documented JWT retrieval paths from earlier captures:
 
@@ -6084,7 +6088,7 @@ Observed behavior:
 The current implementation does not use `https://entrez.enphaseenergy.com/access_token`.
 
 Instead:
-- the Entrez `POST /tokens` response is treated as the access/bearer token source;
+- the Enlighten `GET /users/self/token` response is treated as the access/bearer token source;
 - scheduler/control requests often prefer the JWT found in the `enlighten_manager_token_production` cookie when present;
 - timeseries requests derive `e-auth-token` from the JWT `session_id` claim rather than reusing the raw bearer token.
 
@@ -6105,13 +6109,13 @@ There is no single universal header set; the implementation varies headers by en
 | Endpoint family | Auth/header strategy in current client |
 | --- | --- |
 | Login + MFA | form POSTs plus cookie jar management; `X-CSRF-Token` added for MFA when an XSRF cookie is present |
-| Site discovery | authenticated cookies; `X-CSRF-Token`; add `Authorization` + `e-auth-token` when Entrez token retrieval succeeded |
+| Site discovery | authenticated cookies; `X-CSRF-Token`; add `Authorization` + `e-auth-token` when Enlighten session-token retrieval succeeded |
 | Basic Enlighten reads (`/app-api`, `/pv`, many EV reads) | authenticated cookies plus `e-auth-token` when available |
 | Scheduler + EV control overlays | base headers plus `Authorization: Bearer <jwt>` from manager-token cookie first, stored access token second |
 | Session history + EVSE timeseries | `Authorization: Bearer <jwt>`; `e-auth-token` set to JWT `session_id`; `username` set to JWT `user_id`; `requestid` UUID |
 | System dashboard reads | authenticated cookies; may also include bearer auth opportunistically |
 | HEMS | bearer-preferred auth plus cookies/base headers; `username` and `requestId` when available |
-| BatteryConfig reads | official-web BatteryConfig shape: `Accept`, `Username`, battery-profile `Origin`/`Referer`, Chrome-style `User-Agent`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With`; current client prefers the `e-auth-token` + `requestid` variant and falls back to the lean variant if needed |
+| BatteryConfig reads | current web shape: fresh session `Cookie`, `Username`, `requestid`, battery-profile `Origin`/`Referer`, Chrome-style `User-Agent`, and no `Authorization` or `e-auth-token`; token-backed primary and lean variants remain as fallbacks |
 | BatteryConfig writes | acquire fresh XSRF by preferring `GET /service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` and its `x-csrf-token` response header, then falling back to `/battery/sites/<site_id>/schedules/isValid`; if that fallback returns `4xx`, still harvest `BP-XSRF-Token` from error response cookies or the session cookie jar, then try a final cookie-based `GET /siteSettings/<site_id>` bootstrap before giving up and keeping the existing token; writes then use an endpoint-specific compatibility planner; on affected sites the verified working shape is a stateless raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`), with official-web primary, official-web lean, and mixed-auth fallbacks retained |
 
 - Base Enlighten reads:
@@ -6122,7 +6126,7 @@ There is no single universal header set; the implementation varies headers by en
 - Site discovery after login:
   - authenticated cookies
   - `X-CSRF-Token` when an XSRF cookie is present
-  - `Authorization: Bearer <token>` and `e-auth-token: <token>` when Entrez token retrieval succeeds
+  - `Authorization: Bearer <token>` and `e-auth-token: <token>` when Enlighten session-token retrieval succeeds
 - Scheduler / EV control overlays:
   - `Authorization: Bearer <jwt>` from `enlighten_manager_token_production` cookie when present, otherwise the stored access token
 - Session history / EVSE timeseries:

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -943,6 +943,51 @@ def test_battery_config_headers_can_build_lean_fallback_shape() -> None:
     assert headers["Cookie"] is None
 
 
+def test_battery_config_headers_can_build_session_cookie_shape() -> None:
+    bearer = _make_token({"user_id": "77"})
+    client = _make_client()
+    client.update_credentials(
+        eauth="access-token",
+        cookie=(
+            "_enlighten_4_session=fresh-session; BP-XSRF-Token=raw-token; "
+            f"enlighten_manager_token_production={bearer}"
+        ),
+    )
+
+    headers = client._battery_config_headers(  # noqa: SLF001
+        include_xsrf=True,
+        variant=api._BATTERY_CONFIG_VARIANT_SESSION_COOKIE,
+    )
+
+    assert headers["Authorization"] is None
+    assert headers["e-auth-token"] is None
+    assert headers["requestid"]
+    assert headers["Username"] == "77"
+    assert headers["X-XSRF-Token"] == "raw-token"
+    assert headers["X-CSRF-Token"] is None
+    assert "_enlighten_4_session=fresh-session" in headers["Cookie"]
+    assert "BP-XSRF-Token=raw-token" in headers["Cookie"]
+
+
+def test_battery_config_session_cookie_read_preserves_existing_xsrf_cookie() -> None:
+    bearer = _make_token({"user_id": "77"})
+    client = _make_client()
+    client.update_credentials(
+        eauth="access-token",
+        cookie=(
+            "_enlighten_4_session=fresh-session; BP-XSRF-Token=read-token; "
+            f"enlighten_manager_token_production={bearer}"
+        ),
+    )
+
+    headers = client._battery_config_headers(  # noqa: SLF001
+        variant=api._BATTERY_CONFIG_VARIANT_SESSION_COOKIE,
+    )
+
+    assert "BP-XSRF-Token=read-token" in headers["Cookie"]
+    assert "X-XSRF-Token" not in headers
+
+
 def test_battery_config_headers_drop_cookie_when_none_available() -> None:
     client = _make_client()
     client.update_credentials(cookie="session=1")
@@ -963,6 +1008,19 @@ def test_battery_config_headers_clear_auth_and_username_without_tokens() -> None
     assert headers["Authorization"] is None
     assert headers["e-auth-token"] is None
     assert "Username" not in headers
+
+
+def test_battery_config_variant_order_skips_session_shape_without_cookie() -> None:
+    client = _make_client()
+    client.update_credentials(cookie="")
+    client._battery_config_variant_cache[  # noqa: SLF001
+        client._battery_config_variant_cache_key("profile")  # noqa: SLF001
+    ] = api._BATTERY_CONFIG_VARIANT_SESSION_COOKIE
+
+    assert client._battery_config_variant_order("profile") == [  # noqa: SLF001
+        api._BATTERY_CONFIG_VARIANT_PRIMARY,
+        api._BATTERY_CONFIG_VARIANT_LEAN,
+    ]
 
 
 def test_merge_request_headers_returns_base_for_non_dict_overrides() -> None:
@@ -4199,14 +4257,14 @@ async def test_storm_guard_alert_passes_headers() -> None:
     args, kwargs = client._json.await_args
     assert args[0] == "GET"
     assert "stormGuard" in args[1]
-    assert kwargs["headers"]["e-auth-token"] == token
+    assert kwargs["headers"]["e-auth-token"] is None
+    assert kwargs["headers"]["Cookie"]
     assert kwargs["headers"]["Username"] == "42"
     assert kwargs["headers"]["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert (
         kwargs["headers"]["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
     )
     assert kwargs["headers"]["Authorization"] is None
-    assert kwargs["headers"]["Cookie"] is None
     assert kwargs["headers"]["X-CSRF-Token"] is None
     assert kwargs["headers"]["X-Requested-With"] is None
     assert "requestid" in kwargs["headers"]
@@ -4216,7 +4274,7 @@ async def test_storm_guard_alert_passes_headers() -> None:
 async def test_storm_guard_profile_passes_params() -> None:
     token = _make_token({"user_id": "55"})
     client = _make_client()
-    client.update_credentials(eauth=token)
+    client.update_credentials(eauth=token, cookie="session=1")
     client._json = AsyncMock(return_value={"data": {}})
     await client.storm_guard_profile(locale="en-US")
     args, kwargs = client._json.await_args
@@ -4246,11 +4304,12 @@ async def test_battery_site_settings_passes_params_and_headers() -> None:
     assert args[0] == "GET"
     assert "siteSettings" in args[1]
     assert kwargs["params"]["userId"] == "77"
-    assert kwargs["headers"]["e-auth-token"] == token
+    assert kwargs["headers"]["e-auth-token"] is None
+    assert kwargs["headers"]["Cookie"]
+    assert kwargs["headers"]["requestid"]
     assert kwargs["headers"]["Username"] == "77"
     assert kwargs["headers"]["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert kwargs["headers"]["Authorization"] is None
-    assert kwargs["headers"]["Cookie"] is None
     assert kwargs["headers"]["X-CSRF-Token"] is None
     assert kwargs["headers"]["X-Requested-With"] is None
     assert "requestid" in kwargs["headers"]
@@ -4482,7 +4541,7 @@ async def test_notify_tariff_change_uses_scheduler_endpoint() -> None:
 async def test_battery_settings_details_passes_params_and_headers() -> None:
     token = _make_token({"user_id": "99"})
     client = _make_client()
-    client.update_credentials(eauth=token)
+    client.update_credentials(eauth=token, cookie="session=1")
     client._json = AsyncMock(return_value={"data": {"chargeFromGrid": True}})
 
     out = await client.battery_settings_details()
@@ -4494,9 +4553,9 @@ async def test_battery_settings_details_passes_params_and_headers() -> None:
     assert kwargs["params"]["source"] == "enlm"
     assert kwargs["params"]["userId"] == "99"
     assert kwargs["headers"]["Username"] == "99"
-    assert kwargs["headers"]["e-auth-token"] == token
+    assert kwargs["headers"]["e-auth-token"] is None
     assert kwargs["headers"]["Authorization"] is None
-    assert kwargs["headers"]["Cookie"] is None
+    assert kwargs["headers"]["Cookie"]
     assert kwargs["headers"]["X-CSRF-Token"] is None
     assert kwargs["headers"]["X-Requested-With"] is None
     assert "requestid" in kwargs["headers"]
@@ -4522,8 +4581,8 @@ async def test_battery_settings_details_wire_headers_match_official_web_shape() 
     assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
     assert headers["Username"] == "99"
     assert "Authorization" not in headers
-    assert headers["e-auth-token"] == token
-    assert "Cookie" not in headers
+    assert "e-auth-token" not in headers
+    assert headers["Cookie"]
     assert "X-CSRF-Token" not in headers
     assert "X-Requested-With" not in headers
     assert "requestid" in headers
@@ -4844,6 +4903,61 @@ async def test_battery_config_request_retries_403_and_caches_variant_when_bootst
         == api._BATTERY_CONFIG_VARIANT_LEAN
     )
     assert client._bp_xsrf_token is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_battery_config_request_retries_login_wall_with_token_variant() -> None:
+    client = _make_client()
+    client.update_credentials(cookie="_enlighten_4_session=fresh-session")
+    login_wall = api.EnphaseLoginWallUnauthorized(
+        endpoint="/service/batteryConfig/api/v1/siteSettings/SITE",
+        request_label="GET /service/batteryConfig/api/v1/siteSettings/[site]",
+        status=200,
+        content_type="text/html",
+        body_preview_redacted="Enlighten Login",
+    )
+    client._json = AsyncMock(side_effect=[login_wall, {"message": "success"}])
+
+    out = await client._battery_config_request(  # noqa: SLF001
+        "GET",
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/siteSettings/SITE",
+        endpoint_family="profile",
+        cache_on_success=True,
+    )
+
+    assert out == {"message": "success"}
+    first_call, second_call = client._json.await_args_list
+    assert first_call.kwargs["headers"]["Cookie"]
+    assert first_call.kwargs["headers"]["e-auth-token"] is None
+    assert second_call.kwargs["headers"]["Cookie"] is None
+    assert second_call.kwargs["headers"]["e-auth-token"] == "EAUTH"
+    assert (
+        client._battery_config_cached_variant("profile")  # noqa: SLF001
+        == api._BATTERY_CONFIG_VARIANT_PRIMARY
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_config_request_reraises_login_wall_after_all_variants() -> None:
+    client = _make_client()
+    client.update_credentials(cookie="")
+    login_wall = api.EnphaseLoginWallUnauthorized(
+        endpoint="/service/batteryConfig/api/v1/siteSettings/SITE",
+        request_label="GET /service/batteryConfig/api/v1/siteSettings/[site]",
+        status=200,
+        content_type="text/html",
+        body_preview_redacted="Enlighten Login",
+    )
+    client._json = AsyncMock(side_effect=[login_wall, login_wall])
+
+    with pytest.raises(api.EnphaseLoginWallUnauthorized):
+        await client._battery_config_request(  # noqa: SLF001
+            "GET",
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/siteSettings/SITE",
+            endpoint_family="profile",
+        )
+
+    assert client._json.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_api_http_flow.py
+++ b/tests/components/enphase_ev/test_api_http_flow.py
@@ -602,7 +602,7 @@ async def test_async_authenticate_success_with_jwt_fallback(monkeypatch) -> None
                 response_url=URL(api.BASE_URL),
             )
             return {"session_id": "sid123"}
-        if url == f"{api.ENTREZ_URL}/tokens":
+        if url == api.SELF_TOKEN_URL:
             token = _build_jwt(1_700_000_001)
             return {"token": token}
         if url == api.SITE_SEARCH_URL:
@@ -652,7 +652,7 @@ async def test_async_authenticate_falls_back_to_form_login_on_406(monkeypatch) -
         if url == api.LOGIN_URL:
             login_headers.append(headers or {})
             raise _make_cre(406, "Not Acceptable")
-        if url == f"{api.ENTREZ_URL}/tokens":
+        if url == api.SELF_TOKEN_URL:
             return {"token": "token123", "expires_at": 1_700_000_000}
         if url == api.SITE_SEARCH_URL:
             site_headers.append(headers or {})
@@ -912,7 +912,7 @@ async def test_async_validate_login_otp_success(monkeypatch) -> None:
         }
 
     async def fake_request_json(session, method, url, **kwargs):
-        if url == f"{api.ENTREZ_URL}/tokens":
+        if url == api.SELF_TOKEN_URL:
             return {"token": "token123"}
         if url == api.SITE_SEARCH_URL:
             return {"sites": [{"id": 1}]}
@@ -1277,7 +1277,7 @@ async def test_async_authenticate_token_endpoint_invalid_credentials(
         if url == api.LOGIN_URL:
             session.cookie_jar.update_cookies({}, response_url=URL(api.BASE_URL))
             return {"session_id": "sid123"}
-        if url == f"{api.ENTREZ_URL}/tokens":
+        if url == api.SELF_TOKEN_URL:
             raise _make_cre(403)
         raise AssertionError("Site discovery should not be reached")
 
@@ -1293,7 +1293,7 @@ async def test_async_authenticate_token_endpoint_missing(monkeypatch) -> None:
         if url == api.LOGIN_URL:
             session.cookie_jar.update_cookies({}, response_url=URL(api.BASE_URL))
             return {"session_id": "sid123"}
-        if url == f"{api.ENTREZ_URL}/tokens":
+        if url == api.SELF_TOKEN_URL:
             raise _make_cre(404)
         if url == api.SITE_SEARCH_URL:
             return {"sites": [{"id": 1}]}
@@ -1314,7 +1314,7 @@ async def test_async_authenticate_token_endpoint_generic_error(monkeypatch) -> N
         if url == api.LOGIN_URL:
             session.cookie_jar.update_cookies({}, response_url=URL(api.BASE_URL))
             return {"session_id": "sid123"}
-        if url == f"{api.ENTREZ_URL}/tokens":
+        if url == api.SELF_TOKEN_URL:
             raise _make_cre(500)
         if url == api.SITE_SEARCH_URL:
             return {"sites": [{"id": 2}]}
@@ -1335,7 +1335,7 @@ async def test_async_authenticate_token_endpoint_unavailable(monkeypatch) -> Non
         if url == api.LOGIN_URL:
             session.cookie_jar.update_cookies({}, response_url=URL(api.BASE_URL))
             return {"session_id": "sid123"}
-        if url == f"{api.ENTREZ_URL}/tokens":
+        if url == api.SELF_TOKEN_URL:
             raise api.EnlightenAuthUnavailable("unavailable")
         if url == api.SITE_SEARCH_URL:
             return {"sites": [{"id": "3"}]}
@@ -1356,7 +1356,7 @@ async def test_async_authenticate_token_endpoint_client_error(monkeypatch) -> No
         if url == api.LOGIN_URL:
             session.cookie_jar.update_cookies({}, response_url=URL(api.BASE_URL))
             return {"session_id": "sid123"}
-        if url == f"{api.ENTREZ_URL}/tokens":
+        if url == api.SELF_TOKEN_URL:
             raise aiohttp.ClientOSError()
         if url == api.SITE_SEARCH_URL:
             return {"sites": [{"id": "4"}]}

--- a/tests/components/enphase_ev/test_auth_site_discovery.py
+++ b/tests/components/enphase_ev/test_auth_site_discovery.py
@@ -10,6 +10,7 @@ from custom_components.enphase_ev import api
 @pytest.mark.asyncio
 async def test_async_authenticate_populates_site_headers(monkeypatch):
     site_headers: list[dict[str, str]] = []
+    token_requests: list[tuple[str, dict[str, str]]] = []
 
     async def _fake_request_json(
         session: aiohttp.ClientSession,
@@ -30,7 +31,12 @@ async def test_async_authenticate_populates_site_headers(monkeypatch):
                 response_url=URL(api.BASE_URL),
             )
             return {"session_id": "sid123"}
-        if url == f"{api.ENTREZ_URL}/tokens":
+        if url == api.SELF_TOKEN_URL:
+            token_requests.append((method, headers or {}))
+            session.cookie_jar.update_cookies(
+                {"enlighten_session": "rotated-session"},
+                response_url=URL(api.BASE_URL),
+            )
             return {"token": "token123", "expires_at": 1700000000}
         if url == api.SITE_SEARCH_URL:
             site_headers.append(headers or {})
@@ -47,8 +53,20 @@ async def test_async_authenticate_populates_site_headers(monkeypatch):
     tokens, sites = await api.async_authenticate(session, "user@example.com", "secret")
 
     assert tokens.access_token == "token123"
+    assert tokens.cookie and "rotated-session" in tokens.cookie
     assert sites and sites[0].site_id == "7812456"
     assert site_headers, "Site discovery request headers were not captured"
+    assert token_requests == [
+        (
+            "GET",
+            {
+                "Accept": "application/json, text/plain, */*",
+                "Referer": f"{api.BASE_URL}/",
+                "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
+                "X-Requested-With": "XMLHttpRequest",
+            },
+        )
+    ]
 
     captured = site_headers[0]
     assert captured["Accept"] == "*/*"
@@ -59,4 +77,4 @@ async def test_async_authenticate_populates_site_headers(monkeypatch):
     assert captured["Authorization"] == "Bearer token123"
     assert captured["e-auth-token"] == "token123"
     # Ensure the caller explicitly sets Cookie so the request works without relying on session defaults
-    assert "Cookie" in captured and "enlighten_session" in captured["Cookie"]
+    assert "Cookie" in captured and "rotated-session" in captured["Cookie"]


### PR DESCRIPTION
## Summary

Replace the retired Entrez token mint with Enlighten's first-party session token endpoint, persist session-cookie rotation, and align BatteryConfig reads with the current cookie-authenticated browser request shape.

BatteryConfig reads now preserve existing `BP-XSRF-Token` cookies while omitting token and write-only XSRF headers. Compatibility fallbacks remain for sites that still accept the previous request variants.

Fixes #758.

## Related Issues

- #758
- #750 is related session-management work but does not replace the token mint or BatteryConfig read shape.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/const.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_api_http_flow.py tests/components/enphase_ev/test_auth_site_discovery.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james:/Users/james ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/const.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/config_flow.py"
```

Results:

- 3,440 integration tests passed.
- 3,572 full-suite tests passed.
- `api.py` and `const.py` both report 100% targeted coverage.
- Live account verification passed for token minting, site discovery, BatteryConfig settings/profile reads, EVSE feature flags, EVSE bearer timeseries, and the HEMS endpoint.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The local Home Assistant runtime was tested with an existing configured account. The first BatteryConfig response supplied `BP-XSRF-Token`; subsequent reads preserved it in `Cookie` while omitting `e-auth-token` and `X-XSRF-Token`. The local runtime was shut down after verification.
