### PR TITLE
Bound cloud refresh concurrency and backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 - Fixed config-entry unload and entity removal leaving delayed backoff, schedule,
   battery-profile recovery, or firmware refresh work running against retired
   integration objects.
+- Fixed optional or concurrent cloud reads deadlocking credential refresh while
+  the initiating request still held the shared Enlighten read limiter.
 
 ### 🔧 Improvements
 - Bound optional Enlighten request queueing and startup warmup stages, reserve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this project will be documented in this file.
   integration objects.
 
 ### 🔧 Improvements
+- Bound optional Enlighten request queueing and startup warmup stages, reserve
+  cloud-read capacity for core status traffic, and retain the last current-power
+  sample with retry backoff when that optional endpoint is unavailable.
 - Documented the IQ EV Charger device automation triggers and the integration's
   use of standard Home Assistant conditions.
 - Reused a Home Assistant-managed stateless HTTP session for cookie-authenticated

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -16,13 +16,14 @@ import hashlib
 import json
 import logging
 import re
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
 from datetime import date, datetime, timezone
 from http import HTTPStatus
 from urllib.parse import unquote, urlencode
 import uuid
 from dataclasses import dataclass
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from typing import Any, Awaitable, Callable, Iterable, cast
 
 import aiohttp
@@ -72,6 +73,7 @@ _BATTERY_CONFIG_VARIANT_SESSION_COOKIE = "official_web_session_cookie"
 _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH = "cookie_eauth_compatible"
 _BATTERY_CONFIG_VARIANT_MIXED = "mixed_auth_compatible"
 _ENLIGHTEN_READ_CONCURRENCY_LIMIT = 2
+_ENLIGHTEN_OPTIONAL_READ_CONCURRENCY_LIMIT = 1
 _LIVE_STATUS_GRID_RELAY_ENUM = {
     0: "OPER_RELAY_UNKNOWN",
     1: "OPER_RELAY_OPEN",
@@ -103,6 +105,10 @@ _OCPP_TRIGGER_MESSAGE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]{0,63}$")
 # app. A module-level limiter keeps parallel refresh helpers from creating a
 # burst of browser-like reads during one Home Assistant update cycle.
 _enlighten_read_semaphore: asyncio.Semaphore | None = None
+_enlighten_optional_read_semaphore: asyncio.Semaphore | None = None
+_enlighten_optional_read: ContextVar[bool] = ContextVar(
+    "enphase_ev_enlighten_optional_read", default=False
+)
 JsonDict = dict[str, Any]
 
 
@@ -942,6 +948,28 @@ def _get_enlighten_read_semaphore() -> asyncio.Semaphore:
     return _enlighten_read_semaphore
 
 
+def _get_enlighten_optional_read_semaphore() -> asyncio.Semaphore:
+    """Return the limiter that reserves capacity for core Enlighten reads."""
+
+    global _enlighten_optional_read_semaphore
+    if _enlighten_optional_read_semaphore is None:
+        _enlighten_optional_read_semaphore = asyncio.Semaphore(
+            _ENLIGHTEN_OPTIONAL_READ_CONCURRENCY_LIMIT
+        )
+    return _enlighten_optional_read_semaphore
+
+
+@contextmanager
+def enlighten_optional_read_scope() -> Iterator[None]:
+    """Mark browser-host reads in this context as optional background work."""
+
+    token = _enlighten_optional_read.set(True)
+    try:
+        yield
+    finally:
+        _enlighten_optional_read.reset(token)
+
+
 @asynccontextmanager
 async def _enlighten_read_request_guard(
     method: object, url: object
@@ -950,6 +978,11 @@ async def _enlighten_read_request_guard(
 
     if not _should_limit_enlighten_read_request(method, url):
         yield
+        return
+    if _enlighten_optional_read.get():
+        async with _get_enlighten_optional_read_semaphore():
+            async with _get_enlighten_read_semaphore():
+                yield
         return
     async with _get_enlighten_read_semaphore():
         yield
@@ -1190,8 +1223,8 @@ async def _request_json(
     if json_data is not None:
         req_kwargs["json"] = json_data
 
-    async with _enlighten_read_request_guard(method, url):
-        async with asyncio.timeout(timeout):
+    async with asyncio.timeout(timeout):
+        async with _enlighten_read_request_guard(method, url):
             async with session.request(
                 method, url, allow_redirects=True, **req_kwargs
             ) as resp:
@@ -4318,8 +4351,8 @@ class EnphaseEVClient:
                     base_headers, attempt_headers
                 )
 
-            async with _enlighten_read_request_guard(method, url):
-                async with asyncio.timeout(self._timeout):
+            async with asyncio.timeout(self._timeout):
+                async with _enlighten_read_request_guard(method, url):
                     async with self._request_session(
                         cookie_header_only=use_cookie_header_only
                     ) as request_session:
@@ -4607,8 +4640,8 @@ class EnphaseEVClient:
                     else:
                         base_headers[header_key] = header_value
 
-            async with _enlighten_read_request_guard(method, url):
-                async with asyncio.timeout(self._timeout):
+            async with asyncio.timeout(self._timeout):
+                async with _enlighten_read_request_guard(method, url):
                     async with self._s.request(
                         method, url, headers=base_headers, **kwargs
                     ) as r:

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -109,6 +109,9 @@ _enlighten_optional_read_semaphore: asyncio.Semaphore | None = None
 _enlighten_optional_read: ContextVar[bool] = ContextVar(
     "enphase_ev_enlighten_optional_read", default=False
 )
+_enlighten_read_limiter_bypass: ContextVar[bool] = ContextVar(
+    "enphase_ev_enlighten_read_limiter_bypass", default=False
+)
 JsonDict = dict[str, Any]
 
 
@@ -970,13 +973,26 @@ def enlighten_optional_read_scope() -> Iterator[None]:
         _enlighten_optional_read.reset(token)
 
 
+@contextmanager
+def _enlighten_reauth_read_scope() -> Iterator[None]:
+    """Let nested credential refreshes escape a limiter held by their caller."""
+
+    token = _enlighten_read_limiter_bypass.set(True)
+    try:
+        yield
+    finally:
+        _enlighten_read_limiter_bypass.reset(token)
+
+
 @asynccontextmanager
 async def _enlighten_read_request_guard(
     method: object, url: object
 ) -> AsyncIterator[None]:
     """Limit concurrent GET/HEAD requests to the Enlighten web host."""
 
-    if not _should_limit_enlighten_read_request(method, url):
+    if _enlighten_read_limiter_bypass.get() or not _should_limit_enlighten_read_request(
+        method, url
+    ):
         yield
         return
     if _enlighten_optional_read.get():
@@ -4377,7 +4393,8 @@ class EnphaseEVClient:
                                         safe_request_label,
                                     )
                                     attempt += 1
-                                    reauth_ok = await self._reauth_cb()
+                                    with _enlighten_reauth_read_scope():
+                                        reauth_ok = await self._reauth_cb()
                                     if reauth_ok:
                                         _LOGGER.debug(
                                             "Stored-credential refresh succeeded for %s; retrying request",
@@ -4649,7 +4666,9 @@ class EnphaseEVClient:
                             self._last_unauthorized_request = safe_request_label
                             if self._reauth_cb and attempt == 0:
                                 attempt += 1
-                                if await self._reauth_cb():
+                                with _enlighten_reauth_read_scope():
+                                    reauth_ok = await self._reauth_cb()
+                                if reauth_ok:
                                     continue
                             raise Unauthorized()
                         if expected_statuses and r.status in expected_statuses:

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -954,6 +954,15 @@ class EnphaseCoordinator(
                 failure_backoff_schedule_s=(60.0, 120.0, 300.0, 600.0),
                 max_backoff_s=600.0,
             ),
+            "current_power": EndpointFamilyPolicy(
+                success_ttl_s=60.0,
+                stale_after_s=900.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
             "battery_status": EndpointFamilyPolicy(
                 success_ttl_s=300.0,
                 stale_after_s=1800.0,

--- a/custom_components/enphase_ev/current_power_runtime.py
+++ b/custom_components/enphase_ev/current_power_runtime.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from datetime import timezone as _tz
 from typing import TYPE_CHECKING
 
+from .api import InvalidPayloadError
 from .log_redaction import redact_site_id, redact_text
 
 if TYPE_CHECKING:
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 CURRENT_POWER_CACHE_TTL_S = 60.0
+CURRENT_POWER_ENDPOINT_FAMILY = "current_power"
 
 
 @dataclass(slots=True)
@@ -42,11 +44,13 @@ class CurrentPowerRuntime:
     def __init__(self, coordinator: EnphaseCoordinator) -> None:
         self.coordinator = coordinator
         self._cache_until_mono: float | None = None
+        self.using_stale = False
 
     def clear(self) -> None:
         """Reset cached current power consumption samples."""
 
         self._cache_until_mono = None
+        self.using_stale = False
         CurrentPowerSample().apply_to(self.coordinator)
 
     def _cached_state_present(self) -> bool:
@@ -67,6 +71,10 @@ class CurrentPowerRuntime:
 
         fetcher = getattr(self.coordinator.client, "latest_power", None)
         if callable(fetcher):
+            if not self.coordinator._endpoint_family_should_run(
+                CURRENT_POWER_ENDPOINT_FAMILY
+            ):
+                return False
             cache_until = self._cache_until_mono
             if cache_until is not None and time.monotonic() < cache_until:
                 return False
@@ -85,11 +93,15 @@ class CurrentPowerRuntime:
         cache_until = self._cache_until_mono
         if cache_until is not None and now < cache_until:
             return
+        if not coord._endpoint_family_should_run(CURRENT_POWER_ENDPOINT_FAMILY):
+            self.using_stale = self._cached_state_present()
+            return
 
         try:
             payload = await fetcher()
         except Exception as err:  # noqa: BLE001
-            self.clear()
+            coord._note_endpoint_family_failure(CURRENT_POWER_ENDPOINT_FAMILY, err)
+            self.using_stale = self._cached_state_present()
             _LOGGER.debug(
                 "Skipping current power consumption refresh for site %s: %s",
                 redact_site_id(coord.site_id),
@@ -98,17 +110,17 @@ class CurrentPowerRuntime:
             return
 
         if not isinstance(payload, dict):
-            self.clear()
+            self._note_invalid_payload("Current-power response is not an object")
             return
 
         value = payload.get("value")
         try:
             numeric = float(str(value))
         except Exception:  # noqa: BLE001
-            self.clear()
+            self._note_invalid_payload("Current-power response has no numeric value")
             return
         if numeric != numeric or numeric in (float("inf"), float("-inf")):
-            self.clear()
+            self._note_invalid_payload("Current-power response value is not finite")
             return
 
         sampled_at = None
@@ -149,3 +161,18 @@ class CurrentPowerRuntime:
             source="app-api:get_latest_power",
         ).apply_to(coord)
         self._cache_until_mono = now + CURRENT_POWER_CACHE_TTL_S
+        self.using_stale = False
+        coord._note_endpoint_family_success(CURRENT_POWER_ENDPOINT_FAMILY)
+
+    def _note_invalid_payload(self, summary: str) -> None:
+        """Back off malformed responses while retaining the last valid sample."""
+
+        error = InvalidPayloadError(
+            summary,
+            endpoint="get_latest_power",
+            failure_kind="invalid_current_power_payload",
+        )
+        self.coordinator._note_endpoint_family_failure(
+            CURRENT_POWER_ENDPOINT_FAMILY, error
+        )
+        self.using_stale = self._cached_state_present()

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -26,7 +26,10 @@ REFRESH_TASK_ENDPOINT_FAMILIES: dict[str, str] = {
     "hems_devices_s": "inventory_topology",
     "system_dashboard_s": "inventory_topology",
     "inverters_s": "inverter_inventory",
+    "current_power_s": "current_power",
 }
+
+WARMUP_STAGE_DEADLINE_S = 60.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +46,7 @@ class RefreshStage:
     ordered_tasks: tuple[RefreshTask, ...] = ()
     stage_key: str | None = None
     defer_topology: bool = False
+    deadline_s: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,6 +55,7 @@ class BoundRefreshStage:
     ordered_calls: tuple[BoundRefreshCall, ...] = ()
     stage_key: str | None = None
     defer_topology: bool = False
+    deadline_s: float | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,6 +150,7 @@ def bind_refresh_stage(owner: object, stage: RefreshStage) -> BoundRefreshStage:
         ordered_calls=bind_refresh_tasks(owner, stage.ordered_tasks),
         stage_key=stage.stage_key,
         defer_topology=stage.defer_topology,
+        deadline_s=stage.deadline_s,
     )
 
 
@@ -157,6 +163,7 @@ def bind_refresh_plan(owner: object, plan: RefreshPlan) -> BoundRefreshPlan:
 WARMUP_DISCOVERY_STAGE = RefreshStage(
     stage_key="discovery",
     defer_topology=True,
+    deadline_s=WARMUP_STAGE_DEADLINE_S,
     parallel_tasks=(
         method_task(
             "battery_site_settings_s",
@@ -195,6 +202,7 @@ WARMUP_DISCOVERY_STAGE = RefreshStage(
 
 WARMUP_STATE_STAGE = RefreshStage(
     stage_key="state",
+    deadline_s=WARMUP_STAGE_DEADLINE_S,
     parallel_tasks=(
         method_task(
             "battery_backup_history_s",
@@ -418,6 +426,7 @@ FOLLOWUP_PLAN = RefreshPlan(stages=(FOLLOWUP_STAGE,))
 def warmup_energy_stage(working_data: dict[str, dict[str, object]]) -> RefreshStage:
     return RefreshStage(
         stage_key="energy",
+        deadline_s=WARMUP_STAGE_DEADLINE_S,
         parallel_tasks=(
             object_method_task(
                 "site_energy_s",
@@ -451,11 +460,15 @@ def warmup_energy_stage(working_data: dict[str, dict[str, object]]) -> RefreshSt
 
 
 def warmup_plan(working_data: dict[str, dict[str, object]]) -> RefreshPlan:
+    warmup_heatpump_stage = RefreshStage(
+        ordered_tasks=HEATPUMP_FOLLOWUP_STAGE.ordered_tasks,
+        deadline_s=WARMUP_STAGE_DEADLINE_S,
+    )
     return RefreshPlan(
         stages=(
             WARMUP_DISCOVERY_STAGE,
             WARMUP_STATE_STAGE,
-            HEATPUMP_FOLLOWUP_STAGE,
+            warmup_heatpump_stage,
             warmup_energy_stage(working_data),
         )
     )

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -18,6 +18,7 @@ from .api import (
     EnphaseLoginWallUnauthorized,
     InvalidPayloadError,
     OptionalEndpointUnavailable,
+    enlighten_optional_read_scope,
 )
 from .const import DOMAIN, DEFAULT_CHARGE_LEVEL_SETTING, PHASE_SWITCH_CONFIG_SETTING
 from .log_redaction import redact_site_id, redact_text
@@ -79,9 +80,10 @@ class RefreshRunner:
     ) -> tuple[str, float | None]:
         started = time.monotonic()
         try:
-            result = callback_factory()
-            if inspect.isawaitable(result):
-                await result
+            with enlighten_optional_read_scope():
+                result = callback_factory()
+                if inspect.isawaitable(result):
+                    await result
         except asyncio.CancelledError:
             raise
         except EnphaseLoginWallUnauthorized as err:
@@ -225,6 +227,7 @@ class RefreshRunner:
         ordered_calls: tuple[BoundRefreshCall, ...] = (),
         stage_key: str | None = None,
         defer_topology: bool = False,
+        deadline_s: float | None = None,
     ) -> None:
         if not parallel_calls and not ordered_calls:
             if stage_key is not None:
@@ -234,8 +237,7 @@ class RefreshRunner:
         if defer_topology:
             self._coordinator._begin_topology_refresh_batch()
 
-        group_started = time.monotonic()
-        try:
+        async def _async_run_stage() -> None:
             if parallel_calls:
                 await self.async_run_refresh_calls(
                     phase_timings,
@@ -246,6 +248,24 @@ class RefreshRunner:
                     phase_timings,
                     calls=ordered_calls,
                 )
+
+        group_started = time.monotonic()
+        try:
+            if deadline_s is None:
+                await _async_run_stage()
+            else:
+                try:
+                    async with asyncio.timeout(deadline_s):
+                        await _async_run_stage()
+                except TimeoutError:
+                    timeout_key = f"{stage_key or 'stage'}_deadline_exceeded"
+                    phase_timings[timeout_key] = 1.0
+                    _LOGGER.debug(
+                        "Stopped optional %s refresh stage for site %s after %.1f seconds",
+                        stage_key or "unnamed",
+                        redact_site_id(self._coordinator.site_id),
+                        deadline_s,
+                    )
         finally:
             if defer_topology:
                 self._coordinator._end_topology_refresh_batch()
@@ -267,6 +287,7 @@ class RefreshRunner:
                 defer_topology=stage.defer_topology,
                 parallel_calls=stage.parallel_calls,
                 ordered_calls=stage.ordered_calls,
+                deadline_s=stage.deadline_s,
             )
 
     async def async_startup_warmup_runner(self) -> None:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -6285,6 +6285,7 @@ class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity, RestoreSensor):  # t
             "source": source,
             "reported_units": units,
             "reported_precision": precision,
+            "using_stale": bool(self._coord.current_power_runtime.using_stale),
         }
 
     @property

--- a/tests/components/enphase_ev/test_api_http_flow.py
+++ b/tests/components/enphase_ev/test_api_http_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import asyncio
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -108,6 +109,57 @@ def test_should_limit_enlighten_read_request_handles_bad_string_casts() -> None:
 
     assert api._should_limit_enlighten_read_request(BadMethod(), api.BASE_URL) is False
     assert api._should_limit_enlighten_read_request("GET", BadUrl()) is False
+
+
+@pytest.mark.asyncio
+async def test_enlighten_request_timeout_includes_limiter_queue(monkeypatch) -> None:
+    limiter = asyncio.Semaphore(0)
+    monkeypatch.setattr(api, "_enlighten_read_semaphore", limiter)
+    session = FakeSession([FakeResponse(json_body={"ok": True})])
+
+    with pytest.raises(TimeoutError):
+        await api._request_json(
+            session, "GET", f"{api.BASE_URL}/service/test", timeout=0.01
+        )
+
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_optional_enlighten_reads_reserve_capacity_for_core(monkeypatch) -> None:
+    monkeypatch.setattr(api, "_enlighten_read_semaphore", asyncio.Semaphore(2))
+    monkeypatch.setattr(api, "_enlighten_optional_read_semaphore", asyncio.Semaphore(1))
+    release = asyncio.Event()
+    first_optional_entered = asyncio.Event()
+    second_optional_entered = asyncio.Event()
+    core_entered = asyncio.Event()
+
+    async def _optional(entered: asyncio.Event) -> None:
+        with api.enlighten_optional_read_scope():
+            async with api._enlighten_read_request_guard(  # noqa: SLF001
+                "GET", f"{api.BASE_URL}/service/optional"
+            ):
+                entered.set()
+                await release.wait()
+
+    async def _core() -> None:
+        async with api._enlighten_read_request_guard(  # noqa: SLF001
+            "GET", f"{api.BASE_URL}/service/core"
+        ):
+            core_entered.set()
+            await release.wait()
+
+    first = asyncio.create_task(_optional(first_optional_entered))
+    await asyncio.wait_for(first_optional_entered.wait(), timeout=1)
+    second = asyncio.create_task(_optional(second_optional_entered))
+    core = asyncio.create_task(_core())
+    await asyncio.wait_for(core_entered.wait(), timeout=1)
+
+    assert second_optional_entered.is_set() is False
+
+    release.set()
+    await asyncio.gather(first, second, core)
+    assert second_optional_entered.is_set() is True
 
 
 def test_cookie_header_from_map_empty() -> None:

--- a/tests/components/enphase_ev/test_api_http_flow.py
+++ b/tests/components/enphase_ev/test_api_http_flow.py
@@ -162,6 +162,44 @@ async def test_optional_enlighten_reads_reserve_capacity_for_core(monkeypatch) -
     assert second_optional_entered.is_set() is True
 
 
+@pytest.mark.asyncio
+async def test_optional_read_reauth_does_not_deadlock_on_held_limiter(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(api, "_enlighten_read_semaphore", asyncio.Semaphore(2))
+    monkeypatch.setattr(api, "_enlighten_optional_read_semaphore", asyncio.Semaphore(1))
+    session = FakeSession(
+        [
+            FakeResponse(status=401),
+            FakeResponse(json_body={"refreshed": True}),
+            FakeResponse(json_body={"ok": True}),
+        ]
+    )
+    client = api.EnphaseEVClient(session, "SITE", None, None, timeout=1)
+
+    async def _reauth() -> bool:
+        payload = await api._request_json(
+            session,
+            "GET",
+            f"{api.BASE_URL}/login/refresh",
+            timeout=0.2,
+        )
+        return payload == {"refreshed": True}
+
+    client.set_reauth_callback(_reauth)
+    with api.enlighten_optional_read_scope():
+        payload = await asyncio.wait_for(
+            client._json("GET", f"{api.BASE_URL}/service/optional"), timeout=0.5
+        )
+
+    assert payload == {"ok": True}
+    assert [call[1] for call in session.calls] == [
+        f"{api.BASE_URL}/service/optional",
+        f"{api.BASE_URL}/login/refresh",
+        f"{api.BASE_URL}/service/optional",
+    ]
+
+
 def test_cookie_header_from_map_empty() -> None:
     assert api._cookie_header_from_map(None) == ""
     assert api._cookie_header_from_map({}) == ""

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -17,6 +17,9 @@ from custom_components.enphase_ev.refresh_plan import (
     FOLLOWUP_PLAN,
     HEATPUMP_FOLLOWUP_PLAN,
     SITE_ONLY_FOLLOWUP_PLAN,
+    RefreshPlan,
+    RefreshStage,
+    callback_task,
     bind_refresh_stage,
     bind_refresh_plan,
     build_followup_plan,
@@ -750,6 +753,7 @@ async def test_coordinator_refresh_plan_runner_executes_each_stage(
         ordered_calls,
         stage_key=None,
         defer_topology=False,
+        deadline_s=None,
     ) -> None:
         seen.append(
             (
@@ -1006,6 +1010,47 @@ async def test_refresh_runner_staged_calls_track_empty_stage_timing(
     await runner.async_run_staged_refresh_calls(phase_timings, stage_key="empty")
 
     assert phase_timings == {"empty_s": 0.0}
+
+
+@pytest.mark.asyncio
+async def test_refresh_plan_deadline_cancels_stage_and_continues(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    slow_cancelled = asyncio.Event()
+    later_stage_ran = asyncio.Event()
+
+    async def _slow(_owner) -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            slow_cancelled.set()
+            raise
+
+    async def _later(_owner) -> None:
+        later_stage_ran.set()
+
+    plan = RefreshPlan(
+        stages=(
+            RefreshStage(
+                stage_key="bounded",
+                deadline_s=0.01,
+                parallel_tasks=(callback_task("slow_s", "slow", _slow),),
+            ),
+            RefreshStage(
+                stage_key="later",
+                parallel_tasks=(callback_task("later_s", "later", _later),),
+            ),
+        )
+    )
+    timings: dict[str, float] = {}
+
+    await coord.refresh_runner.async_run_refresh_plan(timings, plan=plan)
+
+    assert slow_cancelled.is_set() is True
+    assert later_stage_ran.is_set() is True
+    assert timings["bounded_deadline_exceeded"] == 1.0
+    assert timings["bounded_s"] >= 0.0
 
 
 def test_coordinator_lazily_creates_refresh_runner() -> None:

--- a/tests/components/enphase_ev/test_current_power_runtime.py
+++ b/tests/components/enphase_ev/test_current_power_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -83,19 +84,27 @@ async def test_async_refresh_fetcher_raises(coordinator_factory) -> None:
 
     await coord.current_power_runtime.async_refresh()
 
-    assert coord._current_power_consumption_w is None
+    assert coord._current_power_consumption_w == 100.0
+    assert coord.current_power_runtime.using_stale is True
+    assert (
+        coord._endpoint_family_state("current_power").consecutive_failures == 1
+    )  # noqa: SLF001
 
 
+@pytest.mark.parametrize("payload", [None, "x", {}, {"value": "nope"}])
 @pytest.mark.asyncio
-async def test_async_refresh_invalid_payload_shapes(coordinator_factory) -> None:
+async def test_async_refresh_invalid_payload_shapes(
+    coordinator_factory, payload
+) -> None:
     coord = coordinator_factory()
-    coord.client = SimpleNamespace(
-        latest_power=AsyncMock(side_effect=[None, "x", {}, {"value": "nope"}])
-    )
+    coord.client = SimpleNamespace(latest_power=AsyncMock(return_value=payload))
 
-    for _ in range(4):
-        await coord.current_power_runtime.async_refresh()
-        assert coord._current_power_consumption_w is None
+    await coord.current_power_runtime.async_refresh()
+
+    assert coord._current_power_consumption_w is None
+    assert (
+        coord._endpoint_family_state("current_power").consecutive_failures == 1
+    )  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -163,6 +172,47 @@ async def test_async_refresh_skips_fetch_inside_success_cache_ttl(
 
     assert fetcher.await_count == 1
     assert coord._current_power_consumption_w == 42.5
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_failure_preserves_sample_and_suppresses_retry(
+    coordinator_factory,
+    monkeypatch,
+) -> None:
+    coord = coordinator_factory()
+    fetcher = AsyncMock(
+        side_effect=[{"value": 42.5, "units": "W"}, RuntimeError("network")]
+    )
+    coord.client = SimpleNamespace(latest_power=fetcher)
+    monotonic = 100.0
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.current_power_runtime.time.monotonic",
+        lambda: monotonic,
+    )
+
+    await coord.current_power_runtime.async_refresh()
+    coord._endpoint_family_state("current_power").next_retry_mono = None  # noqa: SLF001
+    monotonic = 161.0
+    await coord.current_power_runtime.async_refresh()
+    monotonic = 200.0
+    await coord.current_power_runtime.async_refresh()
+
+    assert fetcher.await_count == 2
+    assert coord._current_power_consumption_w == 42.5
+    assert coord._current_power_consumption_reported_units == "W"
+    assert coord.current_power_runtime.using_stale is True
+
+
+def test_refresh_due_suppresses_current_power_during_failure_backoff(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client = SimpleNamespace(latest_power=AsyncMock())
+    coord._endpoint_family_state("current_power").next_retry_mono = (  # noqa: SLF001
+        time.monotonic() + 300.0
+    )
+
+    assert coord.current_power_runtime.refresh_due() is False
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_latency_and_connectivity.py
+++ b/tests/components/enphase_ev/test_latency_and_connectivity.py
@@ -61,6 +61,7 @@ def test_current_power_consumption_sensor_value_and_attributes():
         "source": "app-api:get_latest_power",
         "reported_units": "W",
         "reported_precision": 0,
+        "using_stale": False,
     }
 
 
@@ -148,6 +149,7 @@ def test_current_power_consumption_sensor_keeps_fresh_last_good_runtime_sample(
         "source": "app-api:get_latest_power",
         "reported_units": "W",
         "reported_precision": 0,
+        "using_stale": False,
     }
 
 
@@ -265,6 +267,7 @@ async def test_current_power_consumption_sensor_restores_last_good_state(
         "source": "app-api:get_latest_power",
         "reported_units": "W",
         "reported_precision": None,
+        "using_stale": False,
     }
 
 
@@ -348,6 +351,7 @@ async def test_current_power_consumption_sensor_restore_prefers_cached_at_freshn
         "source": "app-api:get_latest_power",
         "reported_units": "W",
         "reported_precision": 0,
+        "using_stale": False,
     }
 
 


### PR DESCRIPTION
## Summary

Bound optional cloud refresh work, add backoff-aware request scheduling, and prevent nested reauthentication limiter deadlocks under concurrent refresh load.

## Related Issues

Derived from the integration performance review; no tracking issue.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/current_power_runtime.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/refresh_runner.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_api_http_flow.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_current_power_runtime.py tests/components/enphase_ev/test_latency_and_connectivity.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'set -e; files=(tests/components/enphase_ev/test_*.py); export COVERAGE_FILE=/tmp/enphase_ev.coverage; python -m coverage erase; for shard in 0 1 2 3; do shard_files=(); for index in "${!files[@]}"; do if (( index % 4 == shard )); then shard_files+=("${files[$index]}"); fi; done; python -m coverage run --append -m pytest -q "${shard_files[@]}"; done; python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/current_power_runtime.py,custom_components/enphase_ev/refresh_plan.py,custom_components/enphase_ev/refresh_runner.py,custom_components/enphase_ev/sensor.py --fail-under=100'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

- Targeted coverage: 13,796/13,796 statements, 100%.
- Component tests: 3,464 passed.
- Full suite: 3,596 passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed, or no documentation change was required.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid; no translation keys changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The limiter remains cancellation-safe and the tests cover concurrent reauthentication and optional refresh saturation.

