### PR TITLE
Record Enphase request phase timings

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -1058,7 +1058,7 @@ async def _timed_response_text(response: Any) -> str:
 
     started = monotonic()
     try:
-        return await response.text()
+        return str(await response.text())
     finally:
         record_request_timings(parsing_s=monotonic() - started)
 

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -20,6 +20,7 @@ from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from datetime import date, datetime, timezone
 from http import HTTPStatus
+from time import monotonic
 from urllib.parse import unquote, urlencode
 import uuid
 from dataclasses import dataclass
@@ -52,7 +53,7 @@ from .api_models import (
     TextResponse as TextResponse,
 )
 from .log_redaction import redact_identifier, redact_site_id, redact_text
-from .request_metrics import record_request_attempt
+from .request_metrics import record_request_attempt, record_request_timings
 
 _LOGGER = logging.getLogger(__name__)
 _EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b")
@@ -1003,6 +1004,63 @@ async def _enlighten_read_request_guard(
         return
     async with _get_enlighten_read_semaphore():
         yield
+
+
+@asynccontextmanager
+async def _timed_enlighten_read_request_guard(
+    method: object, url: object
+) -> AsyncIterator[None]:
+    """Measure limiter queueing for one scoped client request."""
+
+    if not _should_limit_enlighten_read_request(method, url):
+        yield
+        return
+    started = monotonic()
+    acquired = False
+    try:
+        async with _enlighten_read_request_guard(method, url):
+            acquired = True
+            record_request_timings(queue_s=monotonic() - started)
+            yield
+    finally:
+        if not acquired:
+            record_request_timings(queue_s=monotonic() - started)
+
+
+@asynccontextmanager
+async def _timed_response_context(request_context: Any) -> AsyncIterator[Any]:
+    """Measure the wait until response headers arrive for one HTTP attempt."""
+
+    started = monotonic()
+    headers_received = False
+    try:
+        async with request_context as response:
+            headers_received = True
+            record_request_timings(network_s=monotonic() - started)
+            yield response
+    finally:
+        if not headers_received:
+            record_request_timings(network_s=monotonic() - started)
+
+
+async def _timed_response_json(response: Any) -> Any:
+    """Read and decode a JSON body while recording parsing time."""
+
+    started = monotonic()
+    try:
+        return await response.json()
+    finally:
+        record_request_timings(parsing_s=monotonic() - started)
+
+
+async def _timed_response_text(response: Any) -> str:
+    """Read a text body while recording parsing time."""
+
+    started = monotonic()
+    try:
+        return await response.text()
+    finally:
+        record_request_timings(parsing_s=monotonic() - started)
 
 
 def _seed_cookie_jar(session: aiohttp.ClientSession, cookies: dict[str, str]) -> None:
@@ -4369,14 +4427,16 @@ class EnphaseEVClient:
                 )
 
             async with asyncio.timeout(self._timeout):
-                async with _enlighten_read_request_guard(method, url):
+                async with _timed_enlighten_read_request_guard(method, url):
                     async with self._request_session(
                         cookie_header_only=use_cookie_header_only
                     ) as request_session:
                         self._request_count += 1
                         record_request_attempt()
-                        async with request_session.request(
-                            method, url, headers=base_headers, **kwargs
+                        async with _timed_response_context(
+                            request_session.request(
+                                method, url, headers=base_headers, **kwargs
+                            )
                         ) as r:
                             if r.status == 401:
                                 self._last_unauthorized_request = safe_request_label
@@ -4420,7 +4480,7 @@ class EnphaseEVClient:
                             if r.status >= 400:
                                 body_text: str | None = None
                                 try:
-                                    body_text = await r.text()
+                                    body_text = await _timed_response_text(r)
                                 except (
                                     Exception
                                 ):  # noqa: BLE001 - fall back to generic message
@@ -4549,7 +4609,7 @@ class EnphaseEVClient:
                                         )
                                 raise response_error
                             try:
-                                payload = await r.json()
+                                payload = await _timed_response_json(r)
                             except (aiohttp.ContentTypeError, ValueError) as err:
                                 status = int(getattr(r, "status", 0) or 0)
                                 content_type = ""
@@ -4562,7 +4622,7 @@ class EnphaseEVClient:
                                 ):  # noqa: BLE001 - defensive header parsing
                                     content_type = ""
                                 try:
-                                    body_text = await r.text()
+                                    body_text = await _timed_response_text(r)
                                 except Exception as text_err:  # noqa: BLE001
                                     body_text = (
                                         f"<unavailable:{text_err.__class__.__name__}>"
@@ -4660,9 +4720,11 @@ class EnphaseEVClient:
                         base_headers[header_key] = header_value
 
             async with asyncio.timeout(self._timeout):
-                async with _enlighten_read_request_guard(method, url):
-                    async with self._s.request(
-                        method, url, headers=base_headers, **kwargs
+                async with _timed_enlighten_read_request_guard(method, url):
+                    self._request_count += 1
+                    record_request_attempt()
+                    async with _timed_response_context(
+                        self._s.request(method, url, headers=base_headers, **kwargs)
                     ) as r:
                         if r.status == 401:
                             self._last_unauthorized_request = safe_request_label
@@ -4674,7 +4736,7 @@ class EnphaseEVClient:
                                     continue
                             raise Unauthorized()
                         if expected_statuses and r.status in expected_statuses:
-                            text = await r.text()
+                            text = await _timed_response_text(r)
                             if _is_enphase_login_wall(
                                 endpoint=endpoint or None, payload=text
                             ):
@@ -4698,7 +4760,7 @@ class EnphaseEVClient:
                         if r.status >= 400:
                             body_text: str | None = None
                             try:
-                                body_text = await r.text()
+                                body_text = await _timed_response_text(r)
                             except Exception:  # noqa: BLE001
                                 body_text = None
                             message = _safe_response_error_message(
@@ -4714,7 +4776,7 @@ class EnphaseEVClient:
                                 message=message,
                                 headers=r.headers,
                             )
-                        text = await r.text()
+                        text = await _timed_response_text(r)
                         if _is_enphase_login_wall(
                             endpoint=endpoint or None, payload=text
                         ):

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -26,6 +26,7 @@ from custom_components.enphase_ev.const import (
     GREEN_BATTERY_SETTING,
     PHASE_SWITCH_CONFIG_SETTING,
 )
+from custom_components.enphase_ev.request_metrics import request_metrics_scope
 
 TEST_EVSE_SERIAL = "EVSE-SERIAL-0001"
 
@@ -549,28 +550,38 @@ async def test_async_fetch_battery_site_settings_defensive_branches(
 
 
 @pytest.mark.asyncio
-async def test_text_response_retries_unauthorized_with_header_callback() -> None:
+async def test_text_response_retries_unauthorized_with_header_callback(
+    monkeypatch,
+) -> None:
     class BadURL:
         def __str__(self) -> str:
-            return "https://example.test/path"
+            return f"{api.BASE_URL}/path"
 
     first = _FakeResponse(status=401, json_body={}, text_body="")
     second = _FakeResponse(status=200, json_body={}, text_body="ok")
     session = _FakeSession([first, second])
     client = _make_client(session)
     client._reauth_cb = AsyncMock(return_value=True)  # noqa: SLF001
+    ticks = iter((0.0, 0.1, 1.0, 1.2, 2.0, 2.3, 3.0, 3.4, 4.0, 4.5))
+    monkeypatch.setattr(api, "monotonic", lambda: next(ticks))
 
-    result = await client._text_response(  # noqa: SLF001
-        "GET",
-        BadURL(),
-        expected_statuses=(200,),
-        headers=lambda: {"Authorization": None, "X-Test": "1"},
-    )
+    with request_metrics_scope("text_retry") as metrics:
+        result = await client._text_response(  # noqa: SLF001
+            "GET",
+            BadURL(),
+            expected_statuses=(200,),
+            headers=lambda: {"Authorization": None, "X-Test": "1"},
+        )
 
     assert result.text == "ok"
     assert session.calls[0][2]["headers"]["X-Test"] == "1"
     assert "Authorization" not in session.calls[0][2]["headers"]
     client._reauth_cb.assert_awaited_once()  # noqa: SLF001
+    assert client.request_count == 2
+    assert metrics.attempts == 2
+    assert metrics.queue_s == pytest.approx(0.4)
+    assert metrics.network_s == pytest.approx(0.6)
+    assert metrics.parsing_s == pytest.approx(0.5)
 
 
 @pytest.mark.asyncio
@@ -1540,20 +1551,70 @@ def test_invalid_payload_error_defaults_summary_when_blank() -> None:
 
 
 @pytest.mark.asyncio
-async def test_json_merges_headers_and_returns_payload() -> None:
+async def test_json_merges_headers_and_returns_payload(monkeypatch) -> None:
     session = _FakeSession([_FakeResponse(status=200, json_body={"ok": True})])
     client = api.EnphaseEVClient(session, "SITE", None, "COOKIE")
-    payload = await client._json(
-        "GET",
-        "https://example.test",
-        headers={"Extra": "1"},
-        params={"q": "1"},
-    )
+    ticks = iter((10.0, 10.25, 20.0, 20.5, 30.0, 30.75))
+    monkeypatch.setattr(api, "monotonic", lambda: next(ticks))
+
+    with request_metrics_scope("json") as metrics:
+        payload = await client._json(
+            "GET",
+            f"{api.BASE_URL}/service/test",
+            headers={"Extra": "1"},
+            params={"q": "1"},
+        )
+
     assert payload == {"ok": True}
     method, url, kwargs = session.calls[0]
     assert method == "GET"
     assert kwargs["headers"]["Extra"] == "1"
     assert kwargs["headers"]["Cookie"] == "COOKIE"
+    assert metrics.attempts == 1
+    assert metrics.queue_s == pytest.approx(0.25)
+    assert metrics.network_s == pytest.approx(0.5)
+    assert metrics.parsing_s == pytest.approx(0.75)
+
+
+@pytest.mark.asyncio
+async def test_json_queue_timeout_records_wait_without_attempt(monkeypatch) -> None:
+    session = _FakeSession([_FakeResponse(status=200, json_body={"ok": True})])
+    client = api.EnphaseEVClient(session, "SITE", None, None, timeout=0.01)
+    monkeypatch.setattr(api, "_enlighten_read_semaphore", asyncio.Semaphore(0))
+    ticks = iter((10.0, 10.5))
+    monkeypatch.setattr(api, "monotonic", lambda: next(ticks))
+
+    with request_metrics_scope("queue_timeout") as metrics:
+        with pytest.raises(TimeoutError):
+            await client._json("GET", f"{api.BASE_URL}/service/test")
+
+    assert metrics.attempts == 0
+    assert metrics.queue_s == pytest.approx(0.5)
+    assert metrics.network_s == 0
+    assert metrics.parsing_s == 0
+
+
+@pytest.mark.asyncio
+async def test_json_network_failure_records_header_wait(monkeypatch) -> None:
+    class _EnterFailureResponse(_FakeResponse):
+        async def __aenter__(self):
+            raise RuntimeError("connection failed")
+
+    session = _FakeSession([_EnterFailureResponse(status=200, json_body={"ok": True})])
+    client = api.EnphaseEVClient(session, "SITE", None, None)
+    monkeypatch.setattr(api, "_enlighten_read_semaphore", asyncio.Semaphore(2))
+    ticks = iter((0.0, 0.1, 1.0, 1.3))
+    monkeypatch.setattr(api, "monotonic", lambda: next(ticks))
+
+    with request_metrics_scope("network_failure") as metrics:
+        with pytest.raises(RuntimeError, match="connection failed"):
+            await client._json("GET", f"{api.BASE_URL}/service/test")
+
+    assert client.request_count == 1
+    assert metrics.attempts == 1
+    assert metrics.queue_s == pytest.approx(0.1)
+    assert metrics.network_s == pytest.approx(0.3)
+    assert metrics.parsing_s == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Record queue, network, response-read, and JSON parsing durations for individual Enphase requests so the refresh metrics merged in #762 can distinguish API latency from local processing time.

Keep the timing accumulator strictly typed and operation-scoped so concurrent/background calls do not contaminate coordinator refresh diagnostics.

## Related Issues

Follows #760, #761, and #762.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'set -e; files=(tests/components/enphase_ev/test_*.py); export COVERAGE_FILE=/tmp/enphase_ev.coverage; python -m coverage erase; for shard in 0 1 2 3; do shard_files=(); for index in "${!files[@]}"; do if (( index % 4 == shard )); then shard_files+=("${files[$index]}"); fi; done; python -m coverage run --append -m pytest -q "${shard_files[@]}"; done; python -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

- Targeted coverage: 3,706/3,706 statements, 100%.
- Component tests: 3,476 passed.
- Full suite: 3,608 passed.

## Checklist

- [x] No changelog entry is required because this only enriches existing internal performance diagnostics.
- [x] No documentation or translation keys changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed the restarted GitHub Actions results.
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The rebase dropped all changes already merged through #760, #761, and #762. The final diff contains only `api.py` and its timing tests.
