### PR TITLE
Add active system event monitoring and repairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ All notable changes to this project will be documented in this file.
 ### ✨ New features
 - Added optional installer-level microinverter parameter telemetry with bulk device reads for power and available AC/DC voltage/current, frequency, temperature, signal, and firmware details. Empty authoritative reads clear old values, partial failures retain only bounded stale data, and the diagnostic entities are disabled by default.
 - Added read-only System Dashboard event monitoring with a diagnostic active-event
-  binary sensor and automatically clearing Repairs for active error and critical
-  events.
+  binary sensor and Repairs for active error and critical events. Repairs clear only
+  after Enphase returns a matching explicitly resolved event.
 
 ### 🐛 Bug fixes
 - Fixed Enlighten authentication after Enphase retired the Entrez token mint by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file.
 - Added optional installer-level microinverter parameter telemetry with bulk device reads for power and available AC/DC voltage/current, frequency, temperature, signal, and firmware details. Empty authoritative reads clear old values, partial failures retain only bounded stale data, and the diagnostic entities are disabled by default.
 - Added read-only System Dashboard event monitoring with a diagnostic active-event
   binary sensor and Repairs for active error and critical events. Repairs clear only
-  after Enphase returns a matching explicitly resolved event.
+  after Enphase returns a matching explicitly resolved event. The event entity is
+  created only after the installer endpoint responds successfully, so owner-only
+  accounts do not receive an unavailable installer-only entity.
 
 ### 🐛 Bug fixes
 - Fixed Enlighten authentication after Enphase retired the Entrez token mint by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New features
 - Added optional installer-level microinverter parameter telemetry with bulk device reads for power and available AC/DC voltage/current, frequency, temperature, signal, and firmware details. Empty authoritative reads clear old values, partial failures retain only bounded stale data, and the diagnostic entities are disabled by default.
+- Added read-only System Dashboard event monitoring with a diagnostic active-event
+  binary sensor and automatically clearing Repairs for active error and critical
+  events.
 
 ### 🐛 Bug fixes
 - Fixed Enlighten authentication after Enphase retired the Entrez token mint by

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
 - Site tariff visibility for next billing date, Energy-dashboard-ready current import/export price sensors, editable tariff rate number entities, and a service for billing-cycle, rate, and guided structural tariff updates when Enphase exposes tariff data
 - Health diagnostics, service-availability tracking, and actionable repair issues
+- Read-only System Dashboard event monitoring, including a diagnostic active-event
+  binary sensor and automatically clearing Repairs for high-impact active faults
 - Detailed diagnostic and inventory entities remain available but are disabled by default when they are mainly useful for troubleshooting
 - Rate-conscious microinverter telemetry batches all active devices per supported parameter and exposes power plus available AC/DC, frequency, temperature, signal, and firmware details in a disabled-by-default diagnostic entity
 - Broad localization support across all user-facing integration strings

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -7434,6 +7434,44 @@ class EnphaseEVClient:
 
         return data
 
+    async def system_dashboard_events(self) -> JsonDict | None:
+        """Return current System Dashboard event rows and lookup catalogs.
+
+        GET /service/system_dashboard/api_internal/cs/sites/<site_id>/events
+        """
+
+        url = str(
+            URL(
+                f"{BASE_URL}/service/system_dashboard/api_internal/cs/sites/"
+                f"{self._site}/events"
+            ).update_query(
+                {
+                    "range": "today",
+                    "cassandra_toggle": "false",
+                    "filter_columns": (
+                        "serial_number,device_type,event_date,cleared_date,"
+                        "event_type,event_state,details,updated_at,alarm_id"
+                    ),
+                    "serial_numbers": "",
+                    "type": "table",
+                    "event_state": "default",
+                    "page": "1",
+                    "per_page": "200",
+                }
+            )
+        )
+        try:
+            data = await self._json(
+                "GET",
+                url,
+                headers=self._system_dashboard_headers(),
+            )
+        except Exception as err:  # noqa: BLE001
+            if self._system_dashboard_is_optional_error(err):
+                return None
+            raise
+        return data if isinstance(data, dict) else None
+
     async def devices_details(self, type_key: str) -> JsonDict | None:
         """Return system dashboard per-type device details when available.
 

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -120,7 +120,11 @@ async def async_setup_entry(
         inventory_ready = bool(getattr(coord, "_devices_inventory_ready", False))
         if not site_entity_added:
             async_add_entities(
-                [SiteCloudReachableBinarySensor(coord)], update_before_add=False
+                [
+                    SiteCloudReachableBinarySensor(coord),
+                    SiteActiveSystemEventsBinarySensor(coord),
+                ],
+                update_before_add=False,
             )
             site_entity_added = True
         heatpump_runtime_available = _heatpump_runtime_device_uid(coord) is not None
@@ -257,6 +261,42 @@ class SiteCloudReachableBinarySensor(
     @property
     def extra_state_attributes(self) -> dict[str, object]:
         return {}
+
+    @property
+    def device_info(self) -> object:
+        info = _type_device_info(self._coord, "cloud")
+        if info is not None:
+            return info
+        return _cloud_device_info(self._coord.site_id)
+
+
+class SiteActiveSystemEventsBinarySensor(
+    CoordinatorEntity,  # type: ignore[misc]
+    BinarySensorEntity,  # type: ignore[misc]
+):
+    """Summarize active System Dashboard events without exposing identifiers."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "active_system_events"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coord: EnphaseCoordinator) -> None:
+        super().__init__(coord)
+        self._coord = coord
+        self._attr_unique_id = f"{DOMAIN}_site_{coord.site_id}_active_system_events"
+
+    @property
+    def available(self) -> bool:
+        return bool(self._coord.system_events_runtime.available)
+
+    @property
+    def is_on(self) -> bool:
+        return self._coord.system_events_runtime.active_count > 0
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        return self._coord.system_events_runtime.diagnostics()
 
     @property
     def device_info(self) -> object:

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -292,11 +292,14 @@ class SiteActiveSystemEventsBinarySensor(
 
     @property
     def is_on(self) -> bool:
-        return self._coord.system_events_runtime.active_count > 0
+        return cast(int, self._coord.system_events_runtime.active_count) > 0
 
     @property
     def extra_state_attributes(self) -> dict[str, object]:
-        return self._coord.system_events_runtime.diagnostics()
+        return cast(
+            dict[str, object],
+            self._coord.system_events_runtime.diagnostics(),
+        )
 
     @property
     def device_info(self) -> object:

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -67,7 +67,8 @@ async def async_setup_entry(
 ) -> None:
     coord: EnphaseCoordinator = get_runtime_data(entry).coordinator
     ent_reg = er.async_get(hass)
-    site_entity_added = False
+    cloud_reachable_entity_added = False
+    system_events_entity_added = False
     heatpump_sg_ready_entity_added = False
     known_serials: set[str] = set()
 
@@ -103,7 +104,7 @@ async def async_setup_entry(
 
     @callback
     def _async_remove_site_binary_entity(key: str) -> None:
-        nonlocal heatpump_sg_ready_entity_added
+        nonlocal heatpump_sg_ready_entity_added, system_events_entity_added
         entity_id = ent_reg.async_get_entity_id(
             "binary_sensor",
             DOMAIN,
@@ -113,20 +114,32 @@ async def async_setup_entry(
             ent_reg.async_remove(entity_id)
         if key == "heat_pump_sg_ready_active":
             heatpump_sg_ready_entity_added = False
+        elif key == "active_system_events":
+            system_events_entity_added = False
+
+    @callback
+    def _async_sync_system_events() -> None:
+        nonlocal system_events_entity_added
+        if coord.system_events_runtime.available:
+            if not system_events_entity_added:
+                async_add_entities(
+                    [SiteActiveSystemEventsBinarySensor(coord)],
+                    update_before_add=False,
+                )
+                system_events_entity_added = True
+        elif bool(getattr(coord, "_devices_inventory_ready", False)):
+            _async_remove_site_binary_entity("active_system_events")
 
     @callback
     def _async_sync_chargers() -> None:
-        nonlocal site_entity_added, heatpump_sg_ready_entity_added
+        nonlocal cloud_reachable_entity_added, heatpump_sg_ready_entity_added
         inventory_ready = bool(getattr(coord, "_devices_inventory_ready", False))
-        if not site_entity_added:
+        if not cloud_reachable_entity_added:
             async_add_entities(
-                [
-                    SiteCloudReachableBinarySensor(coord),
-                    SiteActiveSystemEventsBinarySensor(coord),
-                ],
+                [SiteCloudReachableBinarySensor(coord)],
                 update_before_add=False,
             )
-            site_entity_added = True
+            cloud_reachable_entity_added = True
         heatpump_runtime_available = _heatpump_runtime_device_uid(coord) is not None
         if heatpump_runtime_available and not heatpump_sg_ready_entity_added:
             async_add_entities(
@@ -160,13 +173,17 @@ async def async_setup_entry(
             async_add_entities(entities, update_before_add=False)
             known_serials.update(serials)
 
-    add_listener = getattr(coord, "async_add_topology_listener", None)
-    if not callable(add_listener):
-        add_listener = getattr(coord, "async_add_listener", None)
-    if callable(add_listener):
-        entry.async_on_unload(add_listener(_async_sync_chargers))
+    add_topology_listener = getattr(coord, "async_add_topology_listener", None)
+    add_update_listener = getattr(coord, "async_add_listener", None)
+    if callable(add_topology_listener):
+        entry.async_on_unload(add_topology_listener(_async_sync_chargers))
+    elif callable(add_update_listener):
+        entry.async_on_unload(add_update_listener(_async_sync_chargers))
+    if callable(add_update_listener):
+        entry.async_on_unload(add_update_listener(_async_sync_system_events))
     _async_prune_historical_charger_binary_sensor_entities()
     _async_sync_chargers()
+    _async_sync_system_events()
 
 
 class _EVBoolSensor(EnphaseBaseEntity, BinarySensorEntity):  # type: ignore[misc]

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -175,6 +175,7 @@ from .coordinator_refresh_metrics import record_refresh_performance_sample
 from .request_metrics import RequestMetrics, request_metrics_scope
 from .summary import SummaryStore
 from . import system_dashboard_helpers as sd_helpers
+from .system_events import SystemEventsRuntime
 from .refresh_plan import (
     build_followup_plan,
     build_heatpump_followup_plan,
@@ -242,6 +243,7 @@ COORDINATOR_RUNTIME_CLASSES: dict[str, type] = {
     "auth_refresh_runtime": AuthRefreshRuntime,
     "evse_feature_flags_runtime": EvseFeatureFlagsRuntime,
     "tariff_runtime": TariffRuntime,
+    "system_events_runtime": SystemEventsRuntime,
 }
 
 
@@ -868,6 +870,7 @@ class EnphaseCoordinator(
         self._ensure_coordinator_runtime("auth_refresh_runtime")
         self._ensure_coordinator_runtime("evse_feature_flags_runtime")
         self._ensure_coordinator_runtime("tariff_runtime")
+        self._ensure_coordinator_runtime("system_events_runtime")
         self.inventory_runtime = InventoryRuntime(self)
         self.discovery_snapshot = DiscoverySnapshotManager(self)
         self.inventory_view = InventoryView(self)
@@ -996,6 +999,15 @@ class EnphaseCoordinator(
                 stale_after_s=21600.0,
                 failure_backoff_schedule_s=(900.0, 1800.0, 3600.0, 7200.0),
                 max_backoff_s=7200.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+            "system_events": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                stale_after_s=21600.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
                 optional=True,
                 suppress_after_failures=3,
                 support_state_on_success=True,

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -539,6 +539,15 @@ async def async_get_config_entry_diagnostics(
         except DIAGNOSTIC_CAPTURE_ERRORS:
             tariff = {}
 
+    system_events: dict[str, Any] = {}
+    system_events_runtime = getattr(coord, "system_events_runtime", None)
+    system_events_diagnostics = getattr(system_events_runtime, "diagnostics", None)
+    if callable(system_events_diagnostics):
+        try:
+            system_events = system_events_diagnostics()
+        except DIAGNOSTIC_CAPTURE_ERRORS:
+            system_events = {}
+
     firmware_catalog: dict[str, Any] = {}
     firmware_catalog_manager = getattr(coord, "firmware_catalog_manager", None)
     status_snapshot = getattr(firmware_catalog_manager, "status_snapshot", None)
@@ -570,6 +579,7 @@ async def async_get_config_entry_diagnostics(
         "inverters": inverters,
         "payload_health": payload_health,
         "system_dashboard": system_dashboard,
+        "system_events": system_events,
         "heatpump_runtime": heatpump_runtime,
         "scheduler": scheduler,
         "tariff": tariff,

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -25,6 +25,7 @@ REFRESH_TASK_ENDPOINT_FAMILIES: dict[str, str] = {
     "devices_inventory_s": "inventory_topology",
     "hems_devices_s": "inventory_topology",
     "system_dashboard_s": "inventory_topology",
+    "system_events_s": "system_events",
     "inverters_s": "inverter_inventory",
     "current_power_s": "current_power",
 }
@@ -273,6 +274,12 @@ WARMUP_STATE_STAGE = RefreshStage(
 SITE_ONLY_FOLLOWUP_STAGE = RefreshStage(
     defer_topology=True,
     parallel_tasks=(
+        object_method_task(
+            "system_events_s",
+            "system events",
+            "system_events_runtime",
+            "async_refresh",
+        ),
         method_task(
             "battery_site_settings_s",
             "battery site settings",
@@ -571,6 +578,7 @@ def build_followup_plan(owner: object, *, force_full: bool = False) -> RefreshPl
     inventory = getattr(owner, "inventory_runtime")
     current_power = getattr(owner, "current_power_runtime")
     evse_feature_flags = getattr(owner, "evse_feature_flags_runtime")
+    system_events = getattr(owner, "system_events_runtime", None)
     parallel: list[RefreshTask] = []
     ordered: list[RefreshTask] = []
     if battery.battery_site_settings_refresh_due():
@@ -680,6 +688,15 @@ def build_followup_plan(owner: object, *, force_full: bool = False) -> RefreshPl
                 "evse_feature_flags_s",
                 "EVSE feature flags",
                 "_async_refresh_evse_feature_flags",
+            )
+        )
+    if system_events is not None and system_events.refresh_due():
+        parallel.append(
+            object_method_task(
+                "system_events_s",
+                "system events",
+                "system_events_runtime",
+                "async_refresh",
             )
         )
     if battery.battery_status_refresh_due():

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -1948,6 +1948,32 @@
       "cloud_reachable": {
         "name": "Cloud Reachable"
       },
+      "active_system_events": {
+        "name": "Active System Events",
+        "state_attributes": {
+          "available": {
+            "name": "Event Service Available"
+          },
+          "active_count": {
+            "name": "Active Event Count"
+          },
+          "high_impact_count": {
+            "name": "High-impact Event Count"
+          },
+          "severity_counts": {
+            "name": "Severity Counts"
+          },
+          "device_type_counts": {
+            "name": "Device Type Counts"
+          },
+          "last_success_utc": {
+            "name": "Last Event Refresh (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Using Cached Event Data"
+          }
+        }
+      },
       "connected": {
         "name": "Connectivity",
         "state_attributes": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS temporarily paused",
       "description": "Heat Pump/HEMS polling for site {site_id} is paused until {backoff_until} after {failure_count} auth-like failures ({reason}). Wallbox, battery, gateway, and other data can continue. Disable the Heat Pump device group to stop HEMS polling, or use Clear HEMS Auth Backoff after Enphase recovers."
+    },
+    "active_system_event": {
+      "title": "High-impact Enphase system event active",
+      "description": "Site {site_id} has an active {severity} event affecting {device_type}, first reported at {event_date}. Check Enlighten for event details and recommended action. This repair clears automatically when Enphase reports the event resolved."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/system_events.py
+++ b/custom_components/enphase_ev/system_events.py
@@ -154,11 +154,22 @@ def parse_active_system_events(
 ) -> tuple[SystemEvent, ...]:
     """Parse active events while discarding raw identifiers and message details."""
 
+    events, _resolved = _parse_system_event_snapshot(payload, site_id=site_id)
+    return events
+
+
+def _parse_system_event_snapshot(
+    payload: object,
+    *,
+    site_id: str,
+) -> tuple[tuple[SystemEvent, ...], frozenset[str]]:
+    """Return sanitized active rows and explicitly resolved fingerprints."""
+
     if not isinstance(payload, dict):
-        return ()
+        return (), frozenset()
     rows = payload.get("events")
     if not isinstance(rows, list):
-        return ()
+        return (), frozenset()
     states = _lookup_catalog(payload.get("event_states"))
     severities = _lookup_catalog(payload.get("event_severities"))
     event_types = _lookup_catalog(payload.get("event_types"))
@@ -169,14 +180,16 @@ def parse_active_system_events(
         and (serial := _text(row.get("serial_number"))) is not None
     ]
     events: list[SystemEvent] = []
+    resolved: set[str] = set()
     seen: set[str] = set()
     for row in rows:
         if not isinstance(row, dict):
             continue
         state = _catalog_label(row.get("event_state"), states) or "unknown"
-        if not _event_is_active(row, state):
-            continue
         fingerprint = _event_fingerprint(row)
+        if not _event_is_active(row, state):
+            resolved.add(fingerprint)
+            continue
         if fingerprint in seen:
             continue
         seen.add(fingerprint)
@@ -210,7 +223,7 @@ def parse_active_system_events(
                 high_impact=severity in _HIGH_IMPACT_SEVERITIES,
             )
         )
-    return tuple(events)
+    return tuple(events), frozenset(resolved)
 
 
 class SystemEventsRuntime:
@@ -221,6 +234,7 @@ class SystemEventsRuntime:
         self._events: tuple[SystemEvent, ...] = ()
         self._last_success_utc: datetime | None = None
         self._reported_issue_ids: set[str] = set()
+        self._active_reported_issue_ids: set[str] = set()
 
     @property
     def active_events(self) -> tuple[SystemEvent, ...]:
@@ -273,9 +287,14 @@ class SystemEventsRuntime:
         registry = ir.async_get(self.coordinator.hass)
         issues = getattr(registry, "issues", {})
         if not isinstance(issues, dict):
-            return set(self._reported_issue_ids)
+            return set(
+                self._active_reported_issue_ids
+                if active_only
+                else self._reported_issue_ids
+            )
         entry_prefix = f"{SYSTEM_EVENT_REPAIR_PREFIX}{self._entry_suffix()}_"
         existing: set[str] = set()
+        known: set[str] = set()
         for key, entry in issues.items():
             if (
                 not isinstance(key, tuple)
@@ -285,20 +304,31 @@ class SystemEventsRuntime:
                 or not key[1].startswith(entry_prefix)
             ):
                 continue
+            known.add(key[1])
             if active_only and getattr(entry, "active", True) is not True:
                 continue
             existing.add(key[1])
+        if active_only:
+            return existing | (self._active_reported_issue_ids - known)
         return existing | self._reported_issue_ids
 
-    def _sync_repairs(self) -> None:
-        """Create new high-impact repairs and clear resolved repairs."""
+    def _sync_repairs(self, resolved_fingerprints: frozenset[str]) -> None:
+        """Create high-impact repairs and clear only explicitly resolved rows."""
 
         active_high_impact = {
             self._issue_id(event): event for event in self._events if event.high_impact
         }
+        active_issue_ids = {self._issue_id(event) for event in self._events}
+        resolved_issue_ids = {
+            f"{SYSTEM_EVENT_REPAIR_PREFIX}{self._entry_suffix()}_{fingerprint}"
+            for fingerprint in resolved_fingerprints
+        }
         existing = self._existing_issue_ids()
         active_existing = self._existing_issue_ids(active_only=True)
-        for issue_id in existing - active_high_impact.keys():
+        delete_issue_ids = (existing & resolved_issue_ids) | (
+            (existing & active_issue_ids) - active_high_impact.keys()
+        )
+        for issue_id in delete_issue_ids:
             ir.async_delete_issue(self.coordinator.hass, DOMAIN, issue_id)
         for issue_id, event in active_high_impact.items():
             if issue_id in active_existing:
@@ -323,7 +353,10 @@ class SystemEventsRuntime:
                     "event_date": event.event_date,
                 },
             )
-        self._reported_issue_ids = set(active_high_impact)
+        self._reported_issue_ids = (
+            existing | set(active_high_impact)
+        ) - delete_issue_ids
+        self._active_reported_issue_ids = set(active_high_impact)
 
     async def async_refresh(self) -> None:
         """Refresh events, retaining cached state across optional failures."""
@@ -336,13 +369,13 @@ class SystemEventsRuntime:
         payload = await fetcher()
         if not isinstance(payload, dict):
             raise OptionalEndpointUnavailable("System events endpoint unavailable")
-        self._events = parse_active_system_events(
+        self._events, resolved_fingerprints = _parse_system_event_snapshot(
             payload,
             site_id=str(self.coordinator.site_id),
         )
         self._last_success_utc = dt_util.utcnow()
         self.coordinator._note_endpoint_family_success(SYSTEM_EVENTS_ENDPOINT_FAMILY)
-        self._sync_repairs()
+        self._sync_repairs(resolved_fingerprints)
         _LOGGER.debug(
             "System event summary refreshed for site [site]: active=%s high_impact=%s",
             self.active_count,

--- a/custom_components/enphase_ev/system_events.py
+++ b/custom_components/enphase_ev/system_events.py
@@ -1,0 +1,370 @@
+"""Read-only System Dashboard event monitoring and repair synchronization."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers import issue_registry as ir
+from homeassistant.util import dt as dt_util
+
+from .api import OptionalEndpointUnavailable
+from .const import DOMAIN
+from .log_redaction import redact_text
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .coordinator import EnphaseCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+SYSTEM_EVENTS_ENDPOINT_FAMILY = "system_events"
+SYSTEM_EVENT_REPAIR_PREFIX = "active_system_event_"
+_TERMINAL_STATES = frozenset(
+    {"clear", "cleared", "close", "closed", "inactive", "normal", "resolved"}
+)
+_HIGH_IMPACT_SEVERITIES = frozenset(
+    {"critical", "emergency", "error", "fatal", "severe"}
+)
+
+
+def _text(value: object) -> str | None:
+    """Return compact text for scalar event fields."""
+
+    if value is None or isinstance(value, (dict, list, tuple, set)):
+        return None
+    try:
+        text = " ".join(str(value).split()).strip()
+    except Exception:  # noqa: BLE001
+        return None
+    return text or None
+
+
+def _normalized(value: object) -> str:
+    """Return a comparison-safe event label."""
+
+    text = _text(value)
+    if not text:
+        return ""
+    return "_".join(text.casefold().replace("-", " ").split())
+
+
+def _lookup_catalog(payload: object) -> dict[str, dict[str, object]]:
+    """Index a dashboard lookup catalog by both id and name."""
+
+    if not isinstance(payload, list):
+        return {}
+    out: dict[str, dict[str, object]] = {}
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        for key in ("id", "name"):
+            normalized = _normalized(item.get(key))
+            if normalized:
+                out[normalized] = item
+    return out
+
+
+def _catalog_label(
+    value: object,
+    catalog: dict[str, dict[str, object]],
+) -> str | None:
+    """Resolve a lookup id to its display name when available."""
+
+    entry = catalog.get(_normalized(value))
+    if entry is not None:
+        return _text(entry.get("name")) or _text(value)
+    return _text(value)
+
+
+def _event_severity(
+    row: dict[str, object],
+    *,
+    event_types: dict[str, dict[str, object]],
+    severities: dict[str, dict[str, object]],
+) -> str:
+    """Return an explicit event severity without inferring from free text."""
+
+    candidates: list[object] = [
+        row.get("event_severity"),
+        row.get("severity"),
+        row.get("severity_id"),
+    ]
+    event_type = event_types.get(_normalized(row.get("event_type")))
+    if event_type is not None:
+        candidates.extend(
+            (
+                event_type.get("event_severity"),
+                event_type.get("severity"),
+                event_type.get("severity_id"),
+            )
+        )
+    if _normalized(row.get("event_state")) in _HIGH_IMPACT_SEVERITIES:
+        candidates.append(row.get("event_state"))
+    for candidate in candidates:
+        label = _catalog_label(candidate, severities)
+        if label:
+            return _normalized(label)
+    return "unknown"
+
+
+def _event_is_active(row: dict[str, object], state: str) -> bool:
+    """Return whether an event is still active according to explicit fields."""
+
+    if _text(row.get("cleared_date")):
+        return False
+    return _normalized(state) not in _TERMINAL_STATES
+
+
+def _event_fingerprint(row: dict[str, object]) -> str:
+    """Return a stable, non-reversible event key for issue IDs."""
+
+    stable_id = _text(row.get("id")) or _text(row.get("alarm_id"))
+    if stable_id:
+        source = f"id:{stable_id}"
+    else:
+        source = "|".join(
+            _text(row.get(key)) or ""
+            for key in ("serial_number", "event_type", "event_date")
+        )
+    return hashlib.sha256(source.encode()).hexdigest()[:16]
+
+
+@dataclass(frozen=True, slots=True)
+class SystemEvent:
+    """Sanitized normalized System Dashboard event."""
+
+    fingerprint: str
+    event_type: str
+    device_type: str
+    severity: str
+    state: str
+    event_date: str | None
+    updated_at: str | None
+    high_impact: bool
+
+
+def parse_active_system_events(
+    payload: object,
+    *,
+    site_id: str,
+) -> tuple[SystemEvent, ...]:
+    """Parse active events while discarding raw identifiers and message details."""
+
+    if not isinstance(payload, dict):
+        return ()
+    rows = payload.get("events")
+    if not isinstance(rows, list):
+        return ()
+    states = _lookup_catalog(payload.get("event_states"))
+    severities = _lookup_catalog(payload.get("event_severities"))
+    event_types = _lookup_catalog(payload.get("event_types"))
+    serials = [
+        serial
+        for row in rows
+        if isinstance(row, dict)
+        and (serial := _text(row.get("serial_number"))) is not None
+    ]
+    events: list[SystemEvent] = []
+    seen: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        state = _catalog_label(row.get("event_state"), states) or "unknown"
+        if not _event_is_active(row, state):
+            continue
+        fingerprint = _event_fingerprint(row)
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        severity = _event_severity(
+            row,
+            event_types=event_types,
+            severities=severities,
+        )
+        event_type = _catalog_label(row.get("event_type"), event_types) or "unknown"
+        event_type = redact_text(
+            event_type,
+            site_ids=(site_id,),
+            identifiers=serials,
+            max_length=120,
+        )
+        device_type = redact_text(
+            _text(row.get("device_type")) or "unknown",
+            site_ids=(site_id,),
+            identifiers=serials,
+            max_length=80,
+        )
+        events.append(
+            SystemEvent(
+                fingerprint=fingerprint,
+                event_type=event_type or "unknown",
+                device_type=device_type or "unknown",
+                severity=severity,
+                state=_normalized(state) or "unknown",
+                event_date=_text(row.get("event_date")),
+                updated_at=_text(row.get("updated_at")),
+                high_impact=severity in _HIGH_IMPACT_SEVERITIES,
+            )
+        )
+    return tuple(events)
+
+
+class SystemEventsRuntime:
+    """Fetch, cache, summarize, and synchronize active system events."""
+
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
+        self.coordinator = coordinator
+        self._events: tuple[SystemEvent, ...] = ()
+        self._last_success_utc: datetime | None = None
+        self._reported_issue_ids: set[str] = set()
+
+    @property
+    def active_events(self) -> tuple[SystemEvent, ...]:
+        """Return the sanitized active-event cache."""
+
+        return self._events
+
+    @property
+    def available(self) -> bool:
+        """Return whether at least one valid response has been received."""
+
+        return self._last_success_utc is not None
+
+    @property
+    def active_count(self) -> int:
+        """Return the current number of active events."""
+
+        return len(self._events)
+
+    @property
+    def high_impact_count(self) -> int:
+        """Return the number of active error/critical events."""
+
+        return sum(event.high_impact for event in self._events)
+
+    def refresh_due(self) -> bool:
+        """Return whether the optional event endpoint may be polled now."""
+
+        return self.coordinator._endpoint_family_should_run(
+            SYSTEM_EVENTS_ENDPOINT_FAMILY
+        )
+
+    def _entry_suffix(self) -> str:
+        entry_id = getattr(
+            getattr(self.coordinator, "config_entry", None), "entry_id", ""
+        )
+        normalized = "".join(
+            char.casefold() if char.isalnum() else "_" for char in str(entry_id)
+        ).strip("_")
+        if normalized:
+            return normalized
+        return hashlib.sha256(str(self.coordinator.site_id).encode()).hexdigest()[:12]
+
+    def _issue_id(self, event: SystemEvent) -> str:
+        return f"{SYSTEM_EVENT_REPAIR_PREFIX}{self._entry_suffix()}_{event.fingerprint}"
+
+    def _existing_issue_ids(self, *, active_only: bool = False) -> set[str]:
+        """Return event issue IDs already persisted by Home Assistant."""
+
+        registry = ir.async_get(self.coordinator.hass)
+        issues = getattr(registry, "issues", {})
+        if not isinstance(issues, dict):
+            return set(self._reported_issue_ids)
+        entry_prefix = f"{SYSTEM_EVENT_REPAIR_PREFIX}{self._entry_suffix()}_"
+        existing: set[str] = set()
+        for key, entry in issues.items():
+            if (
+                not isinstance(key, tuple)
+                or len(key) != 2
+                or key[0] != DOMAIN
+                or not isinstance(key[1], str)
+                or not key[1].startswith(entry_prefix)
+            ):
+                continue
+            if active_only and getattr(entry, "active", True) is not True:
+                continue
+            existing.add(key[1])
+        return existing | self._reported_issue_ids
+
+    def _sync_repairs(self) -> None:
+        """Create new high-impact repairs and clear resolved repairs."""
+
+        active_high_impact = {
+            self._issue_id(event): event for event in self._events if event.high_impact
+        }
+        existing = self._existing_issue_ids()
+        active_existing = self._existing_issue_ids(active_only=True)
+        for issue_id in existing - active_high_impact.keys():
+            ir.async_delete_issue(self.coordinator.hass, DOMAIN, issue_id)
+        for issue_id, event in active_high_impact.items():
+            if issue_id in active_existing:
+                continue
+            ir.async_create_issue(
+                self.coordinator.hass,
+                DOMAIN,
+                issue_id,
+                is_fixable=False,
+                is_persistent=False,
+                severity=ir.IssueSeverity.ERROR,
+                translation_key="active_system_event",
+                translation_placeholders={
+                    "site_id": str(self.coordinator.site_id),
+                    "severity": event.severity,
+                    "device_type": event.device_type,
+                    "event_date": event.event_date or "unknown",
+                },
+                data={
+                    "severity": event.severity,
+                    "device_type": event.device_type,
+                    "event_date": event.event_date,
+                },
+            )
+        self._reported_issue_ids = set(active_high_impact)
+
+    async def async_refresh(self) -> None:
+        """Refresh events, retaining cached state across optional failures."""
+
+        if not self.refresh_due():
+            return
+        fetcher = getattr(self.coordinator.client, "system_dashboard_events", None)
+        if not callable(fetcher):
+            raise OptionalEndpointUnavailable("System events endpoint unavailable")
+        payload = await fetcher()
+        if not isinstance(payload, dict):
+            raise OptionalEndpointUnavailable("System events endpoint unavailable")
+        self._events = parse_active_system_events(
+            payload,
+            site_id=str(self.coordinator.site_id),
+        )
+        self._last_success_utc = dt_util.utcnow()
+        self.coordinator._note_endpoint_family_success(SYSTEM_EVENTS_ENDPOINT_FAMILY)
+        self._sync_repairs()
+        _LOGGER.debug(
+            "System event summary refreshed for site [site]: active=%s high_impact=%s",
+            self.active_count,
+            self.high_impact_count,
+        )
+
+    def diagnostics(self) -> dict[str, object]:
+        """Return an identifier-free diagnostic summary."""
+
+        severities = Counter(event.severity for event in self._events)
+        device_types = Counter(event.device_type for event in self._events)
+        health = self.coordinator._endpoint_family_state(SYSTEM_EVENTS_ENDPOINT_FAMILY)
+        return {
+            "available": self.available,
+            "active_count": self.active_count,
+            "high_impact_count": self.high_impact_count,
+            "severity_counts": dict(sorted(severities.items())),
+            "device_type_counts": dict(sorted(device_types.items())),
+            "last_success_utc": (
+                self._last_success_utc.isoformat() if self._last_success_utc else None
+            ),
+            "using_cached_data": bool(
+                self.available and health.consecutive_failures > 0
+            ),
+        }

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -1958,6 +1958,32 @@
             "name": "IP адрес"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Активни системни събития",
+        "state_attributes": {
+          "available": {
+            "name": "Услугата за събития е достъпна"
+          },
+          "active_count": {
+            "name": "Брой активни събития"
+          },
+          "high_impact_count": {
+            "name": "Брой събития с голямо въздействие"
+          },
+          "severity_counts": {
+            "name": "Брой по тежест"
+          },
+          "device_type_counts": {
+            "name": "Брой по тип устройство"
+          },
+          "last_success_utc": {
+            "name": "Последно обновяване на събитията (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Използват се кеширани данни за събития"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS е временно спрян",
       "description": "Запитванията Heat Pump/HEMS за сайт {site_id} са спрени до {backoff_until} след {failure_count} грешки, подобни на удостоверяване ({reason}). Wallbox, батерията, шлюзът и другите данни могат да продължат. Изключете групата Heat Pump, за да спрете HEMS, или използвайте Clear HEMS Auth Backoff след възстановяване на Enphase."
+    },
+    "active_system_event": {
+      "title": "Активно системно събитие на Enphase с голямо въздействие",
+      "description": "Сайт {site_id} има активно събитие {severity}, засягащо {device_type}, отчетено за първи път в {event_date}. Проверете Enlighten за подробности и препоръчано действие. Тази поправка се изчиства автоматично, когато Enphase отчете събитието като разрешено."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -1958,6 +1958,32 @@
             "name": "IP adresa"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktivní systémové události",
+        "state_attributes": {
+          "available": {
+            "name": "Služba událostí je dostupná"
+          },
+          "active_count": {
+            "name": "Počet aktivních událostí"
+          },
+          "high_impact_count": {
+            "name": "Počet událostí s vysokým dopadem"
+          },
+          "severity_counts": {
+            "name": "Počty podle závažnosti"
+          },
+          "device_type_counts": {
+            "name": "Počty podle typu zařízení"
+          },
+          "last_success_utc": {
+            "name": "Poslední aktualizace událostí (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Používají se data událostí z mezipaměti"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS je dočasně pozastaveno",
       "description": "Dotazování Heat Pump/HEMS pro lokalitu {site_id} je pozastaveno do {backoff_until} po {failure_count} chybách podobných ověření ({reason}). Wallbox, baterie, brána a ostatní data mohou pokračovat. Vypněte skupinu Heat Pump, nebo použijte Clear HEMS Auth Backoff po obnově Enphase."
+    },
+    "active_system_event": {
+      "title": "Aktivní systémová událost Enphase s vysokým dopadem",
+      "description": "Lokalita {site_id} má aktivní událost {severity}, která ovlivňuje {device_type} a byla poprvé hlášena v {event_date}. Podrobnosti a doporučený postup najdete v Enlighten. Tato oprava se automaticky odstraní, jakmile Enphase označí událost za vyřešenou."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -1958,6 +1958,32 @@
             "name": "IP-adresse"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktive systemhændelser",
+        "state_attributes": {
+          "available": {
+            "name": "Hændelsestjeneste tilgængelig"
+          },
+          "active_count": {
+            "name": "Antal aktive hændelser"
+          },
+          "high_impact_count": {
+            "name": "Antal hændelser med stor påvirkning"
+          },
+          "severity_counts": {
+            "name": "Antal efter alvorlighed"
+          },
+          "device_type_counts": {
+            "name": "Antal efter enhedstype"
+          },
+          "last_success_utc": {
+            "name": "Seneste hændelsesopdatering (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Bruger cachelagrede hændelsesdata"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS er midlertidigt sat på pause",
       "description": "Heat Pump/HEMS-polling for site {site_id} er sat på pause indtil {backoff_until} efter {failure_count} godkendelseslignende fejl ({reason}). Wallbox, batteri, gateway og andre data kan fortsætte. Deaktivér Heat Pump-gruppen, eller brug Clear HEMS Auth Backoff efter Enphase er klar igen."
+    },
+    "active_system_event": {
+      "title": "Aktiv Enphase-systemhændelse med stor påvirkning",
+      "description": "Anlæg {site_id} har en aktiv {severity}-hændelse, som påvirker {device_type}, første gang rapporteret {event_date}. Se Enlighten for detaljer og anbefalet handling. Denne reparation ryddes automatisk, når Enphase melder hændelsen løst."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -1958,6 +1958,32 @@
             "name": "IP-Adresse"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktive Systemereignisse",
+        "state_attributes": {
+          "available": {
+            "name": "Ereignisdienst verfügbar"
+          },
+          "active_count": {
+            "name": "Anzahl aktiver Ereignisse"
+          },
+          "high_impact_count": {
+            "name": "Anzahl schwerwiegender Ereignisse"
+          },
+          "severity_counts": {
+            "name": "Anzahl nach Schweregrad"
+          },
+          "device_type_counts": {
+            "name": "Anzahl nach Gerätetyp"
+          },
+          "last_success_utc": {
+            "name": "Letzte Ereignisaktualisierung (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Zwischengespeicherte Ereignisdaten werden verwendet"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS vorübergehend pausiert",
       "description": "Heat Pump/HEMS-Abfragen für Standort {site_id} sind bis {backoff_until} nach {failure_count} auth-ähnlichen Fehlern pausiert ({reason}). Wallbox, Batterie, Gateway und andere Daten können weiterlaufen. Deaktiviere die Heat Pump-Gerätegruppe oder nutze Clear HEMS Auth Backoff, nachdem Enphase wieder erreichbar ist."
+    },
+    "active_system_event": {
+      "title": "Schwerwiegendes Enphase-Systemereignis aktiv",
+      "description": "Standort {site_id} hat ein aktives Ereignis des Schweregrads {severity}, das {device_type} betrifft und erstmals um {event_date} gemeldet wurde. Details und empfohlene Maßnahmen finden Sie in Enlighten. Diese Reparatur wird automatisch entfernt, sobald Enphase das Ereignis als behoben meldet."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -1958,6 +1958,32 @@
             "name": "Διεύθυνση IP"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Ενεργά συμβάντα συστήματος",
+        "state_attributes": {
+          "available": {
+            "name": "Η υπηρεσία συμβάντων είναι διαθέσιμη"
+          },
+          "active_count": {
+            "name": "Πλήθος ενεργών συμβάντων"
+          },
+          "high_impact_count": {
+            "name": "Πλήθος συμβάντων υψηλής επίπτωσης"
+          },
+          "severity_counts": {
+            "name": "Πλήθος ανά σοβαρότητα"
+          },
+          "device_type_counts": {
+            "name": "Πλήθος ανά τύπο συσκευής"
+          },
+          "last_success_utc": {
+            "name": "Τελευταία ανανέωση συμβάντων (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Χρήση αποθηκευμένων δεδομένων συμβάντων"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Το Enphase Energy HEMS έχει παυθεί προσωρινά",
       "description": "Η ανάκτηση Heat Pump/HEMS για την εγκατάσταση {site_id} έχει παυθεί έως {backoff_until} μετά από {failure_count} σφάλματα τύπου πιστοποίησης ({reason}). Wallbox, μπαταρία, πύλη και άλλα δεδομένα μπορούν να συνεχίσουν. Απενεργοποιήστε την ομάδα Heat Pump ή χρησιμοποιήστε Clear HEMS Auth Backoff όταν ανακάμψει το Enphase."
+    },
+    "active_system_event": {
+      "title": "Ενεργό συμβάν συστήματος Enphase υψηλής επίπτωσης",
+      "description": "Η τοποθεσία {site_id} έχει ενεργό συμβάν {severity} που επηρεάζει το {device_type} και αναφέρθηκε πρώτη φορά στις {event_date}. Ελέγξτε το Enlighten για λεπτομέρειες και προτεινόμενη ενέργεια. Αυτή η επισκευή καταργείται αυτόματα όταν η Enphase αναφέρει ότι το συμβάν επιλύθηκε."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -1958,6 +1958,32 @@
             "name": "IP Address"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Active System Events",
+        "state_attributes": {
+          "available": {
+            "name": "Event Service Available"
+          },
+          "active_count": {
+            "name": "Active Event Count"
+          },
+          "high_impact_count": {
+            "name": "High-impact Event Count"
+          },
+          "severity_counts": {
+            "name": "Severity Counts"
+          },
+          "device_type_counts": {
+            "name": "Device Type Counts"
+          },
+          "last_success_utc": {
+            "name": "Last Event Refresh (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Using Cached Event Data"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS temporarily paused",
       "description": "Heat Pump/HEMS polling for site {site_id} is paused until {backoff_until} after {failure_count} auth-like failures ({reason}). Wallbox, battery, gateway, and other data can continue. Disable the Heat Pump device group to stop HEMS polling, or use Clear HEMS Auth Backoff after Enphase recovers."
+    },
+    "active_system_event": {
+      "title": "High-impact Enphase system event active",
+      "description": "Site {site_id} has an active {severity} event affecting {device_type}, first reported at {event_date}. Check Enlighten for event details and recommended action. This repair clears automatically when Enphase reports the event resolved."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -1958,6 +1958,32 @@
             "name": "IP Address"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Active System Events",
+        "state_attributes": {
+          "available": {
+            "name": "Event Service Available"
+          },
+          "active_count": {
+            "name": "Active Event Count"
+          },
+          "high_impact_count": {
+            "name": "High-impact Event Count"
+          },
+          "severity_counts": {
+            "name": "Severity Counts"
+          },
+          "device_type_counts": {
+            "name": "Device Type Counts"
+          },
+          "last_success_utc": {
+            "name": "Last Event Refresh (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Using Cached Event Data"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS temporarily paused",
       "description": "Heat Pump/HEMS polling for site {site_id} is paused until {backoff_until} after {failure_count} auth-like failures ({reason}). Wallbox, battery, gateway, and other data can continue. Disable the Heat Pump device group to stop HEMS polling, or use Clear HEMS Auth Backoff after Enphase recovers."
+    },
+    "active_system_event": {
+      "title": "High-impact Enphase system event active",
+      "description": "Site {site_id} has an active {severity} event affecting {device_type}, first reported at {event_date}. Check Enlighten for event details and recommended action. This repair clears automatically when Enphase reports the event resolved."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -1958,6 +1958,32 @@
             "name": "IP Address"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Active System Events",
+        "state_attributes": {
+          "available": {
+            "name": "Event Service Available"
+          },
+          "active_count": {
+            "name": "Active Event Count"
+          },
+          "high_impact_count": {
+            "name": "High-impact Event Count"
+          },
+          "severity_counts": {
+            "name": "Severity Counts"
+          },
+          "device_type_counts": {
+            "name": "Device Type Counts"
+          },
+          "last_success_utc": {
+            "name": "Last Event Refresh (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Using Cached Event Data"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS temporarily paused",
       "description": "Heat Pump/HEMS polling for site {site_id} is paused until {backoff_until} after {failure_count} auth-like failures ({reason}). Wallbox, battery, gateway, and other data can continue. Disable the Heat Pump device group to stop HEMS polling, or use Clear HEMS Auth Backoff after Enphase recovers."
+    },
+    "active_system_event": {
+      "title": "High-impact Enphase system event active",
+      "description": "Site {site_id} has an active {severity} event affecting {device_type}, first reported at {event_date}. Check Enlighten for event details and recommended action. This repair clears automatically when Enphase reports the event resolved."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -1958,6 +1958,32 @@
             "name": "IP Address"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Active System Events",
+        "state_attributes": {
+          "available": {
+            "name": "Event Service Available"
+          },
+          "active_count": {
+            "name": "Active Event Count"
+          },
+          "high_impact_count": {
+            "name": "High-impact Event Count"
+          },
+          "severity_counts": {
+            "name": "Severity Counts"
+          },
+          "device_type_counts": {
+            "name": "Device Type Counts"
+          },
+          "last_success_utc": {
+            "name": "Last Event Refresh (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Using Cached Event Data"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS temporarily paused",
       "description": "Heat Pump/HEMS polling for site {site_id} is paused until {backoff_until} after {failure_count} auth-like failures ({reason}). Wallbox, battery, gateway, and other data can continue. Disable the Heat Pump device group to stop HEMS polling, or use Clear HEMS Auth Backoff after Enphase recovers."
+    },
+    "active_system_event": {
+      "title": "High-impact Enphase system event active",
+      "description": "Site {site_id} has an active {severity} event affecting {device_type}, first reported at {event_date}. Check Enlighten for event details and recommended action. This repair clears automatically when Enphase reports the event resolved."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -1958,6 +1958,32 @@
             "name": "IP Address"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Active System Events",
+        "state_attributes": {
+          "available": {
+            "name": "Event Service Available"
+          },
+          "active_count": {
+            "name": "Active Event Count"
+          },
+          "high_impact_count": {
+            "name": "High-impact Event Count"
+          },
+          "severity_counts": {
+            "name": "Severity Counts"
+          },
+          "device_type_counts": {
+            "name": "Device Type Counts"
+          },
+          "last_success_utc": {
+            "name": "Last Event Refresh (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Using Cached Event Data"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS temporarily paused",
       "description": "Heat Pump/HEMS polling for site {site_id} is paused until {backoff_until} after {failure_count} auth-like failures ({reason}). Wallbox, battery, gateway, and other data can continue. Disable the Heat Pump device group to stop HEMS polling, or use Clear HEMS Auth Backoff after Enphase recovers."
+    },
+    "active_system_event": {
+      "title": "High-impact Enphase system event active",
+      "description": "Site {site_id} has an active {severity} event affecting {device_type}, first reported at {event_date}. Check Enlighten for event details and recommended action. This repair clears automatically when Enphase reports the event resolved."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -1958,6 +1958,32 @@
             "name": "IP Address"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Active System Events",
+        "state_attributes": {
+          "available": {
+            "name": "Event Service Available"
+          },
+          "active_count": {
+            "name": "Active Event Count"
+          },
+          "high_impact_count": {
+            "name": "High-impact Event Count"
+          },
+          "severity_counts": {
+            "name": "Severity Counts"
+          },
+          "device_type_counts": {
+            "name": "Device Type Counts"
+          },
+          "last_success_utc": {
+            "name": "Last Event Refresh (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Using Cached Event Data"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS temporarily paused",
       "description": "Heat Pump/HEMS polling for site {site_id} is paused until {backoff_until} after {failure_count} auth-like failures ({reason}). Wallbox, battery, gateway, and other data can continue. Disable the Heat Pump device group to stop HEMS polling, or use Clear HEMS Auth Backoff after Enphase recovers."
+    },
+    "active_system_event": {
+      "title": "High-impact Enphase system event active",
+      "description": "Site {site_id} has an active {severity} event affecting {device_type}, first reported at {event_date}. Check Enlighten for event details and recommended action. This repair clears automatically when Enphase reports the event resolved."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -1958,6 +1958,32 @@
             "name": "Dirección IP"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Eventos activos del sistema",
+        "state_attributes": {
+          "available": {
+            "name": "Servicio de eventos disponible"
+          },
+          "active_count": {
+            "name": "Número de eventos activos"
+          },
+          "high_impact_count": {
+            "name": "Número de eventos de alto impacto"
+          },
+          "severity_counts": {
+            "name": "Recuento por gravedad"
+          },
+          "device_type_counts": {
+            "name": "Recuento por tipo de dispositivo"
+          },
+          "last_success_utc": {
+            "name": "Última actualización de eventos (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Usando datos de eventos en caché"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "HEMS de Enphase Energy pausado temporalmente",
       "description": "El sondeo Heat Pump/HEMS del sitio {site_id} está pausado hasta {backoff_until} tras {failure_count} fallos similares a autenticación ({reason}). Wallbox, batería, gateway y otros datos pueden continuar. Desactiva el grupo Heat Pump o usa Clear HEMS Auth Backoff cuando Enphase se recupere."
+    },
+    "active_system_event": {
+      "title": "Evento del sistema Enphase de alto impacto activo",
+      "description": "El sitio {site_id} tiene un evento {severity} activo que afecta a {device_type}, notificado por primera vez el {event_date}. Consulta Enlighten para ver los detalles y la acción recomendada. Esta reparación se elimina automáticamente cuando Enphase informa que el evento está resuelto."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -1958,6 +1958,32 @@
             "name": "IP-aadress"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktiivsed süsteemisündmused",
+        "state_attributes": {
+          "available": {
+            "name": "Sündmuste teenus on saadaval"
+          },
+          "active_count": {
+            "name": "Aktiivsete sündmuste arv"
+          },
+          "high_impact_count": {
+            "name": "Suure mõjuga sündmuste arv"
+          },
+          "severity_counts": {
+            "name": "Arv raskusastme järgi"
+          },
+          "device_type_counts": {
+            "name": "Arv seadmetüübi järgi"
+          },
+          "last_success_utc": {
+            "name": "Viimane sündmuste värskendus (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Kasutatakse puhverdatud sündmuste andmeid"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS on ajutiselt peatatud",
       "description": "Heat Pump/HEMS päringud saidile {site_id} on peatatud kuni {backoff_until} pärast {failure_count} autentimislaadset tõrget ({reason}). Wallbox, aku, lüüs ja muud andmed võivad jätkata. Keela Heat Pump seadmerühm või kasuta Clear HEMS Auth Backoff pärast Enphase taastumist."
+    },
+    "active_system_event": {
+      "title": "Aktiivne suure mõjuga Enphase süsteemisündmus",
+      "description": "Saidil {site_id} on aktiivne {severity} sündmus, mis mõjutab seadet {device_type} ja millest teatati esimest korda {event_date}. Üksikasjade ja soovitatud toimingu jaoks vaadake Enlighteni. See parandus eemaldatakse automaatselt, kui Enphase märgib sündmuse lahendatuks."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -1958,6 +1958,32 @@
             "name": "IP-osoite"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktiiviset järjestelmätapahtumat",
+        "state_attributes": {
+          "available": {
+            "name": "Tapahtumapalvelu käytettävissä"
+          },
+          "active_count": {
+            "name": "Aktiivisten tapahtumien määrä"
+          },
+          "high_impact_count": {
+            "name": "Vakavien tapahtumien määrä"
+          },
+          "severity_counts": {
+            "name": "Määrät vakavuuden mukaan"
+          },
+          "device_type_counts": {
+            "name": "Määrät laitetyypin mukaan"
+          },
+          "last_success_utc": {
+            "name": "Viimeisin tapahtumapäivitys (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Käytetään välimuistissa olevia tapahtumatietoja"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS on tilapäisesti keskeytetty",
       "description": "Heat Pump/HEMS-kysely kohteelle {site_id} on keskeytetty aikaan {backoff_until} asti {failure_count} todennusluonteisen virheen jälkeen ({reason}). Wallbox, akku, yhdyskäytävä ja muut tiedot voivat jatkua. Poista Heat Pump -laiteryhmä käytöstä tai käytä Clear HEMS Auth Backoff, kun Enphase on palautunut."
+    },
+    "active_system_event": {
+      "title": "Vakava Enphase-järjestelmätapahtuma aktiivinen",
+      "description": "Kohteessa {site_id} on aktiivinen {severity}-tapahtuma, joka vaikuttaa laitteeseen {device_type} ja ilmoitettiin ensimmäisen kerran {event_date}. Katso lisätiedot ja suositeltu toimi Enlightenista. Tämä korjaus poistuu automaattisesti, kun Enphase ilmoittaa tapahtuman ratkaistuksi."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -1958,6 +1958,32 @@
             "name": "Adresse IP"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Événements système actifs",
+        "state_attributes": {
+          "available": {
+            "name": "Service des événements disponible"
+          },
+          "active_count": {
+            "name": "Nombre d’événements actifs"
+          },
+          "high_impact_count": {
+            "name": "Nombre d’événements à impact élevé"
+          },
+          "severity_counts": {
+            "name": "Nombre par gravité"
+          },
+          "device_type_counts": {
+            "name": "Nombre par type d’appareil"
+          },
+          "last_success_utc": {
+            "name": "Dernière actualisation des événements (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Utilisation des données d’événements en cache"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "HEMS Enphase Energy temporairement suspendu",
       "description": "L’interrogation Heat Pump/HEMS du site {site_id} est suspendue jusqu’à {backoff_until} après {failure_count} échecs de type authentification ({reason}). La wallbox, la batterie, la passerelle et les autres données peuvent continuer. Désactivez le groupe Heat Pump ou utilisez Clear HEMS Auth Backoff après le rétablissement d’Enphase."
+    },
+    "active_system_event": {
+      "title": "Événement système Enphase à impact élevé actif",
+      "description": "Le site {site_id} présente un événement {severity} actif affectant {device_type}, signalé pour la première fois à {event_date}. Consultez Enlighten pour les détails et l’action recommandée. Cette réparation disparaît automatiquement lorsque Enphase indique que l’événement est résolu."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -1958,6 +1958,32 @@
             "name": "IP-cím"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktív rendszeresemények",
+        "state_attributes": {
+          "available": {
+            "name": "Az eseményszolgáltatás elérhető"
+          },
+          "active_count": {
+            "name": "Aktív események száma"
+          },
+          "high_impact_count": {
+            "name": "Nagy hatású események száma"
+          },
+          "severity_counts": {
+            "name": "Darabszám súlyosság szerint"
+          },
+          "device_type_counts": {
+            "name": "Darabszám eszköztípus szerint"
+          },
+          "last_success_utc": {
+            "name": "Utolsó eseményfrissítés (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Gyorsítótárazott eseményadatok használata"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Az Enphase Energy HEMS ideiglenesen szünetel",
       "description": "A Heat Pump/HEMS lekérdezés a(z) {site_id} helyen {backoff_until} időpontig szünetel {failure_count} hitelesítés jellegű hiba után ({reason}). A wallbox, akkumulátor, gateway és más adatok tovább működhetnek. Kapcsold ki a Heat Pump eszközcsoportot, vagy használd a Clear HEMS Auth Backoff műveletet az Enphase helyreállása után."
+    },
+    "active_system_event": {
+      "title": "Aktív, nagy hatású Enphase rendszeresemény",
+      "description": "A(z) {site_id} helyszínen aktív {severity} esemény érinti ezt: {device_type}; első jelentése: {event_date}. A részletekért és a javasolt műveletért tekintse meg az Enlightent. Ez a javítás automatikusan eltűnik, amikor az Enphase megoldottként jelenti az eseményt."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -1958,6 +1958,32 @@
             "name": "Indirizzo IP"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Eventi di sistema attivi",
+        "state_attributes": {
+          "available": {
+            "name": "Servizio eventi disponibile"
+          },
+          "active_count": {
+            "name": "Numero di eventi attivi"
+          },
+          "high_impact_count": {
+            "name": "Numero di eventi ad alto impatto"
+          },
+          "severity_counts": {
+            "name": "Conteggio per gravità"
+          },
+          "device_type_counts": {
+            "name": "Conteggio per tipo di dispositivo"
+          },
+          "last_success_utc": {
+            "name": "Ultimo aggiornamento eventi (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Uso dei dati degli eventi memorizzati nella cache"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "HEMS Enphase Energy temporaneamente in pausa",
       "description": "Il polling Heat Pump/HEMS del sito {site_id} è in pausa fino a {backoff_until} dopo {failure_count} errori simili ad autenticazione ({reason}). Wallbox, batteria, gateway e altri dati possono continuare. Disattiva il gruppo Heat Pump oppure usa Clear HEMS Auth Backoff dopo il ripristino di Enphase."
+    },
+    "active_system_event": {
+      "title": "Evento di sistema Enphase ad alto impatto attivo",
+      "description": "Il sito {site_id} presenta un evento {severity} attivo che interessa {device_type}, segnalato per la prima volta il {event_date}. Consulta Enlighten per i dettagli e la procedura consigliata. Questa riparazione viene rimossa automaticamente quando Enphase segnala che evento è risolto."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -1958,6 +1958,32 @@
             "name": "IP adresas"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktyvūs sistemos įvykiai",
+        "state_attributes": {
+          "available": {
+            "name": "Įvykių paslauga pasiekiama"
+          },
+          "active_count": {
+            "name": "Aktyvių įvykių skaičius"
+          },
+          "high_impact_count": {
+            "name": "Didelio poveikio įvykių skaičius"
+          },
+          "severity_counts": {
+            "name": "Skaičius pagal svarbą"
+          },
+          "device_type_counts": {
+            "name": "Skaičius pagal įrenginio tipą"
+          },
+          "last_success_utc": {
+            "name": "Paskutinis įvykių atnaujinimas (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Naudojami talpykloje saugomi įvykių duomenys"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS laikinai pristabdyta",
       "description": "Heat Pump/HEMS apklausa svetainei {site_id} pristabdyta iki {backoff_until} po {failure_count} autentifikavimo tipo klaidų ({reason}). Wallbox, baterija, šliuzas ir kiti duomenys gali tęstis. Išjunkite Heat Pump įrenginių grupę arba naudokite Clear HEMS Auth Backoff, kai Enphase atsigaus."
+    },
+    "active_system_event": {
+      "title": "Aktyvus didelio poveikio Enphase sistemos įvykis",
+      "description": "Svetainėje {site_id} yra aktyvus {severity} įvykis, veikiantis {device_type}, pirmą kartą praneštas {event_date}. Išsamią informaciją ir rekomenduojamą veiksmą rasite Enlighten. Šis taisymas automatiškai pašalinamas, kai Enphase praneša, kad įvykis išspręstas."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -1958,6 +1958,32 @@
             "name": "IP adrese"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktīvi sistēmas notikumi",
+        "state_attributes": {
+          "available": {
+            "name": "Notikumu pakalpojums pieejams"
+          },
+          "active_count": {
+            "name": "Aktīvo notikumu skaits"
+          },
+          "high_impact_count": {
+            "name": "Augstas ietekmes notikumu skaits"
+          },
+          "severity_counts": {
+            "name": "Skaits pēc nopietnības"
+          },
+          "device_type_counts": {
+            "name": "Skaits pēc ierīces tipa"
+          },
+          "last_success_utc": {
+            "name": "Pēdējā notikumu atsvaidzināšana (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Tiek izmantoti kešatmiņā saglabāti notikumu dati"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS īslaicīgi apturēts",
       "description": "Heat Pump/HEMS aptauja vietnei {site_id} ir apturēta līdz {backoff_until} pēc {failure_count} autentifikācijai līdzīgām kļūdām ({reason}). Wallbox, akumulators, vārteja un citi dati var turpināties. Atspējojiet Heat Pump ierīču grupu vai izmantojiet Clear HEMS Auth Backoff pēc Enphase atjaunošanās."
+    },
+    "active_system_event": {
+      "title": "Aktīvs augstas ietekmes Enphase sistēmas notikums",
+      "description": "Vietnē {site_id} ir aktīvs {severity} notikums, kas ietekmē {device_type} un pirmoreiz ziņots {event_date}. Informāciju un ieteicamo rīcību skatiet Enlighten. Šis labojums tiek automātiski noņemts, kad Enphase ziņo, ka notikums ir atrisināts."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -1958,6 +1958,32 @@
             "name": "IP-adresse"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktive systemhendelser",
+        "state_attributes": {
+          "available": {
+            "name": "Hendelsestjeneste tilgjengelig"
+          },
+          "active_count": {
+            "name": "Antall aktive hendelser"
+          },
+          "high_impact_count": {
+            "name": "Antall hendelser med stor påvirkning"
+          },
+          "severity_counts": {
+            "name": "Antall etter alvorlighetsgrad"
+          },
+          "device_type_counts": {
+            "name": "Antall etter enhetstype"
+          },
+          "last_success_utc": {
+            "name": "Siste hendelsesoppdatering (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Bruker bufrede hendelsesdata"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS er midlertidig satt på pause",
       "description": "Heat Pump/HEMS-spørring for sted {site_id} er satt på pause til {backoff_until} etter {failure_count} godkjenningslignende feil ({reason}). Wallbox, batteri, gateway og andre data kan fortsette. Deaktiver Heat Pump-enhetsgruppen eller bruk Clear HEMS Auth Backoff etter at Enphase er tilbake."
+    },
+    "active_system_event": {
+      "title": "Aktiv Enphase-systemhendelse med stor påvirkning",
+      "description": "Anlegg {site_id} har en aktiv {severity}-hendelse som påvirker {device_type}, først rapportert {event_date}. Se Enlighten for detaljer og anbefalt handling. Denne reparasjonen fjernes automatisk når Enphase rapporterer at hendelsen er løst."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -1958,6 +1958,32 @@
             "name": "IP-adres"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Actieve systeemgebeurtenissen",
+        "state_attributes": {
+          "available": {
+            "name": "Gebeurtenisservice beschikbaar"
+          },
+          "active_count": {
+            "name": "Aantal actieve gebeurtenissen"
+          },
+          "high_impact_count": {
+            "name": "Aantal gebeurtenissen met hoge impact"
+          },
+          "severity_counts": {
+            "name": "Aantal per ernst"
+          },
+          "device_type_counts": {
+            "name": "Aantal per apparaattype"
+          },
+          "last_success_utc": {
+            "name": "Laatste gebeurtenisvernieuwing (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Gebeurtenisgegevens uit cache worden gebruikt"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS tijdelijk gepauzeerd",
       "description": "Heat Pump/HEMS-polling voor site {site_id} is gepauzeerd tot {backoff_until} na {failure_count} auth-achtige fouten ({reason}). Wallbox, batterij, gateway en andere gegevens kunnen doorgaan. Schakel de Heat Pump-apparaatgroep uit of gebruik Clear HEMS Auth Backoff nadat Enphase is hersteld."
+    },
+    "active_system_event": {
+      "title": "Actieve Enphase-systeemgebeurtenis met hoge impact",
+      "description": "Locatie {site_id} heeft een actieve gebeurtenis met ernst {severity} die {device_type} beïnvloedt en voor het eerst is gemeld op {event_date}. Bekijk Enlighten voor details en de aanbevolen actie. Deze reparatie verdwijnt automatisch wanneer Enphase meldt dat de gebeurtenis is opgelost."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -1958,6 +1958,32 @@
             "name": "Adres IP"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktywne zdarzenia systemowe",
+        "state_attributes": {
+          "available": {
+            "name": "Usługa zdarzeń dostępna"
+          },
+          "active_count": {
+            "name": "Liczba aktywnych zdarzeń"
+          },
+          "high_impact_count": {
+            "name": "Liczba zdarzeń o dużym wpływie"
+          },
+          "severity_counts": {
+            "name": "Liczba według ważności"
+          },
+          "device_type_counts": {
+            "name": "Liczba według typu urządzenia"
+          },
+          "last_success_utc": {
+            "name": "Ostatnie odświeżenie zdarzeń (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Używanie danych zdarzeń z pamięci podręcznej"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "HEMS Enphase Energy tymczasowo wstrzymany",
       "description": "Odpytywanie Heat Pump/HEMS dla lokalizacji {site_id} jest wstrzymane do {backoff_until} po {failure_count} błędach podobnych do uwierzytelniania ({reason}). Wallbox, bateria, brama i inne dane mogą działać dalej. Wyłącz grupę Heat Pump albo użyj Clear HEMS Auth Backoff po przywróceniu Enphase."
+    },
+    "active_system_event": {
+      "title": "Aktywne zdarzenie systemowe Enphase o dużym wpływie",
+      "description": "W lokalizacji {site_id} występuje aktywne zdarzenie {severity} dotyczące {device_type}, zgłoszone po raz pierwszy {event_date}. Szczegóły i zalecane działanie znajdziesz w Enlighten. Ta naprawa zostanie automatycznie usunięta, gdy Enphase zgłosi rozwiązanie zdarzenia."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -1958,6 +1958,32 @@
             "name": "Endereço IP"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Eventos ativos do sistema",
+        "state_attributes": {
+          "available": {
+            "name": "Serviço de eventos disponível"
+          },
+          "active_count": {
+            "name": "Contagem de eventos ativos"
+          },
+          "high_impact_count": {
+            "name": "Contagem de eventos de alto impacto"
+          },
+          "severity_counts": {
+            "name": "Contagem por gravidade"
+          },
+          "device_type_counts": {
+            "name": "Contagem por tipo de dispositivo"
+          },
+          "last_success_utc": {
+            "name": "Última atualização de eventos (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Usando dados de eventos em cache"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "HEMS da Enphase Energy pausado temporariamente",
       "description": "A consulta Heat Pump/HEMS do site {site_id} está pausada até {backoff_until} após {failure_count} falhas semelhantes a autenticação ({reason}). Wallbox, bateria, gateway e outros dados podem continuar. Desative o grupo Heat Pump ou use Clear HEMS Auth Backoff depois que a Enphase se recuperar."
+    },
+    "active_system_event": {
+      "title": "Evento de sistema Enphase de alto impacto ativo",
+      "description": "O local {site_id} tem um evento {severity} ativo afetando {device_type}, relatado pela primeira vez em {event_date}. Consulte o Enlighten para ver os detalhes e a ação recomendada. Este reparo é removido automaticamente quando a Enphase informa que o evento foi resolvido."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -1958,6 +1958,32 @@
             "name": "Adresă IP"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Evenimente de sistem active",
+        "state_attributes": {
+          "available": {
+            "name": "Serviciul de evenimente este disponibil"
+          },
+          "active_count": {
+            "name": "Număr de evenimente active"
+          },
+          "high_impact_count": {
+            "name": "Număr de evenimente cu impact ridicat"
+          },
+          "severity_counts": {
+            "name": "Număr după severitate"
+          },
+          "device_type_counts": {
+            "name": "Număr după tipul dispozitivului"
+          },
+          "last_success_utc": {
+            "name": "Ultima actualizare a evenimentelor (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Se folosesc date de evenimente din memoria cache"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "HEMS Enphase Energy este pauzat temporar",
       "description": "Interogarea Heat Pump/HEMS pentru site-ul {site_id} este pauzată până la {backoff_until} după {failure_count} erori de tip autentificare ({reason}). Wallbox, bateria, gateway-ul și alte date pot continua. Dezactivează grupul Heat Pump sau folosește Clear HEMS Auth Backoff după revenirea Enphase."
+    },
+    "active_system_event": {
+      "title": "Eveniment de sistem Enphase cu impact ridicat activ",
+      "description": "Site-ul {site_id} are un eveniment {severity} activ care afectează {device_type}, raportat prima dată la {event_date}. Consultați Enlighten pentru detalii și acțiunea recomandată. Această reparație se elimină automat când Enphase raportează că evenimentul este rezolvat."
     }
   },
   "system_health": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -1958,6 +1958,32 @@
             "name": "IP-adress"
           }
         }
+      },
+      "active_system_events": {
+        "name": "Aktiva systemhändelser",
+        "state_attributes": {
+          "available": {
+            "name": "Händelsetjänsten är tillgänglig"
+          },
+          "active_count": {
+            "name": "Antal aktiva händelser"
+          },
+          "high_impact_count": {
+            "name": "Antal händelser med stor påverkan"
+          },
+          "severity_counts": {
+            "name": "Antal per allvarlighetsgrad"
+          },
+          "device_type_counts": {
+            "name": "Antal per enhetstyp"
+          },
+          "last_success_utc": {
+            "name": "Senaste händelseuppdatering (UTC)"
+          },
+          "using_cached_data": {
+            "name": "Använder cachelagrade händelsedata"
+          }
+        }
       }
     },
     "switch": {
@@ -2240,6 +2266,10 @@
     "hems_auth_degraded": {
       "title": "Enphase Energy HEMS är tillfälligt pausat",
       "description": "Heat Pump/HEMS-pollning för plats {site_id} är pausad till {backoff_until} efter {failure_count} auth-liknande fel ({reason}). Wallbox, batteri, gateway och andra data kan fortsätta. Inaktivera Heat Pump-enhetsgruppen eller använd Clear HEMS Auth Backoff när Enphase har återhämtat sig."
+    },
+    "active_system_event": {
+      "title": "Aktiv Enphase-systemhändelse med stor påverkan",
+      "description": "Anläggning {site_id} har en aktiv {severity}-händelse som påverkar {device_type}, först rapporterad {event_date}. Se Enlighten för information och rekommenderad åtgärd. Denna reparation tas bort automatiskt när Enphase rapporterar att händelsen är löst."
     }
   },
   "system_health": {

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -123,6 +123,7 @@ Status labels:
 | Tariff settings MQTT authorizer | `GET` | `/pv/aws_sigv4/tariff_settings_response_stream?serial_number=<gateway_sn>` | authenticated Enlighten session cookies + `e-auth-token` + `x-xsrf-token` | Browser capture only |
 | EVSE tariff-change notification | `PUT` | `/service/evse_scheduler/api/v1/siteConfig/<site_id>/tariff_change` | tariff web write headers + JSON `null` body | Runtime (best-effort) |
 | System dashboard summary | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/summary` | session cookies + optional `Authorization: Bearer <token>` (current implementation adds bearer when available) | Runtime |
+| System dashboard events | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/events?range=today&cassandra_toggle=false&filter_columns=<columns>&serial_numbers=&type=table&event_state=default&page=1&per_page=200` | dashboard-read headers: authenticated cookies, optional bearer | Runtime |
 | System dashboard master data | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/data/master-data` | dashboard-read headers: authenticated cookies, optional bearer, XSRF when present | Runtime |
 | Per-gateway microinverter inventory | `GET` | `/service/system_dashboard/api_internal/dashboard/sites/<site_id>/envoy_inverters?serial_number=<gateway_sn>` | dashboard-read headers: authenticated cookies, optional bearer, XSRF when present | Runtime |
 | Device-level parameter columns | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/data/columns?serial_num=<gateway_sn>&type=device_level` | dashboard-read headers: authenticated cookies, optional bearer, XSRF when present | Runtime |
@@ -3358,7 +3359,52 @@ Inference:
 - The event-history feed provides stable SG Ready transition keys even when the human-readable descriptions are localized, so it is useful for documenting `MODE_2` versus `MODE_3` semantics without relying on translated text.
 
 Implementation note:
-- The current integration does not fetch this homeowner event feed for entities. HEMS per-device event JSON routes in `2.20` are used for diagnostics instead.
+- The integration does not fetch this homeowner feed for entities. It uses the
+  cleaner System Dashboard event table described below and keeps the HEMS
+  per-device event JSON routes in `2.20` for diagnostics.
+
+### 2.10.1 System Dashboard Active Events
+
+```http
+GET /service/system_dashboard/api_internal/cs/sites/<site_id>/events
+    ?range=today
+    &cassandra_toggle=false
+    &filter_columns=serial_number,device_type,event_date,cleared_date,event_type,event_state,details,updated_at,alarm_id
+    &serial_numbers=
+    &type=table
+    &event_state=default
+    &page=1
+    &per_page=200
+```
+
+The runtime uses the authenticated System Dashboard read headers and treats the
+route as optional. Successful responses are cached for five minutes; endpoint
+failures retain the last valid event state and use bounded backoff.
+
+Top-level response fields:
+
+```text
+total, page, per_page, events, event_types, event_states,
+csv_link, event_severities, availablePages
+```
+
+Event rows may contain:
+
+```text
+id, serial_number, device_link, event_date, cleared_date,
+updated_at, device_type, event_type, event_state, alarm_id, details
+```
+
+Runtime safety rules:
+
+- Cleared/closed/resolved rows are not active.
+- Repairs are created only when the payload or lookup catalogs explicitly mark an
+  active row as `error`, `critical`, `fatal`, `emergency`, or `severe`.
+- Event IDs, alarm IDs, device serials, device links, details, and CSV links are
+  discarded. Repair IDs use a truncated SHA-256 fingerprint and expose no raw
+  identifier.
+- A successful response clears repairs for resolved events. A transient endpoint
+  failure never clears a last-known active repair.
 
 ### 2.11 Battery Backup History
 ```

--- a/tests/components/enphase_ev/conftest.py
+++ b/tests/components/enphase_ev/conftest.py
@@ -398,6 +398,10 @@ def coordinator_factory(hass, mock_clientsession, mock_issue_registry, monkeypat
         coord.last_set_amps = getattr(coord, "last_set_amps", {}) or {}
         if client is not None:
             coord.client = client
+        else:
+            coord.client.system_dashboard_events = AsyncMock(
+                return_value={"events": []}
+            )
         if not hasattr(coord.client, "storm_guard_profile"):
             coord.client.storm_guard_profile = AsyncMock(return_value={"data": {}})
         if not hasattr(coord.client, "storm_guard_alert"):

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -8302,6 +8302,63 @@ async def test_system_dashboard_summary_returns_none_for_non_dict_payload() -> N
 
 
 @pytest.mark.asyncio
+async def test_system_dashboard_events_uses_observed_query_and_headers() -> None:
+    client = _make_client()
+    client.update_credentials(
+        cookie="enlighten_manager_token_production=BEAR; XSRF-TOKEN=xsrf",
+        eauth="EAUTH",
+    )
+    client._json = AsyncMock(return_value={"events": []})
+
+    assert await client.system_dashboard_events() == {"events": []}
+
+    args, kwargs = client._json.await_args
+    assert args[0] == "GET"
+    url = URL(args[1])
+    assert url.path.endswith(
+        "/service/system_dashboard/api_internal/cs/sites/SITE/events"
+    )
+    assert dict(url.query) == {
+        "range": "today",
+        "cassandra_toggle": "false",
+        "filter_columns": (
+            "serial_number,device_type,event_date,cleared_date,event_type,"
+            "event_state,details,updated_at,alarm_id"
+        ),
+        "serial_numbers": "",
+        "type": "table",
+        "event_state": "default",
+        "page": "1",
+        "per_page": "200",
+    }
+    assert kwargs["headers"]["Authorization"] == "Bearer BEAR"
+    assert kwargs["headers"]["e-auth-token"] == "EAUTH"
+    assert kwargs["headers"]["X-CSRF-Token"] == "xsrf"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [api.Unauthorized(), _make_cre(404)])
+async def test_system_dashboard_events_optional_errors_return_none(error) -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=error)
+
+    assert await client.system_dashboard_events() is None
+
+
+@pytest.mark.asyncio
+async def test_system_dashboard_events_rejects_invalid_shapes_and_unexpected_errors() -> (
+    None
+):
+    client = _make_client()
+    client._json = AsyncMock(return_value=[])
+    assert await client.system_dashboard_events() is None
+
+    client._json = AsyncMock(side_effect=RuntimeError("boom"))
+    with pytest.raises(RuntimeError, match="boom"):
+        await client.system_dashboard_events()
+
+
+@pytest.mark.asyncio
 async def test_hems_devices_supports_refresh_data_query_flag() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"data": {}})

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -17,6 +17,7 @@ from custom_components.enphase_ev.binary_sensor import (
     ConnectedBinarySensor,
     HeatPumpSgReadyActiveBinarySensor,
     PluggedInBinarySensor,
+    SiteActiveSystemEventsBinarySensor,
     SiteCloudReachableBinarySensor,
     async_setup_entry,
 )
@@ -68,6 +69,16 @@ async def test_async_setup_entry_syncs_binary_sensors(
         len([ent for ent in added if isinstance(ent, SiteCloudReachableBinarySensor)])
         == 1
     )
+    assert (
+        len(
+            [
+                ent
+                for ent in added
+                if isinstance(ent, SiteActiveSystemEventsBinarySensor)
+            ]
+        )
+        == 1
+    )
     per_serial = [ent for ent in added if hasattr(ent, "_sn")]
     assert len(per_serial) == 3
     assert {type(ent) for ent in per_serial} == {
@@ -80,7 +91,7 @@ async def test_async_setup_entry_syncs_binary_sensors(
     sync_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_chargers")
 
     sync_cb()
-    assert len(added) == 4
+    assert len(added) == 5
 
     new_serial = "EV0002"
     coord.data[new_serial] = {
@@ -108,14 +119,14 @@ async def test_async_setup_entry_syncs_binary_sensors(
     )
 
     sync_cb()
-    assert len(added) == 7
+    assert len(added) == 8
     assert {ent._sn for ent in added if hasattr(ent, "_sn")} == {
         RANDOM_SERIAL,
         new_serial,
     }
 
     sync_cb()
-    assert len(added) == 7
+    assert len(added) == 8
 
 
 @pytest.mark.asyncio
@@ -896,11 +907,63 @@ def test_site_cloud_reachable_binary_sensor_metadata(
     assert "last_success_utc" not in attrs
     assert attrs == {}
 
+    monkeypatch.setattr(
+        binary_sensor,
+        "_type_device_info",
+        lambda _coord, _type_key: None,
+    )
     info = sensor.device_info
     assert info["identifiers"] == {(DOMAIN, f"type:{coord.site_id}:cloud")}
     assert info["manufacturer"] == "Enphase"
     assert info["model"] == "Cloud Service"
     assert info["name"] == "Enphase Cloud"
+
+
+def test_site_active_system_events_binary_sensor_metadata(
+    coordinator_factory, monkeypatch
+) -> None:
+    """Expose only the sanitized cached event summary on the cloud device."""
+
+    coord = coordinator_factory(serials=[], data={})
+    runtime = coord.system_events_runtime
+    sensor = SiteActiveSystemEventsBinarySensor(coord)
+
+    assert sensor.translation_key == "active_system_events"
+    assert sensor.device_class == BinarySensorDeviceClass.PROBLEM
+    assert sensor.entity_category == EntityCategory.DIAGNOSTIC
+    assert sensor.available is False
+    assert sensor.is_on is False
+
+    runtime._last_success_utc = datetime.now(timezone.utc)  # noqa: SLF001
+    runtime._events = (  # noqa: SLF001
+        SimpleNamespace(
+            high_impact=True,
+            severity="critical",
+            device_type="IQ Gateway",
+        ),
+    )
+    attrs = sensor.extra_state_attributes
+    assert sensor.available is True
+    assert sensor.is_on is True
+    assert attrs["active_count"] == 1
+    assert attrs["high_impact_count"] == 1
+    assert attrs["severity_counts"] == {"critical": 1}
+    assert "serial_number" not in attrs
+
+    monkeypatch.setattr(
+        binary_sensor,
+        "_type_device_info",
+        lambda _coord, _type_key: None,
+    )
+    info = sensor.device_info
+    assert info["identifiers"] == {(DOMAIN, f"type:{coord.site_id}:cloud")}
+
+    monkeypatch.setattr(
+        binary_sensor,
+        "_type_device_info",
+        lambda _coord, _type_key: {"name": "Custom Cloud"},
+    )
+    assert sensor.device_info == {"name": "Custom Cloud"}
 
 
 def test_site_cloud_reachable_binary_sensor_metadata_includes_optional_failure_fields(

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -48,6 +48,7 @@ async def test_async_setup_entry_syncs_binary_sensors(
             }
         }
     )
+    coord.system_events_runtime._last_success_utc = dt_util.utcnow()  # noqa: SLF001
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     callbacks: list[Callable[[], None]] = []
@@ -127,6 +128,89 @@ async def test_async_setup_entry_syncs_binary_sensors(
 
     sync_cb()
     assert len(added) == 8
+
+
+@pytest.mark.asyncio
+async def test_system_events_entity_requires_successful_installer_response(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    """Create the installer-only entity only after its endpoint succeeds."""
+    from homeassistant.helpers import entity_registry as er
+
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    topology_callbacks: list[Callable[[], None]] = []
+    update_callbacks: list[Callable[[], None]] = []
+
+    def _capture_topology_listener(
+        callback: Callable[[], None],
+    ) -> Callable[[], None]:
+        topology_callbacks.append(callback)
+        return _stub_listener()
+
+    def _capture_update_listener(
+        callback: Callable[[], None], *, context=None
+    ) -> Callable[[], None]:
+        update_callbacks.append(callback)
+        return _stub_listener()
+
+    monkeypatch.setattr(
+        coord, "async_add_topology_listener", _capture_topology_listener
+    )
+    monkeypatch.setattr(coord, "async_add_listener", _capture_update_listener)
+
+    ent_reg = er.async_get(hass)
+    stale = ent_reg.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{coord.site_id}_active_system_events",
+        config_entry=config_entry,
+    )
+    added: list[object] = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    assert len(topology_callbacks) == 1
+    assert ent_reg.async_get(stale.entity_id) is None
+    assert (
+        len(
+            [
+                entity
+                for entity in added
+                if isinstance(entity, SiteCloudReachableBinarySensor)
+            ]
+        )
+        == 1
+    )
+    assert not any(
+        isinstance(entity, SiteActiveSystemEventsBinarySensor) for entity in added
+    )
+
+    coord.system_events_runtime._last_success_utc = dt_util.utcnow()  # noqa: SLF001
+    sync_events = next(
+        callback
+        for callback in update_callbacks
+        if callback.__name__ == "_async_sync_system_events"
+    )
+    sync_events()
+    sync_events()
+
+    assert (
+        len(
+            [
+                entity
+                for entity in added
+                if isinstance(entity, SiteActiveSystemEventsBinarySensor)
+            ]
+        )
+        == 1
+    )
 
 
 @pytest.mark.asyncio
@@ -682,7 +766,11 @@ async def test_async_setup_entry_prunes_heatpump_sg_ready_binary_sensor_when_typ
 
     fake_registry = SimpleNamespace(
         async_get_entity_id=MagicMock(
-            return_value="binary_sensor.heat_pump_sg_ready_active"
+            side_effect=lambda _domain, _platform, unique_id: (
+                "binary_sensor.heat_pump_sg_ready_active"
+                if unique_id.endswith("heat_pump_sg_ready_active")
+                else None
+            )
         ),
         async_remove=MagicMock(),
     )
@@ -772,7 +860,11 @@ async def test_async_setup_entry_prunes_heatpump_sg_ready_binary_sensor_when_ded
 
     fake_registry = SimpleNamespace(
         async_get_entity_id=MagicMock(
-            return_value="binary_sensor.heat_pump_sg_ready_active"
+            side_effect=lambda _domain, _platform, unique_id: (
+                "binary_sensor.heat_pump_sg_ready_active"
+                if unique_id.endswith("heat_pump_sg_ready_active")
+                else None
+            )
         ),
         async_remove=MagicMock(),
     )

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -75,6 +75,7 @@ def _make_coordinator(hass, monkeypatch):
         lambda *_args, **_kwargs: (lambda: None),
     )
     coord = EnphaseCoordinator(hass, cfg)
+    coord.client.system_dashboard_events = AsyncMock(return_value={"events": []})
     coord.client.storm_guard_profile = AsyncMock(return_value={"data": {}})
     coord.client.storm_guard_alert = AsyncMock(
         return_value={"criticalAlertActive": False, "stormAlerts": []}

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -295,6 +295,10 @@ class _RefreshOwner:
         self.evse_feature_flags_runtime = SimpleNamespace(
             refresh_due=lambda: True,
         )
+        self.system_events_runtime = SimpleNamespace(
+            refresh_due=lambda: True,
+            async_refresh=lambda: self._record("system_events"),
+        )
         self.battery_runtime = SimpleNamespace(
             async_refresh_grid_control_check=self._async_refresh_grid_control_check,
             async_refresh_grid_mode_status=self._async_refresh_grid_mode_status,
@@ -456,6 +460,7 @@ def test_followup_refresh_stage_binds_zero_arg_calls() -> None:
 
     assert bound.defer_topology is True
     assert [call[0] for call in bound.parallel_calls] == [
+        "system_events_s",
         "battery_site_settings_s",
         "battery_backup_history_s",
         "battery_settings_s",
@@ -476,9 +481,9 @@ def test_followup_refresh_stage_binds_zero_arg_calls() -> None:
         "hems_devices_s",
     ]
 
-    assert bound.parallel_calls[0][2]() == "site-settings"
+    assert bound.parallel_calls[1][2]() == "site-settings"
     assert bound.ordered_calls[-1][2]() == "hems-devices"
-    assert bound.parallel_calls[0][3] == "battery_site_settings"
+    assert bound.parallel_calls[1][3] == "battery_site_settings"
     assert bound.ordered_calls[-1][3] == "inventory_topology"
     assert owner.calls == ["battery_site_settings", "hems_devices"]
 
@@ -529,6 +534,7 @@ def test_dynamic_followup_plan_skips_up_to_date_tasks() -> None:
     owner.inventory_runtime.hems_devices_refresh_due = lambda: False
     owner.current_power_runtime.refresh_due = lambda: False
     owner.evse_feature_flags_runtime.refresh_due = lambda: False
+    owner.system_events_runtime.refresh_due = lambda: False
     owner.tariff_runtime.refresh_due = lambda: False
 
     assert build_followup_plan(owner).stages == ()
@@ -547,6 +553,7 @@ def test_dynamic_followup_plan_selects_due_subset() -> None:
     owner.inventory_runtime.devices_inventory_refresh_due = lambda: False
     owner.current_power_runtime.refresh_due = lambda: False
     owner.evse_feature_flags_runtime.refresh_due = lambda: False
+    owner.system_events_runtime.refresh_due = lambda: False
 
     plan = build_followup_plan(owner)
 
@@ -599,6 +606,7 @@ def test_dynamic_site_only_followup_plan_creates_inverter_stage_without_base_fol
     owner.inventory_runtime.hems_devices_refresh_due = lambda: False
     owner.current_power_runtime.refresh_due = lambda: False
     owner.evse_feature_flags_runtime.refresh_due = lambda: False
+    owner.system_events_runtime.refresh_due = lambda: False
     owner.tariff_runtime.refresh_due = lambda: False
     owner.inventory_runtime.inverters_refresh_due = lambda: True
     owner.heatpump_runtime.heatpump_runtime_state_refresh_due = lambda: False
@@ -631,6 +639,7 @@ def test_dynamic_followup_plan_includes_due_evse_feature_flags() -> None:
     owner.inventory_runtime.hems_devices_refresh_due = lambda: False
     owner.current_power_runtime.refresh_due = lambda: False
     owner.tariff_runtime.refresh_due = lambda: False
+    owner.system_events_runtime.refresh_due = lambda: False
 
     plan = build_followup_plan(owner)
 
@@ -769,7 +778,7 @@ async def test_coordinator_refresh_plan_runner_executes_each_stage(
     await coord.refresh_runner.async_run_refresh_plan({}, plan=FOLLOWUP_PLAN)
 
     assert seen == [
-        (None, True, 12, 4),
+        (None, True, 13, 4),
     ]
 
 

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -763,6 +763,13 @@ async def test_config_entry_diagnostics_includes_coordinator(
     """Validate coordinator diagnostics payload and redaction logic."""
     coord = DummyCoordinator()
     coord.schedule_sync = SimpleNamespace(diagnostics=lambda: {"enabled": True})
+    coord.system_events_runtime = SimpleNamespace(
+        diagnostics=lambda: {
+            "active_count": 1,
+            "high_impact_count": 1,
+            "device_type_counts": {"IQ Gateway": 1},
+        }
+    )
     coord._scheduler_backoff_ends_utc = datetime(2025, 1, 1, tzinfo=timezone.utc)
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
@@ -1019,6 +1026,26 @@ async def test_config_entry_diagnostics_includes_coordinator(
         "export_rate_available": False,
         "endpoint_family": {"support_state": "supported"},
     }
+    assert diag["coordinator"]["system_events"] == {
+        "active_count": 1,
+        "high_impact_count": 1,
+        "device_type_counts": {"IQ Gateway": 1},
+    }
+
+
+@pytest.mark.asyncio
+async def test_config_entry_diagnostics_handles_system_events_capture_error(
+    hass, config_entry
+) -> None:
+    coord = DummyCoordinator()
+    coord.system_events_runtime = SimpleNamespace(
+        diagnostics=lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
+
+    assert diag["coordinator"]["system_events"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_system_events.py
+++ b/tests/components/enphase_ev/test_system_events.py
@@ -1,0 +1,341 @@
+"""Tests for read-only System Dashboard event monitoring."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.enphase_ev.api import OptionalEndpointUnavailable
+from custom_components.enphase_ev.const import DOMAIN
+from custom_components.enphase_ev.system_events import (
+    SYSTEM_EVENTS_ENDPOINT_FAMILY,
+    SYSTEM_EVENT_REPAIR_PREFIX,
+    SystemEventsRuntime,
+    _catalog_label,
+    _event_fingerprint,
+    _event_is_active,
+    _lookup_catalog,
+    _normalized,
+    _text,
+    parse_active_system_events,
+)
+
+
+class _BadText:
+    def __str__(self) -> str:
+        raise ValueError("boom")
+
+
+def _event_payload() -> dict[str, object]:
+    return {
+        "events": [
+            {
+                "id": None,
+                "serial_number": "SERIAL-PRIVATE-1",
+                "event_date": "2026-07-11T01:02:03Z",
+                "updated_at": "2026-07-11T01:03:03Z",
+                "cleared_date": None,
+                "device_type": "IQ Gateway SERIAL-PRIVATE-1",
+                "event_type": 10,
+                "event_state": "open",
+            },
+            {
+                "id": "closed-event",
+                "serial_number": "SERIAL-PRIVATE-2",
+                "event_date": "2026-07-11T00:00:00Z",
+                "cleared_date": "2026-07-11T00:05:00Z",
+                "device_type": "IQ Battery",
+                "event_type": "Battery warning",
+                "event_state": "open",
+                "severity": "warning",
+            },
+            {
+                "id": "resolved-event",
+                "event_date": "2026-07-11T00:00:00Z",
+                "cleared_date": None,
+                "event_type": "Resolved event",
+                "event_state": 2,
+                "severity": "critical",
+            },
+            "not-a-row",
+        ],
+        "event_types": [
+            {"id": 10, "name": "Gateway SERIAL-PRIVATE-1 fault", "severity_id": 5},
+            None,
+        ],
+        "event_states": [
+            {"id": 2, "name": "Resolved"},
+            "not-a-state",
+        ],
+        "event_severities": [{"id": 5, "name": "Critical"}],
+    }
+
+
+def test_event_parser_normalizes_redacts_and_filters() -> None:
+    events = parse_active_system_events(_event_payload(), site_id="1234567")
+
+    assert len(events) == 1
+    event = events[0]
+    assert len(event.fingerprint) == 16
+    assert event.event_type == "Gateway SERI...TE-1 fault"
+    assert event.device_type == "IQ Gateway SERI...TE-1"
+    assert event.severity == "critical"
+    assert event.state == "open"
+    assert event.high_impact is True
+    assert event.event_date == "2026-07-11T01:02:03Z"
+    assert event.updated_at == "2026-07-11T01:03:03Z"
+    assert "SERIAL-PRIVATE-1" not in repr(event)
+
+
+def test_event_parser_handles_malformed_and_direct_severity_shapes() -> None:
+    assert parse_active_system_events(None, site_id="1") == ()
+    assert parse_active_system_events({"events": {}}, site_id="1") == ()
+
+    payload = {
+        "events": [
+            {
+                "id": "warning",
+                "event_type": "Warning",
+                "event_state": None,
+                "event_severity": "Warning",
+            },
+            {
+                "alarm_id": "alarm",
+                "event_type": "Severe",
+                "event_state": "set",
+                "severity": "Severe",
+            },
+            {
+                "event_type": _BadText(),
+                "event_date": "date",
+                "event_state": "closed",
+            },
+        ],
+        "event_types": {},
+        "event_states": None,
+        "event_severities": [None, {"id": "warn", "name": "Warning"}],
+    }
+    events = parse_active_system_events(payload, site_id="1")
+
+    assert [event.severity for event in events] == ["warning", "severe"]
+    assert [event.high_impact for event in events] == [False, True]
+    assert events[0].state == "unknown"
+    assert events[1].device_type == "unknown"
+
+    duplicate_payload = {
+        "events": [
+            {"id": "same", "event_type": "Unclassified", "event_state": "open"},
+            {"id": "same", "event_type": "Duplicate", "event_state": "open"},
+        ]
+    }
+    duplicate_events = parse_active_system_events(duplicate_payload, site_id="1")
+    assert len(duplicate_events) == 1
+    assert duplicate_events[0].severity == "unknown"
+
+    state_severity = parse_active_system_events(
+        {"events": [{"id": "state", "event_state": "Error"}]},
+        site_id="1",
+    )
+    assert state_severity[0].high_impact is True
+
+
+def test_event_helper_edge_cases() -> None:
+    assert _text(None) is None
+    assert _text([]) is None
+    assert _text(_BadText()) is None
+    assert _text("  hello\nworld ") == "hello world"
+    assert _normalized(None) == ""
+    assert _normalized("High-Impact Event") == "high_impact_event"
+    assert _lookup_catalog({}) == {}
+    assert _lookup_catalog([None, {"id": "", "name": "Open"}]) == {
+        "open": {"id": "", "name": "Open"}
+    }
+    assert _catalog_label("missing", {}) == "missing"
+    assert _catalog_label("open", {"open": {"name": None}}) == "open"
+    assert _event_is_active({"cleared_date": "now"}, "open") is False
+    assert _event_is_active({"cleared_date": None}, "resolved") is False
+    assert _event_is_active({"cleared_date": None}, "open") is True
+    assert _event_fingerprint({"id": "event-id"}) == _event_fingerprint(
+        {"id": "event-id", "serial_number": "different"}
+    )
+
+
+def _runtime_coordinator(
+    hass,
+    *,
+    payload: object = None,
+    due: bool = True,
+    entry_id: str | None = "Entry-ID",
+) -> SimpleNamespace:
+    health = SimpleNamespace(consecutive_failures=0)
+    return SimpleNamespace(
+        hass=hass,
+        site_id="1234567",
+        config_entry=(SimpleNamespace(entry_id=entry_id) if entry_id else None),
+        client=SimpleNamespace(system_dashboard_events=AsyncMock(return_value=payload)),
+        _endpoint_family_should_run=lambda family: (
+            family == SYSTEM_EVENTS_ENDPOINT_FAMILY and due
+        ),
+        _endpoint_family_state=lambda family: health,
+        _note_endpoint_family_success=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_refresh_creates_stable_repairs_and_clears_resolved(
+    hass, monkeypatch
+) -> None:
+    coordinator = _runtime_coordinator(hass, payload=_event_payload())
+    runtime = SystemEventsRuntime(coordinator)
+    created: list[tuple[str, dict[str, object]]] = []
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_get",
+        lambda _hass: SimpleNamespace(issues={}),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_create_issue",
+        lambda _hass, _domain, issue_id, **kwargs: created.append((issue_id, kwargs)),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_delete_issue",
+        lambda _hass, _domain, issue_id: deleted.append(issue_id),
+    )
+
+    await runtime.async_refresh()
+
+    assert runtime.available is True
+    assert runtime.active_count == 1
+    assert runtime.high_impact_count == 1
+    assert len(created) == 1
+    issue_id, issue = created[0]
+    assert issue_id.startswith(f"{SYSTEM_EVENT_REPAIR_PREFIX}entry_id_")
+    assert "SERIAL-PRIVATE" not in issue_id
+    assert issue["translation_key"] == "active_system_event"
+    assert issue["severity"].value == "error"
+    assert issue["translation_placeholders"]["device_type"] == (
+        "IQ Gateway SERI...TE-1"
+    )
+    assert issue["data"] == {
+        "severity": "critical",
+        "device_type": "IQ Gateway SERI...TE-1",
+        "event_date": "2026-07-11T01:02:03Z",
+    }
+    coordinator._note_endpoint_family_success.assert_called_once_with(
+        SYSTEM_EVENTS_ENDPOINT_FAMILY
+    )
+
+    # Repeated identical data does not recreate or update the repair.
+    await runtime.async_refresh()
+    assert len(created) == 1
+
+    coordinator.client.system_dashboard_events.return_value = {"events": []}
+    await runtime.async_refresh()
+    assert deleted == [issue_id]
+    assert runtime.active_count == 0
+    assert runtime.high_impact_count == 0
+
+
+@pytest.mark.asyncio
+async def test_runtime_skips_cooldown_and_keeps_cache_on_failures(hass) -> None:
+    coordinator = _runtime_coordinator(hass, payload={"events": []}, due=False)
+    runtime = SystemEventsRuntime(coordinator)
+
+    await runtime.async_refresh()
+    coordinator.client.system_dashboard_events.assert_not_awaited()
+
+    coordinator._endpoint_family_should_run = lambda _family: True
+    coordinator.client = SimpleNamespace()
+    with pytest.raises(OptionalEndpointUnavailable):
+        await runtime.async_refresh()
+
+    coordinator.client.system_dashboard_events = AsyncMock(return_value=None)
+    with pytest.raises(OptionalEndpointUnavailable):
+        await runtime.async_refresh()
+    assert runtime.available is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_diagnostics_and_persisted_issue_cleanup(
+    hass, monkeypatch
+) -> None:
+    coordinator = _runtime_coordinator(
+        hass,
+        payload={
+            "events": [
+                {
+                    "id": "warning",
+                    "event_type": "Warning",
+                    "event_state": "open",
+                    "event_severity": "warning",
+                    "device_type": "IQ Battery",
+                }
+            ]
+        },
+        entry_id=None,
+    )
+    runtime = SystemEventsRuntime(coordinator)
+    fallback_suffix = runtime._entry_suffix()  # noqa: SLF001
+    stale_issue = f"{SYSTEM_EVENT_REPAIR_PREFIX}{fallback_suffix}_stale"
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_get",
+        lambda _hass: SimpleNamespace(
+            issues={
+                (DOMAIN, stale_issue): object(),
+                ("other", stale_issue): object(),
+                (DOMAIN, "unrelated"): object(),
+                "malformed": object(),
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_delete_issue",
+        lambda _hass, _domain, issue_id: deleted.append(issue_id),
+    )
+
+    await runtime.async_refresh()
+    coordinator._endpoint_family_state(
+        SYSTEM_EVENTS_ENDPOINT_FAMILY
+    ).consecutive_failures = 1
+    snapshot = runtime.diagnostics()
+
+    assert deleted == [stale_issue]
+    assert snapshot["available"] is True
+    assert snapshot["active_count"] == 1
+    assert snapshot["high_impact_count"] == 0
+    assert snapshot["severity_counts"] == {"warning": 1}
+    assert snapshot["device_type_counts"] == {"IQ Battery": 1}
+    assert snapshot["last_success_utc"].endswith("+00:00")
+    assert snapshot["using_cached_data"] is True
+    assert runtime.active_events[0].event_type == "Warning"
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_get",
+        lambda _hass: SimpleNamespace(issues=None),
+    )
+    assert runtime._existing_issue_ids() == set()  # noqa: SLF001
+
+    active_issue = f"{SYSTEM_EVENT_REPAIR_PREFIX}{fallback_suffix}_active"
+    inactive_issue = f"{SYSTEM_EVENT_REPAIR_PREFIX}{fallback_suffix}_inactive"
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_get",
+        lambda _hass: SimpleNamespace(
+            issues={
+                (DOMAIN, active_issue): SimpleNamespace(active=True),
+                (DOMAIN, inactive_issue): SimpleNamespace(active=False),
+            }
+        ),
+    )
+    assert runtime._existing_issue_ids(active_only=True) == {  # noqa: SLF001
+        active_issue
+    }
+
+
+def test_runtime_unavailable_diagnostics(hass) -> None:
+    runtime = SystemEventsRuntime(_runtime_coordinator(hass))
+    snapshot = runtime.diagnostics()
+    assert snapshot["last_success_utc"] is None
+    assert snapshot["using_cached_data"] is False

--- a/tests/components/enphase_ev/test_system_events.py
+++ b/tests/components/enphase_ev/test_system_events.py
@@ -184,7 +184,7 @@ def _runtime_coordinator(
 
 
 @pytest.mark.asyncio
-async def test_runtime_refresh_creates_stable_repairs_and_clears_resolved(
+async def test_runtime_refresh_clears_repairs_only_for_explicit_resolution(
     hass, monkeypatch
 ) -> None:
     coordinator = _runtime_coordinator(hass, payload=_event_payload())
@@ -233,9 +233,15 @@ async def test_runtime_refresh_creates_stable_repairs_and_clears_resolved(
 
     coordinator.client.system_dashboard_events.return_value = {"events": []}
     await runtime.async_refresh()
-    assert deleted == [issue_id]
+    assert deleted == []
     assert runtime.active_count == 0
     assert runtime.high_impact_count == 0
+
+    resolved_row = dict(_event_payload()["events"][0])
+    resolved_row["cleared_date"] = "2026-07-11T02:00:00Z"
+    coordinator.client.system_dashboard_events.return_value = {"events": [resolved_row]}
+    await runtime.async_refresh()
+    assert deleted == [issue_id]
 
 
 @pytest.mark.asyncio
@@ -302,7 +308,7 @@ async def test_runtime_diagnostics_and_persisted_issue_cleanup(
     ).consecutive_failures = 1
     snapshot = runtime.diagnostics()
 
-    assert deleted == [stale_issue]
+    assert deleted == []
     assert snapshot["available"] is True
     assert snapshot["active_count"] == 1
     assert snapshot["high_impact_count"] == 0
@@ -316,7 +322,7 @@ async def test_runtime_diagnostics_and_persisted_issue_cleanup(
         "custom_components.enphase_ev.system_events.ir.async_get",
         lambda _hass: SimpleNamespace(issues=None),
     )
-    assert runtime._existing_issue_ids() == set()  # noqa: SLF001
+    assert runtime._existing_issue_ids() == {stale_issue}  # noqa: SLF001
 
     active_issue = f"{SYSTEM_EVENT_REPAIR_PREFIX}{fallback_suffix}_active"
     inactive_issue = f"{SYSTEM_EVENT_REPAIR_PREFIX}{fallback_suffix}_inactive"


### PR DESCRIPTION
## Summary

Adds read-only System Dashboard event monitoring, a diagnostic Active System Events problem sensor, sanitized diagnostics, and conservative Home Assistant Repairs for explicitly high-impact active events.

Event payload identifiers, links, and details are discarded. Stable non-reversible fingerprints prevent duplicate Repairs. Follow-up review ensures a Repair is cleared only when Enphase returns a matching explicitly terminal or cleared row; absence from a filtered or paginated response never implies resolution.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/binary_sensor.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/diagnostics.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/system_events.py tests/components/enphase_ev/conftest.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_binary_sensor_module.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_system_events.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/pr-feature3.coverage python -m coverage erase && COVERAGE_FILE=/tmp/pr-feature3.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/pr-feature3.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/binary_sensor.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/diagnostics.py,custom_components/enphase_ev/refresh_plan.py,custom_components/enphase_ev/system_events.py --fail-under=100"
```

Post-rebase full suite: 3,631 passed. Touched modules: 9,112/9,112 statements covered.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, `docs/`) when behaviour or options changed.
- [x] I verified all 25 locale files are complete and localized.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results.
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No event write or force-clear endpoint is called. Repairs are created only from explicit severity fields and clear only after an explicit matching resolution.
