### PR TITLE
Optimize entity update processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project will be documented in this file.
   frequently updated IQ EV Charger Power and Last Reported sensors to reduce
   Recorder growth. Power restore baselines now use private Home Assistant
   restore data.
+- Removed high-cardinality device metadata from IQ Battery charge and
+  microinverter lifetime-energy state attributes. Use integration diagnostics
+  for the complete device payload; the remaining operational attributes are
+  excluded from recorder history.
 
 ### ✨ New features
 - None
@@ -32,6 +36,11 @@ All notable changes to this project will be documented in this file.
   BatteryConfig writes instead of creating a new connection pool per request.
 - Added localized System Health labels for tariff status, degraded services,
   and firmware catalog diagnostics in every supported language.
+- Reduced recorder and event-loop overhead on large sites by reconciling sensor
+  registries only when topology or entity capabilities change, caching per-update
+  battery and microinverter snapshots, and excluding diagnostic device metadata
+  from recorder history. Detailed inverter and battery metadata remains available
+  in integration diagnostics.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/schedule_sync.py
+++ b/custom_components/enphase_ev/schedule_sync.py
@@ -475,6 +475,10 @@ class ScheduleSync:
 
     @callback
     def _handle_coordinator_update(self) -> None:
+        if self._last_sync is not None:
+            age = dt_util.utcnow() - self._last_sync
+            if age < SYNC_INTERVAL:
+                return
         coro = self._refresh_if_stale()
         try:
             self.hass.async_create_task(

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -322,7 +322,6 @@ async def async_setup_entry(
         registry_setup.prune_removed_gateway_iq_router_entities
     )
     _async_remove_site_sensor_entity = registry_setup.remove_site_sensor_entity
-    _async_remove_type_sensor_entity = registry_setup.remove_type_sensor_entity
     _site_sensor_entity_registered = registry_setup.site_sensor_entity_registered
     _async_remove_site_sensor_entities_with_prefix = (
         registry_setup.remove_site_sensor_entities_with_prefix
@@ -340,6 +339,7 @@ async def async_setup_entry(
     last_ac_battery_serial_set: set[str] | None = None
     last_charger_serial_set: set[str] | None = None
     last_inverter_serial_set: set[str] | None = None
+    last_entity_shape_signature: tuple[object, ...] | None = None
 
     @callback
     def _async_sync_site_entities() -> None:
@@ -464,15 +464,12 @@ async def async_setup_entry(
             "current_production_power",
             EnphaseCurrentPowerConsumptionSensor(coord),
         )
-        _async_remove_site_sensor_entity("current_power_consumption")
         if _site_lifetime_power_channel_present(
             "grid_import"
         ) or _site_lifetime_power_channel_present("grid_export"):
             _add_site_entity("grid_power", EnphaseGridPowerSensor(coord))
         else:
             _async_remove_site_sensor_entity("grid_power")
-        _async_remove_site_sensor_entity("grid_import_power")
-        _async_remove_site_sensor_entity("grid_export_power")
         _add_site_entity("site_last_error_code", EnphaseSiteLastErrorCodeSensor(coord))
         _add_site_entity(
             "site_service_status",
@@ -561,10 +558,6 @@ async def async_setup_entry(
                 current_import_rate_key,
                 EnphaseCurrentTariffRateSensor(coord, is_import=True),
             )
-        _async_remove_site_sensor_entity("tariff_import_rate")
-        _async_remove_site_sensor_entities_with_prefix(
-            "tariff_import_rate_",
-        )
         current_export_rate_key = "tariff_current_export_rate"
         if tariff_export_rate is not None:
             _add_site_entity(
@@ -580,10 +573,6 @@ async def async_setup_entry(
                 current_export_rate_key,
                 EnphaseCurrentTariffRateSensor(coord, is_import=False),
             )
-        _async_remove_site_sensor_entity("tariff_export_rate")
-        _async_remove_site_sensor_entities_with_prefix(
-            "tariff_export_rate_",
-        )
 
         for record in router_records:
             router_key = str(record.get("key", "")).strip()
@@ -800,12 +789,6 @@ async def async_setup_entry(
 
     @callback
     def _async_sync_type_inventory() -> None:
-        _async_prune_dry_contact_type_inventory_entities()
-        _async_prune_blocked_type_inventory_entities({"encharge"})
-        for type_key in list(known_type_keys):
-            if not _is_dry_contact_type_key(type_key):
-                continue
-            _async_remove_type_sensor_entity(type_key)
         keys = [
             key
             for key in coord.inventory_view.iter_type_keys()
@@ -968,6 +951,7 @@ async def async_setup_entry(
 
     @callback
     def _async_sync_topology() -> None:
+        nonlocal last_entity_shape_signature
         nonlocal last_type_key_set
         nonlocal last_battery_serial_set
         nonlocal last_ac_battery_serial_set
@@ -988,9 +972,13 @@ async def async_setup_entry(
             current_charger_serials = {sn for sn in coord.iter_serials() if sn}
         current_inverter_serials = active_inverter_serials_for_cleanup(coord)
 
+        # The dedicated topology signal also covers router membership, which is
+        # intentionally absent from the cheap coordinator-update signature.
         _async_sync_site_entities()
-        _async_sync_type_inventory()
-        last_type_key_set = current_type_keys
+        last_entity_shape_signature = _entity_shape_signature()
+        if current_type_keys != last_type_key_set:
+            _async_sync_type_inventory()
+            last_type_key_set = current_type_keys
         if current_battery_serials != last_battery_serial_set:
             _async_sync_batteries()
             _async_sync_chargers()
@@ -1005,6 +993,87 @@ async def async_setup_entry(
             _async_sync_inverters()
             last_inverter_serial_set = current_inverter_serials
 
+    def _entity_shape_signature() -> tuple[object, ...]:
+        """Return inexpensive state that controls site-level entity presence."""
+
+        energy = getattr(coord, "energy", None)
+        site_energy = (
+            getattr(energy, "site_energy", None)
+            if energy is not None
+            else getattr(coord, "site_energy", None)
+        )
+        site_energy_meta = (
+            getattr(energy, "site_energy_meta", None)
+            if energy is not None
+            else getattr(coord, "site_energy_meta", None)
+        )
+        bucket_lengths = (
+            site_energy_meta.get("bucket_lengths")
+            if isinstance(site_energy_meta, dict)
+            else None
+        )
+        populated_bucket_keys = (
+            frozenset(key for key, value in bucket_lengths.items() if value)
+            if isinstance(bucket_lengths, dict)
+            else frozenset()
+        )
+        try:
+            gateway_meter_shape = (
+                _gateway_meter_member(coord, "production") is not None,
+                _gateway_meter_member(coord, "consumption") is not None,
+                bool(_gateway_dry_contact_members(coord)),
+            )
+        except Exception:  # noqa: BLE001
+            gateway_meter_shape = (None, None, None)
+        known_channels: tuple[bool, ...] = ()
+        channel_known = getattr(
+            getattr(coord, "discovery_snapshot", None),
+            "site_energy_channel_known",
+            None,
+        )
+        if callable(channel_known):
+            values: list[bool] = []
+            for flow_key in SITE_LIFETIME_FLOW_BUCKET_LENGTH_KEYS:
+                try:
+                    values.append(bool(channel_known(flow_key)))
+                except Exception:  # noqa: BLE001
+                    values.append(False)
+            known_channels = tuple(values)
+        return (
+            bool(getattr(coord, "_devices_inventory_ready", False)),
+            _site_has_battery(coord),
+            getattr(coord, "battery_has_enpower", None),
+            bool(getattr(coord, "include_inverters", True)),
+            _type_available(coord, "envoy"),
+            _type_available(coord, "encharge"),
+            _type_available(coord, "ac_battery"),
+            _type_available(coord, "microinverter"),
+            _type_available(coord, "heatpump"),
+            _type_available(coord, "enpower"),
+            _heatpump_runtime_device_uid(coord),
+            _battery_schedule_inventory_supported(coord),
+            _grid_control_site_applicable(coord),
+            getattr(coord, "tariff_billing", None) is not None,
+            getattr(coord, "tariff_import_rate", None) is not None,
+            getattr(coord, "tariff_export_rate", None) is not None,
+            getattr(coord, "tariff_rates_last_refresh_utc", None) is not None,
+            frozenset(site_energy) if isinstance(site_energy, dict) else frozenset(),
+            populated_bucket_keys,
+            known_channels,
+            gateway_meter_shape,
+        )
+
+    @callback
+    def _async_sync_capabilities() -> None:
+        """Reconcile site entities only when their capability shape changes."""
+
+        nonlocal last_entity_shape_signature
+        signature = _entity_shape_signature()
+        if signature == last_entity_shape_signature:
+            return
+        _async_sync_site_entities()
+        last_entity_shape_signature = signature
+
     add_topology_listener = getattr(coord, "async_add_topology_listener", None)
     has_topology_listener = callable(add_topology_listener)
     if not has_topology_listener:
@@ -1013,7 +1082,18 @@ async def async_setup_entry(
         entry.async_on_unload(add_topology_listener(_async_sync_topology))
     add_coordinator_listener = getattr(coord, "async_add_listener", None)
     if has_topology_listener and callable(add_coordinator_listener):
-        entry.async_on_unload(add_coordinator_listener(_async_sync_topology))
+        entry.async_on_unload(add_coordinator_listener(_async_sync_capabilities))
+    # One-time migrations and retired-entity cleanup must not scan the registry on
+    # every coordinator update.
+    _async_prune_dry_contact_type_inventory_entities()
+    _async_prune_blocked_type_inventory_entities({"encharge"})
+    _async_remove_site_sensor_entity("current_power_consumption")
+    _async_remove_site_sensor_entity("grid_import_power")
+    _async_remove_site_sensor_entity("grid_export_power")
+    _async_remove_site_sensor_entity("tariff_import_rate")
+    _async_remove_site_sensor_entities_with_prefix("tariff_import_rate_")
+    _async_remove_site_sensor_entity("tariff_export_rate")
+    _async_remove_site_sensor_entities_with_prefix("tariff_export_rate_")
     registry_setup.prune_historical_charger_sensor_entities()
     registry_setup.prune_removed_site_entities()
     _async_sync_topology()
@@ -3065,6 +3145,9 @@ class EnphaseInverterLifetimeEnergySensor(CoordinatorEntity, RestoreSensor):  # 
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
     _attr_suggested_display_precision = 2
     _attr_translation_key = "inverter_lifetime_energy"
+    _unrecorded_attributes = frozenset(
+        {"sampled_at_utc", "status", "status_text", "rssi"}
+    )
 
     def __init__(self, coord: EnphaseCoordinator, serial: str) -> None:
         super().__init__(coord)
@@ -3073,6 +3156,8 @@ class EnphaseInverterLifetimeEnergySensor(CoordinatorEntity, RestoreSensor):  # 
         self._attr_translation_placeholders = {"serial": self._sn}
         self._attr_unique_id = f"{DOMAIN}_inverter_{self._sn}_lifetime_energy"
         self._last_good_native_value: float | None = None
+        self._snapshot_cache_token: tuple[int, int] | None = None
+        self._snapshot_cache: dict[str, object] | None = None
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -3106,12 +3191,24 @@ class EnphaseInverterLifetimeEnergySensor(CoordinatorEntity, RestoreSensor):  # 
             self._attr_native_value = restored
 
     def _snapshot(self) -> dict[str, object] | None:
+        coordinator_data = getattr(self._coord, "data", None)
+        inverter_data = getattr(self._coord, "_inverter_data", None)
+        cacheable = coordinator_data is not None or inverter_data is not None
+        token = (id(coordinator_data), id(inverter_data))
+        if cacheable and token == self._snapshot_cache_token:
+            return self._snapshot_cache
         getter = getattr(self._coord, "inverter_data", None)
         if not callable(getter):
             return None
         data = getter(self._sn)
         if isinstance(data, dict):
+            if cacheable:
+                self._snapshot_cache_token = token
+                self._snapshot_cache = data
             return data
+        if cacheable:
+            self._snapshot_cache_token = token
+            self._snapshot_cache = None
         return None
 
     @property
@@ -3152,29 +3249,9 @@ class EnphaseInverterLifetimeEnergySensor(CoordinatorEntity, RestoreSensor):  # 
             "sampled_at_utc": (
                 sampled_at.isoformat() if sampled_at is not None else None
             ),
-            "serial_number": data.get("serial_number"),
-            "inverter_id": data.get("inverter_id"),
-            "device_id": data.get("device_id"),
-            "inverter_type": data.get("inverter_type"),
-            "name": data.get("name"),
-            "array_name": data.get("array_name"),
-            "sku_id": data.get("sku_id"),
-            "part_num": data.get("part_num"),
-            "sku": data.get("sku"),
             "status": data.get("status"),
             "status_text": data.get("status_text"),
-            "status_code": data.get("status_code"),
-            "last_report": data.get("last_report"),
-            "fw1": data.get("fw1"),
-            "fw2": data.get("fw2"),
-            "warranty_end_date": data.get("warranty_end_date"),
-            "show_sig_str": data.get("show_sig_str"),
-            "emu_version": data.get("emu_version"),
-            "issi": data.get("issi"),
             "rssi": data.get("rssi"),
-            "lifetime_production_wh": data.get("lifetime_production_wh"),
-            "lifetime_query_start_date": data.get("lifetime_query_start_date"),
-            "lifetime_query_end_date": data.get("lifetime_query_end_date"),
         }
 
     @property
@@ -3193,6 +3270,9 @@ class EnphaseInverterLifetimeEnergySensor(CoordinatorEntity, RestoreSensor):  # 
 
 class _EnphaseBatteryStorageBaseSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
     _attr_has_entity_name = True
+    _unrecorded_attributes = frozenset(
+        {"serial_number", "status", "sampled_at_utc", "state"}
+    )
 
     def __init__(
         self, coord: EnphaseCoordinator, serial: str, unique_suffix: str
@@ -3203,14 +3283,28 @@ class _EnphaseBatteryStorageBaseSensor(CoordinatorEntity, SensorEntity):  # type
         self._attr_unique_id = (
             f"{DOMAIN}_site_{coord.site_id}_battery_{self._sn}{unique_suffix}"
         )
+        self._snapshot_cache_token: tuple[int, int] | None = None
+        self._snapshot_cache: dict[str, object] | None = None
 
     def _snapshot(self) -> dict[str, object] | None:
+        coordinator_data = getattr(self._coord, "data", None)
+        battery_data = getattr(self._coord, "_battery_storage_data", None)
+        cacheable = coordinator_data is not None or battery_data is not None
+        token = (id(coordinator_data), id(battery_data))
+        if cacheable and token == self._snapshot_cache_token:
+            return self._snapshot_cache
         getter = getattr(self._coord, "battery_storage", None)
         if not callable(getter):
             return None
         payload = getter(self._sn)
         if isinstance(payload, dict):
+            if cacheable:
+                self._snapshot_cache_token = token
+                self._snapshot_cache = payload
             return payload
+        if cacheable:
+            self._snapshot_cache_token = token
+            self._snapshot_cache = None
         return None
 
     @staticmethod
@@ -3289,9 +3383,15 @@ class EnphaseBatteryStorageChargeSensor(_EnphaseBatteryStorageBaseSensor):
 
     @property
     def extra_state_attributes(self) -> Any:
-        attrs = dict(self._snapshot() or {})
-        attrs.pop("led_status", None)
-        return attrs
+        snapshot = self._snapshot() or {}
+        sampled_at = _battery_snapshot_last_reported(snapshot)
+        return {
+            "serial_number": snapshot.get("serial_number") or self._sn,
+            "status": snapshot.get("status"),
+            "sampled_at_utc": (
+                sampled_at.isoformat() if sampled_at is not None else None
+            ),
+        }
 
 
 class EnphaseBatteryStorageStatusSensor(_EnphaseBatteryStorageBaseSensor):
@@ -3435,6 +3535,19 @@ class EnphaseBatteryStorageLastReportedSensor(_EnphaseBatteryStorageBaseSensor):
 
 class _EnphaseAcBatteryStorageBaseSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
     _attr_has_entity_name = True
+    _unrecorded_attributes = frozenset(
+        {
+            "battery_id",
+            "part_number",
+            "phase",
+            "status_text",
+            "sleep_state",
+            "sleep_control_class",
+            "sleep_control_label",
+            "operating_mode",
+            "last_reported_utc",
+        }
+    )
 
     def __init__(
         self, coord: EnphaseCoordinator, serial: str, unique_suffix: str
@@ -3445,9 +3558,21 @@ class _EnphaseAcBatteryStorageBaseSensor(CoordinatorEntity, SensorEntity):  # ty
         self._attr_unique_id = (
             f"{DOMAIN}_site_{coord.site_id}_ac_battery_{self._sn}{unique_suffix}"
         )
+        self._snapshot_cache_token: tuple[int, int] | None = None
+        self._snapshot_cache: dict[str, object] | None = None
 
     def _snapshot(self) -> dict[str, object] | None:
-        return ac_battery_storage_snapshot(self._coord, self._sn)
+        coordinator_data = getattr(self._coord, "data", None)
+        battery_data = getattr(self._coord, "_ac_battery_data", None)
+        cacheable = coordinator_data is not None or battery_data is not None
+        token = (id(coordinator_data), id(battery_data))
+        if cacheable and token == self._snapshot_cache_token:
+            return self._snapshot_cache
+        snapshot = ac_battery_storage_snapshot(self._coord, self._sn)
+        if cacheable:
+            self._snapshot_cache_token = token
+            self._snapshot_cache = snapshot
+        return snapshot
 
     @staticmethod
     def _as_int(value: object) -> int | None:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -1017,6 +1017,7 @@ async def async_setup_entry(
             if isinstance(bucket_lengths, dict)
             else frozenset()
         )
+        gateway_meter_shape: tuple[bool | None, bool | None, bool | None]
         try:
             gateway_meter_shape = (
                 _gateway_meter_member(coord, "production") is not None,

--- a/tests/components/enphase_ev/test_schedule_sync.py
+++ b/tests/components/enphase_ev/test_schedule_sync.py
@@ -1166,6 +1166,26 @@ async def test_schedule_sync_callbacks_trigger_refresh(hass) -> None:
 
 
 @pytest.mark.asyncio
+async def test_schedule_sync_fresh_coordinator_update_does_not_create_task(
+    hass, monkeypatch
+) -> None:
+    payload = {
+        "meta": {"serverTimeStamp": "2025-01-01T00:00:00.000+00:00"},
+        "config": {},
+        "slots": [],
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data={"site_id": RANDOM_SITE_ID}, options={})
+    sync, _client = await _setup_sync(hass, entry, payload)
+    create_task = MagicMock()
+    monkeypatch.setattr(hass, "async_create_task", create_task)
+    sync._last_sync = dt_util.utcnow()
+
+    sync._handle_coordinator_update()
+
+    create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_schedule_sync_callbacks_fall_back_for_legacy_create_task(
     hass, monkeypatch
 ) -> None:

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -141,6 +141,168 @@ async def test_async_setup_entry_registers_entities(
 
 
 @pytest.mark.asyncio
+async def test_large_site_unchanged_update_skips_registry_reconciliation(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    """A telemetry-only update must stay constant-cost for a large site."""
+
+    from custom_components.enphase_ev.sensor import (
+        EnphaseInverterLifetimeEnergySensor,
+        async_setup_entry,
+    )
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    inverter_serials = [f"INV-{index:04d}" for index in range(500)]
+    coord._inverter_data = {  # noqa: SLF001
+        serial: {
+            "serial_number": serial,
+            "lifetime_production_wh": index * 1000,
+        }
+        for index, serial in enumerate(inverter_serials)
+    }
+    coord._inverter_order = inverter_serials  # noqa: SLF001
+    _mark_inverter_inventory_ready(coord)
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "microinverter": {
+                "type_key": "microinverter",
+                "type_label": "Microinverters",
+                "count": len(inverter_serials),
+                "devices": [{"serial_number": serial} for serial in inverter_serials],
+            }
+        },
+        ["microinverter"],
+    )
+    topology_callbacks: list[Any] = []
+    coordinator_callbacks: list[Any] = []
+    coord.async_add_topology_listener = (  # type: ignore[assignment]
+        lambda callback: topology_callbacks.append(callback) or (lambda: None)
+    )
+    coord.async_add_listener = (  # type: ignore[assignment]
+        lambda callback, *args, **kwargs: coordinator_callbacks.append(callback)
+        or (lambda: None)
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    class CountingEntities(dict[str, object]):
+        values_calls = 0
+
+        def values(self):  # type: ignore[override]
+            self.values_calls += 1
+            return super().values()
+
+    entities = CountingEntities()
+    fake_registry = SimpleNamespace(
+        entities=entities,
+        async_remove=MagicMock(),
+        async_get_entity_id=MagicMock(return_value=None),
+    )
+    monkeypatch.setattr(sensor_mod.er, "async_get", lambda _hass: fake_registry)
+    added: list[Any] = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda new, update_before_add=False: added.extend(new),
+    )
+
+    assert (
+        len(
+            [
+                entity
+                for entity in added
+                if isinstance(entity, EnphaseInverterLifetimeEnergySensor)
+            ]
+        )
+        == 500
+    )
+    capability_callback = next(
+        callback
+        for callback in coordinator_callbacks
+        if callback.__name__ == "_async_sync_capabilities"
+    )
+    lookup_calls = fake_registry.async_get_entity_id.call_count
+    values_calls = entities.values_calls
+    added_count = len(added)
+
+    capability_callback()
+
+    assert fake_registry.async_get_entity_id.call_count == lookup_calls
+    assert entities.values_calls == values_calls
+    assert len(added) == added_count
+
+    coord.tariff_billing = {"cycle": "monthly"}
+    capability_callback()
+
+    assert len(added) > added_count
+
+
+def test_per_update_device_snapshots_are_reused(coordinator_factory) -> None:
+    from custom_components.enphase_ev.sensor import (
+        EnphaseAcBatteryStorageChargeSensor,
+        EnphaseBatteryStorageChargeSensor,
+        EnphaseInverterLifetimeEnergySensor,
+    )
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._battery_storage_data = {  # noqa: SLF001
+        "BAT-1": {"serial_number": "BAT-1", "current_charge_pct": 42}
+    }
+    coord._inverter_data = {  # noqa: SLF001
+        "INV-1": {"serial_number": "INV-1", "lifetime_production_wh": 1000}
+    }
+    coord._ac_battery_data = {  # noqa: SLF001
+        "AC-1": {"serial_number": "AC-1", "current_charge_pct": 37}
+    }
+    original_battery_storage = coord.battery_storage
+    original_inverter_data = coord.inverter_data
+    original_ac_battery_storage = coord.ac_battery_storage
+    coord.battery_storage = MagicMock(side_effect=original_battery_storage)  # type: ignore[method-assign]
+    coord.inverter_data = MagicMock(side_effect=original_inverter_data)  # type: ignore[method-assign]
+    coord.ac_battery_storage = MagicMock(side_effect=original_ac_battery_storage)  # type: ignore[method-assign]
+    battery = EnphaseBatteryStorageChargeSensor(coord, "BAT-1")
+    inverter = EnphaseInverterLifetimeEnergySensor(coord, "INV-1")
+    ac_battery = EnphaseAcBatteryStorageChargeSensor(coord, "AC-1")
+
+    assert battery.available is True
+    assert battery.native_value == 42
+    assert battery.extra_state_attributes["serial_number"] == "BAT-1"
+    assert inverter.available is True
+    assert inverter.native_value == 1
+    assert inverter.extra_state_attributes["sampled_at_utc"] is None
+    assert ac_battery.native_value == 37
+    assert ac_battery.extra_state_attributes["battery_id"] is None
+    assert coord.battery_storage.call_count == 1
+    assert coord.inverter_data.call_count == 1
+    assert coord.ac_battery_storage.call_count == 1
+
+    coord.data = dict(coord.data)
+    assert battery.native_value == 42
+    assert inverter.native_value == 1
+    assert ac_battery.native_value == 37
+    assert coord.battery_storage.call_count == 2
+    assert coord.inverter_data.call_count == 2
+    assert coord.ac_battery_storage.call_count == 2
+
+    coord._battery_storage_data = {}  # noqa: SLF001
+    coord.data = dict(coord.data)
+    assert battery.native_value is None
+    assert battery.native_value is None
+    assert coord.battery_storage.call_count == 3
+
+    coord._inverter_data = {  # noqa: SLF001
+        "INV-1": {"serial_number": "INV-1", "lifetime_production_wh": "invalid"}
+    }
+    coord.data = dict(coord.data)
+    assert inverter.native_value == 1
+    coord._inverter_data = {  # noqa: SLF001
+        "INV-1": {"serial_number": "INV-1", "lifetime_production_wh": 500}
+    }
+    coord.data = dict(coord.data)
+    assert inverter.native_value == 1
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_restored_topology_adds_dynamic_entities(
     hass, config_entry, coordinator_factory
 ) -> None:
@@ -1212,8 +1374,13 @@ async def test_async_setup_entry_adds_inverter_lifetime_sensors(
     entity = inverter_entities[0]
     assert entity.native_value == pytest.approx(1500.0)
     attrs = entity.extra_state_attributes
-    assert attrs["device_id"] == 42
-    assert attrs["lifetime_production_wh"] == 1_500_000
+    assert attrs == {
+        "sampled_at_utc": None,
+        "status": None,
+        "status_text": None,
+        "rssi": None,
+    }
+    assert set(attrs) <= entity._unrecorded_attributes  # noqa: SLF001
 
     # Entity reports unavailable once the inverter snapshot is removed.
     coord._inverter_data = {}  # noqa: SLF001
@@ -3204,14 +3371,12 @@ def test_battery_storage_sensors_include_dashboard_detail_fields(
     assert charge.native_value == 48.0
     assert status.native_value == "charging"
     attrs = charge.extra_state_attributes
-    assert attrs["phase"] == "L1(A)"
-    assert attrs["operation_mode"] == "Multi-mode On Grid, Charging"
-    assert attrs["app_version"] == "3.0.8557_rel/31.44"
-    assert attrs["sw_version"] == "546-00002-01-v01"
-    assert attrs["rssi_subghz"] == 1
-    assert attrs["rssi_24ghz"] == 5
-    assert attrs["rssi_dbm"] == -61
-    assert "led_status" not in attrs
+    assert attrs == {
+        "serial_number": "BAT-1",
+        "status": "normal",
+        "sampled_at_utc": None,
+    }
+    assert set(attrs) <= charge._unrecorded_attributes  # noqa: SLF001
     assert status.extra_state_attributes["state"] == 12
 
 
@@ -6738,7 +6903,7 @@ async def test_async_setup_entry_prunes_legacy_drycontactloads_inventory_entity_
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_removes_known_dry_contact_type_inventory_entity(
+async def test_async_setup_entry_does_not_repeat_legacy_dry_contact_cleanup(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
     from custom_components.enphase_ev.sensor import async_setup_entry
@@ -6798,7 +6963,7 @@ async def test_async_setup_entry_removes_known_dry_contact_type_inventory_entity
     flag["enabled"] = True
     sync_type_cb()
 
-    fake_registry.async_remove.assert_any_call("sensor.dry_contact_inventory")
+    fake_registry.async_remove.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -3741,7 +3741,7 @@ async def test_tariff_setup_prunes_dynamic_export_for_summary_snapshot(
 
 
 @pytest.mark.asyncio
-async def test_tariff_rate_sensor_entities_resync_when_structure_changes(
+async def test_tariff_rate_structure_change_skips_retired_entity_rescan(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
     from homeassistant.helpers import entity_registry as er
@@ -3832,4 +3832,4 @@ async def test_tariff_rate_sensor_entities_resync_when_structure_changes(
         f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_peak"
     )
     assert new_unique_id not in {entity.unique_id for entity in added}
-    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is not None


### PR DESCRIPTION
## Summary

Optimize entity update processing by caching stable capability signatures, reducing repeated registry work, and avoiding unnecessary state recomputation during coordinator refreshes.

## Related Issues

Derived from the integration performance review; no tracking issue.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/schedule_sync.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_schedule_sync.py tests/components/enphase_ev/test_sensor_additional_coverage.py tests/components/enphase_ev/test_tariff.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'set -e; files=(tests/components/enphase_ev/test_*.py); export COVERAGE_FILE=/tmp/enphase_ev.coverage; python -m coverage erase; for shard in 0 1 2 3; do shard_files=(); for index in "${!files[@]}"; do if (( index % 4 == shard )); then shard_files+=("${files[$index]}"); fi; done; python -m coverage run --append -m pytest -q "${shard_files[@]}"; done; python -m coverage report -m --include=custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/schedule_sync.py --fail-under=100'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

- Targeted coverage: 6,116/6,116 statements, 100%.
- Component tests: 3,458 passed.
- Full suite: 3,590 passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed, or no documentation change was required.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid; no translation keys changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots are required for this internal performance change.

