### PR TITLE
Optimize discovery snapshots and request metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ All notable changes to this project will be documented in this file.
   battery and microinverter snapshots, and excluding diagnostic device metadata
   from recorder history. Detailed inverter and battery metadata remains available
   in integration diagnostics.
+- Reduced refresh overhead by persisting compact discovery identity metadata only
+  when its revision changes, and made cloud-call diagnostics operation-scoped so
+  background work no longer inflates coordinator refresh counts.
+- Added failed and cancelled refreshes plus request queue, network, and parsing
+  timing totals to the rolling refresh performance diagnostics when available.
 
 ### 🔄 Other changes
 - None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ All notable changes to this project will be documented in this file.
   integration objects.
 - Fixed optional or concurrent cloud reads deadlocking credential refresh while
   the initiating request still held the shared Enlighten read limiter.
+- Preserved pending discovery snapshots when a storage write is cancelled so a
+  later refresh can retry persistence instead of losing the observed revision.
 
 ### 🔧 Improvements
 - Bound optional Enlighten request queueing and startup warmup stages, reserve

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -52,6 +52,7 @@ from .api_models import (
     TextResponse as TextResponse,
 )
 from .log_redaction import redact_identifier, redact_site_id, redact_text
+from .request_metrics import record_request_attempt
 
 _LOGGER = logging.getLogger(__name__)
 _EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b")
@@ -4373,6 +4374,7 @@ class EnphaseEVClient:
                         cookie_header_only=use_cookie_header_only
                     ) as request_session:
                         self._request_count += 1
+                        record_request_attempt()
                         async with request_session.request(
                             method, url, headers=base_headers, **kwargs
                         ) as r:

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -172,6 +172,7 @@ from .session_history import (
     SessionHistoryManager,
 )
 from .coordinator_refresh_metrics import record_refresh_performance_sample
+from .request_metrics import RequestMetrics, request_metrics_scope
 from .summary import SummaryStore
 from . import system_dashboard_helpers as sd_helpers
 from .refresh_plan import (
@@ -504,6 +505,8 @@ class RefreshPipelineContext:
     status_stale_network_failure: bool = False
     status_stale_dns_failure: bool = False
     fast_poll: bool = False
+    request_metrics: RequestMetrics | None = None
+    performance_recorded: bool = False
 
 
 class EnphaseCoordinator(
@@ -2819,9 +2822,6 @@ class EnphaseCoordinator(
         refresh_started_utc = dt_util.utcnow()
         if refresh_started_utc.tzinfo is None:
             refresh_started_utc = refresh_started_utc.replace(tzinfo=_tz.utc)
-        reset_request_count = getattr(self.client, "reset_request_count", None)
-        if callable(reset_request_count):
-            reset_request_count()
         fallback_data: dict[str, dict[str, object]] = {}
         if isinstance(self.data, dict):
             try:
@@ -3138,22 +3138,30 @@ class EnphaseCoordinator(
                 return True
         return False
 
-    def _finish_refresh_pipeline(
+    def _record_refresh_pipeline_performance(
         self,
         context: RefreshPipelineContext,
+        *,
+        outcome: str,
     ) -> None:
+        if context.performance_recorded:
+            return
         phase_timings = context.phase_timings
+        if context.request_metrics is not None:
+            phase_timings.update(context.request_metrics.phase_timings())
         phase_timings["total_s"] = round(time.monotonic() - context.started_mono, 3)
         self._phase_timings = phase_timings.copy()
-        request_count = getattr(self.client, "request_count", None)
-        if isinstance(request_count, int):
+        request_count = (
+            context.request_metrics.attempts
+            if context.request_metrics is not None
+            else None
+        )
+        if request_count is not None:
             self._last_refresh_cloud_calls = request_count
             if context.fast_poll:
                 self._last_fast_refresh_cloud_calls = request_count
             else:
                 self._last_steady_refresh_cloud_calls = request_count
-        else:
-            request_count = None
         self._refresh_performance_history = record_refresh_performance_sample(
             getattr(self, "_refresh_performance_history", []),
             phase_timings,
@@ -3165,14 +3173,40 @@ class EnphaseCoordinator(
             payload_using_stale=getattr(context, "status_used_stale", False)
             or bool(getattr(self, "payload_using_stale", False)),
             manual_bypass=self.endpoint_manual_bypass_active(),
+            outcome=outcome,
         )
-        if context.first_refresh:
+        context.performance_recorded = True
+        if context.first_refresh and outcome == "success":
             self._bootstrap_phase_timings = phase_timings.copy()
+
+    def _finish_refresh_pipeline(
+        self,
+        context: RefreshPipelineContext,
+    ) -> None:
+        self._record_refresh_pipeline_performance(context, outcome="success")
         self._refresh_cached_topology()
         self.discovery_snapshot.schedule_save()
 
     async def _async_update_data(self) -> dict[str, dict[str, object]]:
-        context = self._start_refresh_pipeline()
+        with request_metrics_scope("core_refresh") as request_metrics:
+            context = self._start_refresh_pipeline()
+            context.request_metrics = request_metrics
+            outcome = "success"
+            try:
+                return await self._async_update_data_impl(context)
+            except asyncio.CancelledError:
+                outcome = "cancelled"
+                raise
+            except BaseException:
+                outcome = "failed"
+                raise
+            finally:
+                self._record_refresh_pipeline_performance(context, outcome=outcome)
+
+    async def _async_update_data_impl(
+        self,
+        context: RefreshPipelineContext,
+    ) -> dict[str, dict[str, object]]:
         t0 = context.started_mono
         refresh_started_utc = context.refresh_started_utc
         phase_timings = context.phase_timings

--- a/custom_components/enphase_ev/coordinator_refresh_metrics.py
+++ b/custom_components/enphase_ev/coordinator_refresh_metrics.py
@@ -102,6 +102,7 @@ def record_refresh_performance_sample(
     first_refresh: bool = False,
     payload_using_stale: bool = False,
     manual_bypass: bool = False,
+    outcome: str = "success",
     max_samples: int = REFRESH_PERFORMANCE_HISTORY_LIMIT,
 ) -> list[dict[str, object]]:
     """Append a diagnostics-safe refresh sample and return the trimmed history."""
@@ -125,6 +126,7 @@ def record_refresh_performance_sample(
         "first_refresh": bool(first_refresh),
         "payload_using_stale": bool(payload_using_stale),
         "manual_bypass": bool(manual_bypass),
+        "outcome": str(outcome),
     }
     if refresh_started_utc is not None:
         try:
@@ -151,6 +153,8 @@ def refresh_performance_history_summary(
     first_refresh_count = 0
     stale_count = 0
     manual_bypass_count = 0
+    failed_count = 0
+    cancelled_count = 0
     for sample in samples:
         if sample.get("fast_poll"):
             fast_count += 1
@@ -160,6 +164,10 @@ def refresh_performance_history_summary(
             stale_count += 1
         if sample.get("manual_bypass"):
             manual_bypass_count += 1
+        if sample.get("outcome") == "failed":
+            failed_count += 1
+        elif sample.get("outcome") == "cancelled":
+            cancelled_count += 1
         try:
             total = float(str(sample["total_s"]))
         except (KeyError, TypeError, ValueError):
@@ -189,6 +197,8 @@ def refresh_performance_history_summary(
         "first_refresh_count": first_refresh_count,
         "payload_using_stale_count": stale_count,
         "manual_bypass_count": manual_bypass_count,
+        "failed_count": failed_count,
+        "cancelled_count": cancelled_count,
         "total_s": _numeric_summary(total_values),
         "cloud_calls": {
             "count": cloud_summary["count"],

--- a/custom_components/enphase_ev/discovery_snapshot.py
+++ b/custom_components/enphase_ev/discovery_snapshot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from datetime import datetime
@@ -603,6 +604,13 @@ class DiscoverySnapshotManager:
         self._save_in_progress = True
         try:
             await self._store.async_save(snapshot)
+        except asyncio.CancelledError:
+            if self._pending_snapshot is None:
+                self._pending_snapshot = snapshot
+                self._pending_signature = signature
+                self._pending_revision = revision
+            self.coordinator._discovery_snapshot_pending = True
+            raise
         except Exception:  # noqa: BLE001
             _LOGGER.debug(
                 "Failed to save discovery snapshot for site %s",

--- a/custom_components/enphase_ev/discovery_snapshot.py
+++ b/custom_components/enphase_ev/discovery_snapshot.py
@@ -21,6 +21,149 @@ _LOGGER = logging.getLogger(__name__)
 DISCOVERY_SNAPSHOT_STORE_VERSION = 1
 DISCOVERY_SNAPSHOT_SAVE_DELAY_S = 1.0
 
+_DISCOVERY_RECORD_KEYS = frozenset(
+    {
+        "array_name",
+        "battery_id",
+        "channel_type",
+        "channelType",
+        "application-version",
+        "applicationVersion",
+        "application_version",
+        "ap_mode",
+        "device-id",
+        "device-type",
+        "device-uid",
+        "device_id",
+        "device_sn",
+        "device_type",
+        "device_uid",
+        "fw1",
+        "fw2",
+        "firmware-version",
+        "firmwareVersion",
+        "firmware_version",
+        "hardware_sku",
+        "hardware-version",
+        "hardwareVersion",
+        "hardware_version",
+        "hems_device_facet_id",
+        "hems_device_id",
+        "id",
+        "identity",
+        "inverter_id",
+        "inverter_type",
+        "ip",
+        "ip_address",
+        "iqer_uid",
+        "manufacturer",
+        "model",
+        "model_name",
+        "modelId",
+        "model_id",
+        "name",
+        "part_num",
+        "part_number",
+        "parent",
+        "parentDeviceUid",
+        "parentId",
+        "parentUid",
+        "parent_device_uid",
+        "parent_id",
+        "parent_uid",
+        "phase",
+        "serial",
+        "serialNumber",
+        "serial_number",
+        "sku",
+        "sku_id",
+        "sn",
+        "software-version",
+        "softwareVersion",
+        "software_version",
+        "supportsEntrez",
+        "sw_version",
+        "system_version",
+        "type",
+        "type_label",
+        "uid",
+    }
+)
+
+
+def _is_discovery_record_key(key: object) -> bool:
+    key_text = str(key)
+    if key_text in _DISCOVERY_RECORD_KEYS:
+        return True
+    normalized = key_text.strip().lower().replace("-", "_")
+    return bool(
+        normalized.endswith(("_id", "_uid", "_version"))
+        or normalized.startswith(("has_", "supports_"))
+        or any(
+            token in normalized
+            for token in (
+                "capability",
+                "device_type",
+                "firmware",
+                "hardware_sku",
+                "model",
+                "parent",
+                "serial",
+            )
+        )
+    )
+
+
+def _compact_discovery_record(record: object) -> dict[str, object]:
+    """Return only stable identity and capability fields used for discovery."""
+
+    if not isinstance(record, dict):
+        return {}
+    return {
+        str(key): _snapshot_compatible_value(value)
+        for key, value in record.items()
+        if _is_discovery_record_key(key) and value is not None
+    }
+
+
+def _compact_type_buckets(value: object) -> dict[str, object]:
+    """Compact inventory buckets without persisting changing telemetry."""
+
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, object] = {}
+    for raw_key, raw_bucket in value.items():
+        if not isinstance(raw_bucket, dict):
+            continue
+        bucket: dict[str, object] = {}
+        for key in ("count", "type_label", "model_counts", "model_summary"):
+            item = raw_bucket.get(key)
+            if item is not None:
+                bucket[key] = _snapshot_compatible_value(item)
+        members = raw_bucket.get("devices")
+        if isinstance(members, list):
+            bucket["devices"] = [
+                compact_member
+                for member in members
+                if (compact_member := _compact_discovery_record(member))
+            ]
+        else:
+            bucket["devices"] = []
+        compact[str(raw_key)] = bucket
+    return compact
+
+
+def _compact_keyed_records(value: object) -> dict[str, object]:
+    """Compact a serial-keyed discovery mapping."""
+
+    if not isinstance(value, dict):
+        return {}
+    return {
+        str(key): _compact_discovery_record(record)
+        for key, record in value.items()
+        if isinstance(record, dict)
+    }
+
 
 def _snapshot_compatible_value(value: object) -> object:
     if value is None or isinstance(value, (bool, int, float, str)):
@@ -72,6 +215,13 @@ class DiscoverySnapshotManager:
             f"{DOMAIN}.discovery_snapshot.{entry_id}",
         )
         self._last_persisted_signature: str | None = None
+        self._revision = 0
+        self._persisted_revision = -1
+        self._last_observed_key: object | None = None
+        self._pending_snapshot: dict[str, object] | None = None
+        self._pending_signature: str | None = None
+        self._pending_revision: int | None = None
+        self._save_in_progress = False
 
     def _snapshot_signature(self, snapshot: object) -> str:
         compatible = _snapshot_compatible_value(snapshot)
@@ -88,6 +238,79 @@ class DiscoverySnapshotManager:
 
     def _mark_persisted(self, snapshot: object) -> None:
         self._last_persisted_signature = self._snapshot_signature(snapshot)
+
+    @staticmethod
+    def _record_key(record: object) -> tuple[tuple[str, str], ...]:
+        compact = _compact_discovery_record(record)
+        return tuple(sorted((key, repr(value)) for key, value in compact.items()))
+
+    def _discovery_key(self) -> tuple[object, ...]:
+        """Build a lightweight key for discovery-affecting coordinator state."""
+
+        type_buckets = getattr(self.coordinator, "_type_device_buckets", {}) or {}
+        type_key: list[object] = []
+        if isinstance(type_buckets, dict):
+            for raw_key, raw_bucket in type_buckets.items():
+                if not isinstance(raw_bucket, dict):
+                    continue
+                members = raw_bucket.get("devices")
+                member_keys = (
+                    tuple(self._record_key(member) for member in members)
+                    if isinstance(members, list)
+                    else ()
+                )
+                type_key.append(
+                    (
+                        str(raw_key),
+                        raw_bucket.get("count"),
+                        raw_bucket.get("type_label"),
+                        member_keys,
+                    )
+                )
+        battery_data = getattr(self.coordinator, "_battery_storage_data", {}) or {}
+        battery_key = (
+            tuple(
+                (str(key), self._record_key(record))
+                for key, record in battery_data.items()
+            )
+            if isinstance(battery_data, dict)
+            else ()
+        )
+        inverter_data = getattr(self.coordinator, "_inverter_data", {}) or {}
+        inverter_key = (
+            tuple(
+                (str(key), self._record_key(record))
+                for key, record in inverter_data.items()
+            )
+            if isinstance(inverter_data, dict)
+            else ()
+        )
+        return (
+            tuple(self.coordinator.iter_serials()),
+            tuple(getattr(self.coordinator, "_type_device_order", []) or []),
+            tuple(type_key),
+            tuple(getattr(self.coordinator, "_battery_storage_order", []) or []),
+            battery_key,
+            tuple(getattr(self.coordinator, "_inverter_order", []) or []),
+            inverter_key,
+            getattr(self.coordinator, "_battery_has_encharge", None),
+            getattr(self.coordinator, "_battery_has_enpower", None),
+            bool(getattr(self.coordinator, "_heatpump_known_present", False)),
+            bool(getattr(self.coordinator, "_site_energy_discovery_ready", False)),
+            tuple(sorted(self.live_site_energy_channels())),
+            tuple(
+                self._record_key(record)
+                for record in self.gateway_iq_energy_router_records()
+            ),
+        )
+
+    def _observe_revision(self) -> bool:
+        key = self._discovery_key()
+        if key == self._last_observed_key:
+            return False
+        self._last_observed_key = key
+        self._revision += 1
+        return True
 
     def live_site_energy_channels(self) -> set[str]:
         channels: set[str] = set()
@@ -190,20 +413,20 @@ class DiscoverySnapshotManager:
             "type_device_order": list(
                 getattr(self.coordinator, "_type_device_order", []) or []
             ),
-            "type_device_buckets": _snapshot_compatible_value(
-                dict(getattr(self.coordinator, "_type_device_buckets", {}) or {})
+            "type_device_buckets": _compact_type_buckets(
+                getattr(self.coordinator, "_type_device_buckets", {})
             ),
             "battery_storage_order": list(
                 getattr(self.coordinator, "_battery_storage_order", []) or []
             ),
-            "battery_storage_data": _snapshot_compatible_value(
-                dict(getattr(self.coordinator, "_battery_storage_data", {}) or {})
+            "battery_storage_data": _compact_keyed_records(
+                getattr(self.coordinator, "_battery_storage_data", {})
             ),
             "inverter_order": list(
                 getattr(self.coordinator, "_inverter_order", []) or []
             ),
-            "inverter_data": _snapshot_compatible_value(
-                dict(getattr(self.coordinator, "_inverter_data", {}) or {})
+            "inverter_data": _compact_keyed_records(
+                getattr(self.coordinator, "_inverter_data", {})
             ),
             "battery_has_encharge": getattr(
                 self.coordinator, "_battery_has_encharge", None
@@ -222,9 +445,11 @@ class DiscoverySnapshotManager:
                 )
             ),
             "site_energy_channels": sorted(site_energy_channels),
-            "gateway_iq_energy_router_records": _snapshot_compatible_value(
-                router_records
-            ),
+            "gateway_iq_energy_router_records": [
+                compact
+                for record in router_records
+                if (compact := _compact_discovery_record(record))
+            ],
         }
         return snapshot
 
@@ -335,7 +560,11 @@ class DiscoverySnapshotManager:
                 dict(item) for item in restored_router_records if isinstance(item, dict)
             ]
         self.coordinator._refresh_cached_topology()
+        # Normalize legacy/full snapshots to the compact representation once on
+        # restore so the next unchanged refresh does not rewrite storage.
         self._mark_persisted(self.capture())
+        self._last_observed_key = self._discovery_key()
+        self._persisted_revision = self._revision
 
     async def async_restore_state(self) -> None:
         if self.coordinator._discovery_snapshot_loaded:
@@ -356,10 +585,22 @@ class DiscoverySnapshotManager:
         self.apply(snapshot)
 
     async def async_save(self) -> None:
+        if self._pending_snapshot is None:
+            self._observe_revision()
+            snapshot, signature = self._capture_signature()
+            revision = self._revision
+        else:
+            snapshot = self._pending_snapshot
+            signature = self._pending_signature or self._snapshot_signature(snapshot)
+            revision = self._pending_revision or self._revision
+        self._pending_snapshot = None
+        self._pending_signature = None
+        self._pending_revision = None
         self.coordinator._discovery_snapshot_pending = False
-        snapshot, signature = self._capture_signature()
         if signature == self._last_persisted_signature:
+            self._persisted_revision = max(self._persisted_revision, revision)
             return
+        self._save_in_progress = True
         try:
             await self._store.async_save(snapshot)
         except Exception:  # noqa: BLE001
@@ -368,16 +609,45 @@ class DiscoverySnapshotManager:
                 redact_site_id(self.coordinator.site_id),
                 exc_info=True,
             )
+            if self._pending_snapshot is None:
+                self._pending_snapshot = snapshot
+                self._pending_signature = signature
+                self._pending_revision = revision
+                self.coordinator._discovery_snapshot_pending = True
             return
+        finally:
+            self._save_in_progress = False
         self._last_persisted_signature = signature
+        self._persisted_revision = max(self._persisted_revision, revision)
+        if self._pending_snapshot is not None:
+            self.coordinator._discovery_snapshot_pending = True
+            self._schedule_pending_save()
 
     def schedule_save(self) -> None:
-        _, signature = self._capture_signature()
-        if signature == self._last_persisted_signature:
+        changed = self._observe_revision()
+        if not changed and self._pending_snapshot is None:
             self.coordinator._discovery_snapshot_pending = False
             return
+        if changed or self._pending_snapshot is None:
+            snapshot, signature = self._capture_signature()
+            if signature == self._last_persisted_signature:
+                self._persisted_revision = self._revision
+                self._pending_snapshot = None
+                self._pending_signature = None
+                self._pending_revision = None
+                self.coordinator._discovery_snapshot_pending = False
+                return
+            self._pending_snapshot = snapshot
+            self._pending_signature = signature
+            self._pending_revision = self._revision
         self.coordinator._discovery_snapshot_pending = True
-        if self.coordinator._discovery_snapshot_save_cancel is not None:
+        self._schedule_pending_save()
+
+    def _schedule_pending_save(self) -> None:
+        if (
+            self._save_in_progress
+            or self.coordinator._discovery_snapshot_save_cancel is not None
+        ):
             return
 
         @callback  # type: ignore[untyped-decorator]

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -33,6 +33,7 @@ from .const import (
     OPT_SLOW_POLL_INTERVAL,
 )
 from .log_redaction import redact_identifier, redact_text
+from .request_metrics import request_metrics_scope
 from .runtime_helpers import coerce_int, normalize_poll_intervals
 from .session_history import MIN_SESSION_HISTORY_CACHE_TTL
 
@@ -497,6 +498,12 @@ class EvseRuntime:
                 coord.hass.async_create_task(self.async_auto_resume(sn_str, snapshot))
 
     async def async_auto_resume(
+        self, sn: str, snapshot: dict[str, object] | None = None
+    ) -> None:
+        with request_metrics_scope("write_followup"):
+            await self._async_auto_resume_impl(sn, snapshot)
+
+    async def _async_auto_resume_impl(
         self, sn: str, snapshot: dict[str, object] | None = None
     ) -> None:
         coord = self.coordinator

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -23,6 +23,7 @@ from .api import (
 from .const import DOMAIN, DEFAULT_CHARGE_LEVEL_SETTING, PHASE_SWITCH_CONFIG_SETTING
 from .log_redaction import redact_site_id, redact_text
 from .refresh_plan import BoundRefreshCall, RefreshPlan, bind_refresh_plan, warmup_plan
+from .request_metrics import request_metrics_scope
 
 if TYPE_CHECKING:
     from .coordinator import EnphaseCoordinator
@@ -291,6 +292,10 @@ class RefreshRunner:
             )
 
     async def async_startup_warmup_runner(self) -> None:
+        with request_metrics_scope("startup_warmup"):
+            await self._async_startup_warmup_runner_impl()
+
+    async def _async_startup_warmup_runner_impl(self) -> None:
         coordinator = self._coordinator
         warmup_timings: dict[str, float] = {}
         coordinator._warmup_in_progress = True

--- a/custom_components/enphase_ev/request_metrics.py
+++ b/custom_components/enphase_ev/request_metrics.py
@@ -1,0 +1,74 @@
+"""Operation-scoped cloud request performance metrics."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class RequestMetrics:
+    """Mutable request metrics for one logical integration operation."""
+
+    operation: str
+    attempts: int = 0
+    queue_s: float = 0.0
+    network_s: float = 0.0
+    parsing_s: float = 0.0
+
+    def phase_timings(self) -> dict[str, float]:
+        """Return non-zero request-layer timing totals for diagnostics."""
+
+        timings: dict[str, float] = {}
+        for key, value in (
+            ("request_queue_s", self.queue_s),
+            ("request_network_s", self.network_s),
+            ("response_parsing_s", self.parsing_s),
+        ):
+            if value > 0:
+                timings[key] = round(value, 3)
+        return timings
+
+
+_CURRENT_REQUEST_METRICS: ContextVar[RequestMetrics | None] = ContextVar(
+    "enphase_ev_request_metrics",
+    default=None,
+)
+
+
+@contextmanager
+def request_metrics_scope(operation: str) -> Iterator[RequestMetrics]:
+    """Collect cloud request metrics for a logical operation."""
+
+    metrics = RequestMetrics(operation=str(operation))
+    token = _CURRENT_REQUEST_METRICS.set(metrics)
+    try:
+        yield metrics
+    finally:
+        _CURRENT_REQUEST_METRICS.reset(token)
+
+
+def record_request_attempt() -> None:
+    """Record one HTTP attempt in the active operation, when present."""
+
+    metrics = _CURRENT_REQUEST_METRICS.get()
+    if metrics is not None:
+        metrics.attempts += 1
+
+
+def record_request_timings(
+    *,
+    queue_s: float = 0.0,
+    network_s: float = 0.0,
+    parsing_s: float = 0.0,
+) -> None:
+    """Add request-layer timings to the active operation, when present."""
+
+    metrics = _CURRENT_REQUEST_METRICS.get()
+    if metrics is None:
+        return
+    metrics.queue_s += max(0.0, float(queue_s))
+    metrics.network_s += max(0.0, float(network_s))
+    metrics.parsing_s += max(0.0, float(parsing_s))

--- a/custom_components/enphase_ev/schedule_sync.py
+++ b/custom_components/enphase_ev/schedule_sync.py
@@ -33,6 +33,7 @@ from .const import (
     OPT_SCHEDULE_SYNC_ENABLED,
 )
 from .log_redaction import redact_identifier, redact_text
+from .request_metrics import request_metrics_scope
 from .schedule import normalize_slot_payload
 
 if TYPE_CHECKING:
@@ -499,6 +500,12 @@ class ScheduleSync:
 
     async def async_refresh(
         self, *, reason: str = "manual", serials: Iterable[str] | None = None
+    ) -> None:
+        with request_metrics_scope("schedule_sync"):
+            await self._async_refresh_impl(reason=reason, serials=serials)
+
+    async def _async_refresh_impl(
+        self, *, reason: str, serials: Iterable[str] | None
     ) -> None:
         if not self._sync_enabled():
             self._last_status = "disabled"

--- a/custom_components/enphase_ev/session_history.py
+++ b/custom_components/enphase_ev/session_history.py
@@ -16,6 +16,7 @@ from homeassistant.util import dt as dt_util
 
 from .api import InvalidPayloadError, SessionHistoryUnavailable, Unauthorized
 from .log_redaction import redact_identifier, redact_text
+from .request_metrics import request_metrics_scope
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -409,6 +410,20 @@ class SessionHistoryManager:
         return updates
 
     async def _async_enrich_sessions(
+        self,
+        serials: Iterable[str],
+        *,
+        day_local: datetime,
+        max_cache_age: float | None = None,
+    ) -> dict[str, list[dict[str, Any]]]:
+        with request_metrics_scope("session_history"):
+            return await self._async_enrich_sessions_impl(
+                serials,
+                day_local=day_local,
+                max_cache_age=max_cache_age,
+            )
+
+    async def _async_enrich_sessions_impl(
         self,
         serials: Iterable[str],
         *,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,6 +55,13 @@ The coordinator distinguishes core failures from optional endpoint failures:
 - Rate limits and cloud outages enter bounded backoff and expose diagnostic sensors.
 - Optional endpoint failures mark that family stale, preserve recent useful data where safe, and report repairs when needed.
 
+Cloud request metrics are scoped to logical operations. Core refresh, startup
+warmup, session-history enrichment, and schedule sync use separate scopes, so
+the coordinator's rolling performance history reports only work performed for
+that refresh. Failed and cancelled refresh attempts are retained in the same
+bounded history. Request-layer queue, network, and parsing totals are included
+when the HTTP boundary supplies them.
+
 ## Cloud Client
 
 `api.py` is the HTTP boundary. It handles Enlighten login, MFA, credential refresh helpers, request headers, response parsing, invalid payload signatures, and endpoint-specific compatibility paths.
@@ -90,6 +97,12 @@ Entity platforms under `sensor.py`, `binary_sensor.py`, `button.py`, `number.py`
 2. Add charger or device entities for discovered serials/type members.
 3. Wait for inventory readiness before pruning managed entity registry entries.
 4. Use optimistic coordinator caches only when Enphase writes are known to settle asynchronously.
+
+`discovery_snapshot.py` persists only stable identity and capability metadata
+needed to restore entity discovery before live inventory arrives. It observes a
+lightweight discovery revision on refresh completion; unchanged telemetry does
+not deep-copy or JSON-serialize inverter and battery snapshots. Delayed writes
+coalesce revisions and reuse the already captured compact payload.
 
 ## Diagnostics, Redaction, And Repairs
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -41,6 +41,7 @@ from custom_components.enphase_ev.coordinator_refresh_metrics import (
     refresh_performance_history_summary,
     refresh_performance_summary,
 )
+from custom_components.enphase_ev.request_metrics import RequestMetrics
 from custom_components.enphase_ev.session_history import (
     SESSION_CACHE_STATE_UNAVAILABLE,
     SessionCacheEntry,
@@ -2150,8 +2151,8 @@ def test_refresh_pipeline_records_cloud_call_counts(hass, monkeypatch) -> None:
     coord.client = client
 
     context = coord._start_refresh_pipeline()  # noqa: SLF001
-    assert client.request_count == 0
-    client.request_count = 4
+    assert client.request_count == 99
+    context.request_metrics = RequestMetrics("core_refresh", attempts=4)
     coord._finish_refresh_pipeline(context)  # noqa: SLF001
     assert coord._last_refresh_cloud_calls == 4  # noqa: SLF001
     assert coord._last_steady_refresh_cloud_calls == 4  # noqa: SLF001
@@ -2161,7 +2162,7 @@ def test_refresh_pipeline_records_cloud_call_counts(hass, monkeypatch) -> None:
     context = coord._start_refresh_pipeline()  # noqa: SLF001
     context.fast_poll = True
     context.phase_timings["status_s"] = 0.2
-    client.request_count = 6
+    context.request_metrics = RequestMetrics("core_refresh", attempts=6)
     coord._finish_refresh_pipeline(context)  # noqa: SLF001
     assert coord._last_refresh_cloud_calls == 6  # noqa: SLF001
     assert coord._last_fast_refresh_cloud_calls == 6  # noqa: SLF001
@@ -4329,6 +4330,8 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
     assert coord._discovery_snapshot_pending is False  # noqa: SLF001
 
     coord.discovery_snapshot.capture = Mock(return_value={"serial_order": ["NEW"]})  # type: ignore[assignment]
+    coord._serial_order = ["NEW"]  # noqa: SLF001
+    coord.serials = {"NEW"}
     coord.discovery_snapshot.schedule_save()
     assert scheduled == []
     assert coord._discovery_snapshot_pending is True  # noqa: SLF001

--- a/tests/components/enphase_ev/test_request_metrics.py
+++ b/tests/components/enphase_ev/test_request_metrics.py
@@ -207,6 +207,57 @@ async def test_snapshot_save_coalesces_mutation_during_write(
     assert scheduled
 
 
+@pytest.mark.asyncio
+async def test_cancelled_snapshot_save_retains_pending_revision(
+    coordinator_factory, monkeypatch
+) -> None:
+    """Cancellation must not make an observed but unpersisted revision disappear."""
+
+    coord = coordinator_factory()
+    manager = coord.discovery_snapshot
+    coord._inverter_order = ["INV-1"]  # noqa: SLF001
+    coord._inverter_data = {  # noqa: SLF001
+        "INV-1": {"serial_number": "INV-1", "name": "Garage"}
+    }
+    coord.inventory_runtime._inverter_order = coord._inverter_order  # noqa: SLF001
+    coord.inventory_runtime._inverter_data = coord._inverter_data  # noqa: SLF001
+    coord._discovery_snapshot_save_cancel = lambda: None  # noqa: SLF001
+    manager.schedule_save()
+
+    save_started = asyncio.Event()
+    keep_saving = asyncio.Event()
+
+    async def _save(_snapshot) -> None:
+        save_started.set()
+        await keep_saving.wait()
+
+    coord._discovery_snapshot_save_cancel = None  # noqa: SLF001
+    manager._store = SimpleNamespace(  # noqa: SLF001
+        async_save=AsyncMock(side_effect=_save)
+    )
+    save_task = asyncio.create_task(manager.async_save())
+    await asyncio.wait_for(save_started.wait(), timeout=1)
+    save_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await save_task
+
+    assert coord._discovery_snapshot_pending is True  # noqa: SLF001
+    assert manager._pending_snapshot is not None  # noqa: SLF001
+
+    scheduled: list[object] = []
+
+    def _call_later(_hass, _delay, callback):
+        scheduled.append(callback)
+        return lambda: None
+
+    from custom_components.enphase_ev import discovery_snapshot as snapshot_module
+
+    monkeypatch.setattr(snapshot_module, "async_call_later", _call_later)
+    manager.schedule_save()
+
+    assert scheduled
+
+
 def test_unchanged_snapshot_revision_matches_persisted_payload(
     coordinator_factory,
 ) -> None:

--- a/tests/components/enphase_ev/test_request_metrics.py
+++ b/tests/components/enphase_ev/test_request_metrics.py
@@ -1,0 +1,224 @@
+"""Tests for operation-scoped request and snapshot performance metrics."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.enphase_ev.request_metrics import (
+    record_request_attempt,
+    record_request_timings,
+    request_metrics_scope,
+)
+from custom_components.enphase_ev.coordinator_refresh_metrics import (
+    refresh_performance_history_summary,
+)
+from custom_components.enphase_ev.discovery_snapshot import (
+    _compact_discovery_record,
+    _compact_keyed_records,
+    _compact_type_buckets,
+)
+
+
+def test_request_metrics_scopes_are_isolated() -> None:
+    """Nested and unscoped requests must not pollute an outer operation."""
+
+    record_request_attempt()
+    record_request_timings(queue_s=1, network_s=1, parsing_s=1)
+
+    with request_metrics_scope("core_refresh") as outer:
+        record_request_attempt()
+        record_request_timings(queue_s=0.125, network_s=0.25, parsing_s=0.375)
+        with request_metrics_scope("session_history") as nested:
+            record_request_attempt()
+            record_request_attempt()
+            record_request_timings(queue_s=-1, network_s=0.5)
+
+        assert outer.attempts == 1
+        assert outer.phase_timings() == {
+            "request_queue_s": 0.125,
+            "request_network_s": 0.25,
+            "response_parsing_s": 0.375,
+        }
+        assert nested.attempts == 2
+        assert nested.phase_timings() == {"request_network_s": 0.5}
+
+
+def test_discovery_compaction_defensive_paths(coordinator_factory) -> None:
+    """Compaction accepts partial persisted and upstream inventory shapes."""
+
+    assert _compact_discovery_record("bad") == {}
+    assert _compact_keyed_records("bad") == {}
+    assert _compact_type_buckets("bad") == {}
+    assert _compact_type_buckets(
+        {
+            "bad": "bucket",
+            "envoy": {"count": 1, "devices": "bad"},
+            "iqevse": {"devices": ["bad", {"serial_number": "EVSE-1"}]},
+        }
+    ) == {
+        "envoy": {"count": 1, "devices": []},
+        "iqevse": {"devices": [{"serial_number": "EVSE-1"}]},
+    }
+    coord = coordinator_factory()
+    coord._type_device_buckets = {"bad": "bucket"}  # type: ignore[dict-item]  # noqa: SLF001
+    assert coord.discovery_snapshot._discovery_key()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_failed_and_cancelled_refreshes_record_scoped_metrics(
+    coordinator_factory,
+) -> None:
+    """Every attempted coordinator refresh contributes a history sample."""
+
+    coord = coordinator_factory()
+
+    async def _fail(_context) -> dict[str, dict[str, object]]:
+        record_request_attempt()
+        record_request_timings(queue_s=0.1, network_s=0.2, parsing_s=0.3)
+        raise RuntimeError("failed")
+
+    coord._async_update_data_impl = _fail  # type: ignore[method-assign]
+    with pytest.raises(RuntimeError, match="failed"):
+        await coord._async_update_data()  # noqa: SLF001
+
+    failed = coord._refresh_performance_history[-1]  # noqa: SLF001
+    assert failed["outcome"] == "failed"
+    assert failed["cloud_calls"] == 1
+    assert failed["phase_timings"]["request_queue_s"] == 0.1
+    assert failed["phase_timings"]["request_network_s"] == 0.2
+    assert failed["phase_timings"]["response_parsing_s"] == 0.3
+    assert failed["phase_timings"]["total_s"] >= 0
+
+    async def _cancel(_context) -> dict[str, dict[str, object]]:
+        record_request_attempt()
+        raise asyncio.CancelledError
+
+    coord._async_update_data_impl = _cancel  # type: ignore[method-assign]
+    with pytest.raises(asyncio.CancelledError):
+        await coord._async_update_data()  # noqa: SLF001
+
+    cancelled = coord._refresh_performance_history[-1]  # noqa: SLF001
+    assert cancelled["outcome"] == "cancelled"
+    assert cancelled["cloud_calls"] == 1
+    summary = refresh_performance_history_summary(
+        coord._refresh_performance_history  # noqa: SLF001
+    )
+    assert summary["failed_count"] == 1
+    assert summary["cancelled_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_snapshot_skips_telemetry_only_updates_at_scale(
+    coordinator_factory,
+) -> None:
+    """Large inverter telemetry updates must not rebuild persisted discovery."""
+
+    coord = coordinator_factory()
+    inverter_data = {
+        f"INV-{index:04d}": {
+            "serial_number": f"INV-{index:04d}",
+            "name": f"Inverter {index}",
+            "sku_id": "IQ8",
+            "lifetime_production_wh": index * 1000,
+            "rssi": -50,
+        }
+        for index in range(500)
+    }
+    coord._inverter_order = list(inverter_data)  # noqa: SLF001
+    coord._inverter_data = inverter_data  # noqa: SLF001
+    coord.inventory_runtime._inverter_order = coord._inverter_order  # noqa: SLF001
+    coord.inventory_runtime._inverter_data = inverter_data  # noqa: SLF001
+
+    manager = coord.discovery_snapshot
+    original_capture = manager.capture
+    manager.capture = Mock(wraps=original_capture)  # type: ignore[method-assign]
+    coord._discovery_snapshot_save_cancel = lambda: None  # noqa: SLF001
+
+    manager.schedule_save()
+    assert manager.capture.call_count == 1  # type: ignore[attr-defined]
+    pending = manager._pending_snapshot  # noqa: SLF001
+    assert pending is not None
+    compact = pending["inverter_data"]
+    assert isinstance(compact, dict)
+    assert len(compact) == 500
+    assert "lifetime_production_wh" not in compact["INV-0001"]
+    assert "rssi" not in compact["INV-0001"]
+
+    for index, record in enumerate(inverter_data.values()):
+        record["lifetime_production_wh"] = index * 2000
+        record["rssi"] = -60
+    manager.schedule_save()
+    assert manager.capture.call_count == 1  # type: ignore[attr-defined]
+
+    inverter_data["INV-0001"]["name"] = "Renamed inverter"
+    manager.schedule_save()
+    assert manager.capture.call_count == 2  # type: ignore[attr-defined]
+
+    coord._discovery_snapshot_save_cancel = None  # noqa: SLF001
+    manager._store = SimpleNamespace(async_save=AsyncMock())  # noqa: SLF001
+    await manager.async_save()
+    assert manager.capture.call_count == 2  # type: ignore[attr-defined]
+    manager._store.async_save.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_snapshot_save_coalesces_mutation_during_write(
+    coordinator_factory, monkeypatch
+) -> None:
+    """A revision arriving during storage I/O remains queued for one later save."""
+
+    coord = coordinator_factory()
+    manager = coord.discovery_snapshot
+    coord._inverter_order = ["INV-1"]  # noqa: SLF001
+    coord._inverter_data = {  # noqa: SLF001
+        "INV-1": {"serial_number": "INV-1", "name": "Before"}
+    }
+    coord.inventory_runtime._inverter_order = coord._inverter_order  # noqa: SLF001
+    coord.inventory_runtime._inverter_data = coord._inverter_data  # noqa: SLF001
+    coord._discovery_snapshot_save_cancel = lambda: None  # noqa: SLF001
+    manager.schedule_save()
+
+    scheduled: list[object] = []
+
+    def _call_later(_hass, _delay, callback):
+        scheduled.append(callback)
+        return lambda: None
+
+    from custom_components.enphase_ev import discovery_snapshot as snapshot_module
+
+    monkeypatch.setattr(snapshot_module, "async_call_later", _call_later)
+
+    async def _save(_snapshot) -> None:
+        coord._inverter_data["INV-1"]["name"] = "After"  # noqa: SLF001
+        manager.schedule_save()
+
+    coord._discovery_snapshot_save_cancel = None  # noqa: SLF001
+    manager._store = SimpleNamespace(
+        async_save=AsyncMock(side_effect=_save)
+    )  # noqa: SLF001
+    await manager.async_save()
+
+    assert coord._discovery_snapshot_pending is True  # noqa: SLF001
+    assert manager._pending_snapshot is not None  # noqa: SLF001
+    assert scheduled
+
+
+def test_unchanged_snapshot_revision_matches_persisted_payload(
+    coordinator_factory,
+) -> None:
+    """A newly observed but already persisted revision remains a no-op."""
+
+    coord = coordinator_factory()
+    manager = coord.discovery_snapshot
+    snapshot = manager.capture()
+    manager._last_persisted_signature = manager._snapshot_signature(
+        snapshot
+    )  # noqa: SLF001
+    manager.schedule_save()
+
+    assert manager._persisted_revision == manager._revision  # noqa: SLF001
+    assert manager._pending_snapshot is None  # noqa: SLF001


### PR DESCRIPTION
## Summary

Optimize discovery snapshot reuse, preserve cancellation semantics, and add bounded refresh/request phase metrics for diagnosing integration latency.

## Related Issues

Derived from the integration performance review; no tracking issue.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_refresh_metrics.py custom_components/enphase_ev/discovery_snapshot.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/refresh_runner.py custom_components/enphase_ev/request_metrics.py custom_components/enphase_ev/schedule_sync.py custom_components/enphase_ev/session_history.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_request_metrics.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_refresh_metrics.py,custom_components/enphase_ev/discovery_snapshot.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/refresh_runner.py,custom_components/enphase_ev/request_metrics.py,custom_components/enphase_ev/schedule_sync.py,custom_components/enphase_ev/session_history.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

- Targeted coverage: 11,298/11,298 statements, 100%.
- Component tests: 3,474 passed.
- Full suite: 3,606 passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid; no translation keys changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Metrics are bounded and cancellation-safe; no screenshots are required.


