### PR TITLE
Add multi-gateway phase map support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 - Added read-only IQ Gateway software-update progress monitoring to the existing
   advisory update entity, including Home Assistant in-progress/percentage state,
   timing, installed image version, and sanitized component transfer details.
+- Added multi-gateway phase-map discovery so site controls prefer the primary or
+  default IQ Gateway and Gateway Status reports phase/topology diagnostics.
 
 ### 🐛 Bug fixes
 - Fixed Enlighten authentication after Enphase retired the Entrez token mint by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ All notable changes to this project will be documented in this file.
   advisory update entity, including Home Assistant in-progress/percentage state,
   timing, installed image version, and sanitized component transfer details.
 - Added multi-gateway phase-map discovery so site controls prefer the primary or
-  default IQ Gateway and Gateway Status reports phase/topology diagnostics.
+  default IQ Gateway and Gateway Status reports phase/topology diagnostics only when
+  authoritative phase-map data is available.
 
 ### 🐛 Bug fixes
 - Fixed Enlighten authentication after Enphase retired the Entrez token mint by

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 
 - Guided onboarding for site selection and device-category enablement
 - Unified support for EV chargers, gateway, battery, and microinverter entities
+- Multi-gateway topology awareness for primary/default Gateway and phase selection
 - EV charging controls and session telemetry, including charge-mode aware behavior and persistent default charge-level controls when exposed by Enphase
 - Advisory firmware update entities for gateway and EV charger devices with locale-aware release-note links; the gateway entity also monitors read-only live update progress, percentage, timing, and sanitized component status when Enphase exposes it
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -7383,6 +7383,21 @@ class EnphaseEVClient:
             return data
         return {}
 
+    async def phase_map_multiple_envoy(self) -> JsonDict | None:
+        """Return per-gateway phase and topology metadata for the site.
+
+        GET /app-api/<site_id>/phase_map_multiple_envoy
+        """
+
+        url = f"{BASE_URL}/app-api/{self._site}/phase_map_multiple_envoy"
+        try:
+            data = await self._json("GET", url, headers=self._history_headers())
+        except InvalidPayloadError as err:
+            if _is_optional_non_json_payload(err) or _is_optional_html_payload(err):
+                raise OptionalEndpointUnavailable(err.summary) from err
+            raise
+        return data if isinstance(data, dict) else None
+
     async def devices_tree(self) -> JsonDict | None:
         """Return the system dashboard device hierarchy when available.
 

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -5448,6 +5448,9 @@ class BatteryRuntime:
         )
 
     def grid_envoy_serial(self) -> str | None:
+        preferred = self.coordinator.inventory_view.primary_gateway_serial()
+        if preferred:
+            return preferred
         bucket = self.coordinator.inventory_view.type_bucket("envoy")
         if not isinstance(bucket, dict):
             return None

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -68,6 +68,8 @@ def _typed_callback(func: _CallbackT) -> _CallbackT:
 
 
 DEVICES_INVENTORY_CACHE_TTL = 600.0
+GATEWAY_PHASE_MAP_CACHE_TTL = 21600.0
+GATEWAY_PHASE_MAP_FAILURE_BACKOFF_S = 3600.0
 HEMS_INVENTORY_ENDPOINT_FAMILY = "hems_inventory"
 HEMS_DEVICES_STALE_AFTER_S = 90.0
 HEMS_DEVICES_CACHE_TTL = 60.0
@@ -135,6 +137,9 @@ class InventoryRuntime:
     _gateway_iq_energy_router_records_cache: list[dict[str, object]]
     _gateway_iq_energy_router_records_source: object
     _gateway_iq_energy_router_records_by_key_cache: dict[str, dict[str, object]]
+    _gateway_phase_map: dict[str, dict[str, object]]
+    _gateway_phase_map_cache_until: float | None
+    _gateway_phase_map_failure_backoff_until: float | None
     _devices_inventory_cache_until: float | None
     _devices_inventory_ready: bool
     _hems_inventory_ready: bool
@@ -154,6 +159,11 @@ class InventoryRuntime:
         self.refresh_state = coordinator.refresh_state
         self.inventory_state = coordinator.inventory_state
         self.heatpump_state = coordinator.heatpump_state
+        self._update_shared_state(
+            _gateway_phase_map={},
+            _gateway_phase_map_cache_until=None,
+            _gateway_phase_map_failure_backoff_until=None,
+        )
 
     def _set_shared_state_attr(self, name: str, value: object) -> None:
         object.__setattr__(self, name, value)
@@ -194,6 +204,203 @@ class InventoryRuntime:
 
     def type_bucket(self, type_key: object) -> dict[str, object] | None:
         return self.coordinator.inventory_view.type_bucket(type_key)
+
+    @staticmethod
+    def _normalize_gateway_phase_map(
+        payload: object,
+    ) -> dict[str, dict[str, object]]:
+        """Normalize the dynamic gateway-keyed phase-map response."""
+
+        if not isinstance(payload, dict):
+            return {}
+        field_aliases = {
+            "connectedLoadControl": "connected_load_control",
+            "hasGenerator": "has_generator",
+            "hasIqBattery": "has_iq_battery",
+            "hasAcb": "has_acb",
+            "isSplitPhase": "is_split_phase",
+            "isProductionOnly": "is_production_only",
+            "isConsumptionOnly": "is_consumption_only",
+            "showSmartMeterConsumption": "show_smart_meter_consumption",
+            "hasEnpower": "has_enpower",
+            "hasEncharge": "has_encharge",
+            "showStorage": "show_storage",
+            "isEnsemble": "is_ensemble",
+            "isDefaultGateway": "is_default_gateway",
+            "isPrimaryGateway": "is_primary_gateway",
+            "any": "any_phase",
+            "all": "all_phases",
+        }
+        normalized: dict[str, dict[str, object]] = {}
+        for raw_serial, raw_details in payload.items():
+            serial = coerce_optional_text(raw_serial)
+            if serial is None or not isinstance(raw_details, dict):
+                continue
+            details: dict[str, object] = {}
+            for source_key, target_key in field_aliases.items():
+                value = coerce_optional_bool(raw_details.get(source_key))
+                if value is not None:
+                    details[target_key] = value
+            total_phase = coerce_int(raw_details.get("totalPhase"), default=0)
+            if total_phase > 0:
+                details["total_phase"] = total_phase
+            gateway_status = coerce_optional_text(raw_details.get("gatewayStatus"))
+            if gateway_status is not None:
+                details["gateway_status"] = gateway_status
+            phases_raw = raw_details.get("phases")
+            if isinstance(phases_raw, dict):
+                phases: dict[str, bool] = {}
+                for raw_phase, raw_enabled in phases_raw.items():
+                    phase = coerce_optional_text(raw_phase)
+                    enabled = coerce_optional_bool(raw_enabled)
+                    if phase is not None and enabled is not None:
+                        phases[phase] = enabled
+                if phases:
+                    details["phases"] = phases
+            normalized[serial] = details
+        return normalized
+
+    def gateway_phase_map(self) -> dict[str, dict[str, object]]:
+        """Return a defensive copy of normalized gateway topology metadata."""
+
+        raw = getattr(self, "_gateway_phase_map", None)
+        if not isinstance(raw, dict):
+            return {}
+        copied: dict[str, dict[str, object]] = {}
+        for serial, details in raw.items():
+            if not isinstance(details, dict):
+                continue
+            item = dict(details)
+            phases = item.get("phases")
+            if isinstance(phases, dict):
+                item["phases"] = dict(phases)
+            copied[str(serial)] = item
+        return copied
+
+    def gateway_phase_map_for_serial(self, serial: object) -> dict[str, object] | None:
+        """Return phase-map metadata for one gateway serial."""
+
+        serial_text = coerce_optional_text(serial)
+        if serial_text is None:
+            return None
+        details = self.gateway_phase_map().get(serial_text)
+        return dict(details) if isinstance(details, dict) else None
+
+    def gateway_phase_map_preferred_serial(self) -> str | None:
+        """Return the primary/default gateway serial advertised by the phase map."""
+
+        phase_map = self.gateway_phase_map()
+        for flag in ("is_primary_gateway", "is_default_gateway"):
+            for serial, details in phase_map.items():
+                if details.get(flag) is True:
+                    return serial
+        if len(phase_map) == 1:
+            return next(iter(phase_map))
+        return None
+
+    def gateway_phase_map_summary(self) -> dict[str, object]:
+        """Return a compact topology summary suitable for diagnostics/entities."""
+
+        phase_map = self.gateway_phase_map()
+        preferred = self.gateway_phase_map_preferred_serial()
+        primary = next(
+            (
+                serial
+                for serial, details in phase_map.items()
+                if details.get("is_primary_gateway") is True
+            ),
+            None,
+        )
+        default = next(
+            (
+                serial
+                for serial, details in phase_map.items()
+                if details.get("is_default_gateway") is True
+            ),
+            None,
+        )
+        preferred_details = phase_map.get(preferred or "", {})
+        return {
+            "gateway_count": len(phase_map),
+            "multi_gateway": len(phase_map) > 1,
+            "primary_gateway_serial": primary,
+            "default_gateway_serial": default,
+            "preferred_gateway_serial": preferred,
+            "preferred_gateway_phase_count": preferred_details.get("total_phase"),
+            "split_phase_gateway_count": sum(
+                details.get("is_split_phase") is True for details in phase_map.values()
+            ),
+            "three_phase_gateway_count": sum(
+                details.get("total_phase") == 3 for details in phase_map.values()
+            ),
+            "production_only_gateway_count": sum(
+                details.get("is_production_only") is True
+                for details in phase_map.values()
+            ),
+            "consumption_only_gateway_count": sum(
+                details.get("is_consumption_only") is True
+                for details in phase_map.values()
+            ),
+            "storage_gateway_count": sum(
+                details.get("show_storage") is True
+                or details.get("has_iq_battery") is True
+                or details.get("has_encharge") is True
+                for details in phase_map.values()
+            ),
+        }
+
+    def gateway_phase_map_refresh_due(self, *, force: bool = False) -> bool:
+        """Return whether the optional gateway phase map should be refreshed."""
+
+        fetcher = getattr(self.client, "phase_map_multiple_envoy", None)
+        if not callable(fetcher):
+            return False
+        if force:
+            return True
+        now = time.monotonic()
+        cache_until = getattr(self, "_gateway_phase_map_cache_until", None)
+        if isinstance(cache_until, (int, float)) and now < float(cache_until):
+            return False
+        backoff_until = getattr(self, "_gateway_phase_map_failure_backoff_until", None)
+        return not (
+            isinstance(backoff_until, (int, float)) and now < float(backoff_until)
+        )
+
+    async def _async_refresh_gateway_phase_map(self, *, force: bool = False) -> None:
+        """Refresh optional multi-gateway topology without failing inventory."""
+
+        if not self.gateway_phase_map_refresh_due(force=force):
+            return
+        fetcher = cast(
+            Callable[[], Awaitable[object]],
+            getattr(self.client, "phase_map_multiple_envoy"),
+        )
+        now = time.monotonic()
+        try:
+            payload = await fetcher()
+        except Exception as err:  # noqa: BLE001
+            self._set_shared_state_attr(
+                "_gateway_phase_map_failure_backoff_until",
+                now + GATEWAY_PHASE_MAP_FAILURE_BACKOFF_S,
+            )
+            _LOGGER.debug(
+                "Gateway phase-map refresh failed for site %s: %s",
+                redact_site_id(self.site_id),
+                redact_text(err, site_ids=(self.site_id,)),
+            )
+            return
+        if payload is not None and not isinstance(payload, dict):
+            self._set_shared_state_attr(
+                "_gateway_phase_map_failure_backoff_until",
+                now + GATEWAY_PHASE_MAP_FAILURE_BACKOFF_S,
+            )
+            return
+        normalized = self._normalize_gateway_phase_map(payload or {})
+        self._update_shared_state(
+            _gateway_phase_map=normalized,
+            _gateway_phase_map_cache_until=now + GATEWAY_PHASE_MAP_CACHE_TTL,
+            _gateway_phase_map_failure_backoff_until=None,
+        )
 
     def _type_member_text(self, member: dict[str, object], *keys: str) -> str | None:
         value = type_member_text(member, *keys)
@@ -1247,6 +1454,7 @@ class InventoryRuntime:
         return (
             id(self._summary_type_bucket_source("envoy")),
             id(dashboard_envoy),
+            id(getattr(self, "_gateway_phase_map", None)),
         )
 
     def _microinverter_inventory_summary_marker(self) -> tuple[object, ...]:
@@ -1467,6 +1675,7 @@ class InventoryRuntime:
             ),
             "latest_reported_device": latest_reported_device,
             "property_keys": sorted(property_keys),
+            **self.gateway_phase_map_summary(),
         }
 
     def _build_microinverter_inventory_summary(self) -> dict[str, object]:
@@ -1872,6 +2081,7 @@ class InventoryRuntime:
     async def _async_refresh_devices_inventory(self, *, force: bool = False) -> None:
         coord = self.coordinator
         now = time.monotonic()
+        await self._async_refresh_gateway_phase_map(force=force)
         family = "inventory_topology"
         if not coord._endpoint_family_should_run(family, force=force):
             return
@@ -1948,13 +2158,14 @@ class InventoryRuntime:
     def devices_inventory_refresh_due(self, *, force: bool = False) -> bool:
         coord = self.coordinator
         now = time.monotonic()
+        phase_map_due = self.gateway_phase_map_refresh_due(force=force)
         if not coord._endpoint_family_should_run("inventory_topology", force=force):
-            return False
+            return phase_map_due
         if not force and self._devices_inventory_cache_until:
             if now < self._devices_inventory_cache_until:
-                return False
+                return phase_map_due
         fetcher = getattr(self.client, "devices_inventory", None)
-        return callable(fetcher)
+        return phase_map_due or callable(fetcher)
 
     async def _async_refresh_hems_devices(self, *, force: bool = False) -> None:
         coord = self.coordinator

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -302,6 +302,8 @@ class InventoryRuntime:
         """Return a compact topology summary suitable for diagnostics/entities."""
 
         phase_map = self.gateway_phase_map()
+        if not phase_map:
+            return {}
         preferred = self.gateway_phase_map_preferred_serial()
         primary = next(
             (
@@ -389,13 +391,13 @@ class InventoryRuntime:
                 redact_text(err, site_ids=(self.site_id,)),
             )
             return
-        if payload is not None and not isinstance(payload, dict):
+        if not isinstance(payload, dict):
             self._set_shared_state_attr(
                 "_gateway_phase_map_failure_backoff_until",
                 now + GATEWAY_PHASE_MAP_FAILURE_BACKOFF_S,
             )
             return
-        normalized = self._normalize_gateway_phase_map(payload or {})
+        normalized = self._normalize_gateway_phase_map(payload)
         self._update_shared_state(
             _gateway_phase_map=normalized,
             _gateway_phase_map_cache_until=now + GATEWAY_PHASE_MAP_CACHE_TTL,

--- a/custom_components/enphase_ev/inventory_view.py
+++ b/custom_components/enphase_ev/inventory_view.py
@@ -367,6 +367,17 @@ class InventoryView:
             return "consumption"
         return None
 
+    @staticmethod
+    def _envoy_member_serial(member: dict[str, object]) -> str | None:
+        return InventoryView._type_member_text(
+            member,
+            "serial_number",
+            "serialNumber",
+            "serial",
+            "device_sn",
+            "sn",
+        )
+
     def _envoy_system_controller_member(self) -> dict[str, object] | None:
         for member in self._type_bucket_members("envoy"):
             if self._envoy_member_kind(member) == "controller":
@@ -380,6 +391,15 @@ class InventoryView:
             "controller",
         ):
             return False
+        serial = self._envoy_member_serial(member)
+        phase_map_for_serial = getattr(
+            self.coordinator.inventory_runtime,
+            "gateway_phase_map_for_serial",
+            None,
+        )
+        if serial and callable(phase_map_for_serial):
+            if phase_map_for_serial(serial) is not None:
+                return True
         if any(
             member.get(key) is not None
             for key in (
@@ -396,10 +416,34 @@ class InventoryView:
         return "gateway" in name
 
     def _envoy_primary_gateway_member(self) -> dict[str, object] | None:
-        for member in self._type_bucket_members("envoy"):
-            if self._envoy_member_looks_like_gateway(member):
-                return member
+        members = [
+            member
+            for member in self._type_bucket_members("envoy")
+            if self._envoy_member_looks_like_gateway(member)
+        ]
+        preferred_serial_getter = getattr(
+            self.coordinator.inventory_runtime,
+            "gateway_phase_map_preferred_serial",
+            None,
+        )
+        preferred_serial = (
+            preferred_serial_getter() if callable(preferred_serial_getter) else None
+        )
+        if preferred_serial:
+            for member in members:
+                if self._envoy_member_serial(member) == preferred_serial:
+                    return member
+        if members:
+            return members[0]
         return None
+
+    def primary_gateway_serial(self) -> str | None:
+        """Return the phase-map-preferred active gateway serial."""
+
+        member = self._envoy_primary_gateway_member()
+        if member is None:
+            return None
+        return self._envoy_member_serial(member)
 
     def _envoy_preferred_member(self) -> dict[str, object] | None:
         gateway = self._envoy_primary_gateway_member()

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -7416,6 +7416,9 @@ class EnphaseGatewayConnectivityStatusSensor(_SiteBaseEntity):
             "latest_reported_utc",
             "latest_reported_device",
             "property_keys",
+            "primary_gateway_serial",
+            "default_gateway_serial",
+            "preferred_gateway_serial",
         }
     )
 
@@ -7459,6 +7462,23 @@ class EnphaseGatewayConnectivityStatusSensor(_SiteBaseEntity):
             "latest_reported_utc": snapshot.get("latest_reported_utc"),
             "latest_reported_device": snapshot.get("latest_reported_device"),
             "property_keys": snapshot.get("property_keys"),
+            "gateway_count": snapshot.get("gateway_count"),
+            "multi_gateway": snapshot.get("multi_gateway"),
+            "primary_gateway_serial": snapshot.get("primary_gateway_serial"),
+            "default_gateway_serial": snapshot.get("default_gateway_serial"),
+            "preferred_gateway_serial": snapshot.get("preferred_gateway_serial"),
+            "preferred_gateway_phase_count": snapshot.get(
+                "preferred_gateway_phase_count"
+            ),
+            "split_phase_gateway_count": snapshot.get("split_phase_gateway_count"),
+            "three_phase_gateway_count": snapshot.get("three_phase_gateway_count"),
+            "production_only_gateway_count": snapshot.get(
+                "production_only_gateway_count"
+            ),
+            "consumption_only_gateway_count": snapshot.get(
+                "consumption_only_gateway_count"
+            ),
+            "storage_gateway_count": snapshot.get("storage_gateway_count"),
         }
 
 

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -7449,7 +7449,7 @@ class EnphaseGatewayConnectivityStatusSensor(_SiteBaseEntity):
     @property
     def extra_state_attributes(self) -> Any:
         snapshot = _gateway_inventory_snapshot(self._coord)
-        return {
+        attributes = {
             "total_devices": snapshot.get("total_devices"),
             "connected_devices": snapshot.get("connected_devices"),
             "disconnected_devices": snapshot.get("disconnected_devices"),
@@ -7462,24 +7462,24 @@ class EnphaseGatewayConnectivityStatusSensor(_SiteBaseEntity):
             "latest_reported_utc": snapshot.get("latest_reported_utc"),
             "latest_reported_device": snapshot.get("latest_reported_device"),
             "property_keys": snapshot.get("property_keys"),
-            "gateway_count": snapshot.get("gateway_count"),
-            "multi_gateway": snapshot.get("multi_gateway"),
-            "primary_gateway_serial": snapshot.get("primary_gateway_serial"),
-            "default_gateway_serial": snapshot.get("default_gateway_serial"),
-            "preferred_gateway_serial": snapshot.get("preferred_gateway_serial"),
-            "preferred_gateway_phase_count": snapshot.get(
-                "preferred_gateway_phase_count"
-            ),
-            "split_phase_gateway_count": snapshot.get("split_phase_gateway_count"),
-            "three_phase_gateway_count": snapshot.get("three_phase_gateway_count"),
-            "production_only_gateway_count": snapshot.get(
-                "production_only_gateway_count"
-            ),
-            "consumption_only_gateway_count": snapshot.get(
-                "consumption_only_gateway_count"
-            ),
-            "storage_gateway_count": snapshot.get("storage_gateway_count"),
         }
+        phase_map_keys = (
+            "gateway_count",
+            "multi_gateway",
+            "primary_gateway_serial",
+            "default_gateway_serial",
+            "preferred_gateway_serial",
+            "preferred_gateway_phase_count",
+            "split_phase_gateway_count",
+            "three_phase_gateway_count",
+            "production_only_gateway_count",
+            "consumption_only_gateway_count",
+            "storage_gateway_count",
+        )
+        attributes.update(
+            {key: snapshot[key] for key in phase_map_keys if key in snapshot}
+        )
+        return attributes
 
 
 class EnphaseGatewayLastReportedSensor(_SiteBaseEntity):

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -105,6 +105,7 @@ Status labels:
 | EV daily timeseries | `GET` | `/service/timeseries/evse/timeseries/daily_energy?site_id=<site_id>&source=evse&requestId=<uuid>&start_date=<YYYY-MM-DD>[&username=<user_id>]` | bearer token + session headers | Runtime |
 | EV lifetime timeseries | `GET` | `/service/timeseries/evse/timeseries/lifetime_energy?site_id=<site_id>&source=evse&requestId=<uuid>[&username=<user_id>]` | bearer token + session headers | Runtime |
 | Site inventory | `GET` | `/app-api/<site_id>/devices.json` | `e-auth-token` + cookies | Runtime |
+| Multi-gateway phase map | `GET` | `/app-api/<site_id>/phase_map_multiple_envoy` | authenticated session cookies + `e-auth-token` | Runtime |
 | Site bootstrap payload | `GET` | `/app-api/<site_id>/data.json?app=<id>&device_status=non_retired&is_mobile=<id>` | authenticated session cookies + `e-auth-token` | Browser capture only |
 | Filtered site-device inventory | `POST` | `/service/site-device/api/v2/devices/list` | `e-auth-token` + cookies | Browser capture only |
 | Site live-stream flags | `GET` | `/app-api/<site_id>/show_livestream` | authenticated session cookies | Runtime |
@@ -1486,7 +1487,54 @@ Notes:
 - The observed capture returned `value=-30`, confirming the field can go negative. Preserve negative samples rather than clamping to `0`; they likely represent net import or reverse power flow.
 - The normalized runtime field is `current_power_consumption_w` with source `app-api:get_latest_power`.
 
-### 2.9.3.a Site Bootstrap Payload
+### 2.9.3.a Multi-Gateway Phase Map
+
+```http
+GET /app-api/<site_id>/phase_map_multiple_envoy
+```
+
+Returns a map keyed by Gateway serial number. The integration uses it to select
+the primary/default Gateway on multi-Gateway sites and to expose compact phase
+and topology diagnostics.
+
+```json
+{
+  "<gateway_sn>": {
+    "connectedLoadControl": false,
+    "hasGenerator": false,
+    "hasIqBattery": true,
+    "hasAcb": false,
+    "isSplitPhase": false,
+    "isProductionOnly": false,
+    "isConsumptionOnly": false,
+    "showSmartMeterConsumption": false,
+    "totalPhase": 3,
+    "hasEnpower": true,
+    "hasEncharge": true,
+    "showStorage": true,
+    "isEnsemble": true,
+    "gatewayStatus": "normal",
+    "isDefaultGateway": true,
+    "isPrimaryGateway": true,
+    "phases": {"0": true, "1": true, "2": true},
+    "any": true,
+    "all": true
+  }
+}
+```
+
+Implementation notes:
+
+- The dynamic object keys are device serial numbers and must be redacted in
+  logs and diagnostics.
+- Prefer `isPrimaryGateway`, then `isDefaultGateway`, when selecting a Gateway
+  for site-level controls. A one-entry map is an unambiguous fallback.
+- The payload is topology metadata and is cached for six hours. Failures use a
+  one-hour retry backoff and preserve the last successful map.
+- The optional endpoint must not make the authoritative device inventory
+  unavailable.
+
+### 2.9.3.b Site Bootstrap Payload
 ```
 GET /app-api/<site_id>/data.json?app=1&device_status=non_retired&is_mobile=0
 ```
@@ -1533,7 +1581,7 @@ Observed notes:
 - Real captures contain personal data, support URLs, authenticity tokens, and signed links; those must be redacted before sharing.
 - This appears to be an app bootstrap/config payload rather than a stable telemetry endpoint.
 
-### 2.9.3.b Site Currency Conversion Settings
+### 2.9.3.c Site Currency Conversion Settings
 ```
 GET /app-api/<site_id>/get_currency_conversion.json
 ```
@@ -1556,7 +1604,7 @@ Observed notes:
 - `value_per_kwh` was observed as a string rather than a numeric JSON value.
 - `currency_symbol` is display-oriented text and should not be interpreted as a normalized ISO code.
 
-### 2.9.3.c Requested Battery Usage Hint
+### 2.9.3.d Requested Battery Usage Hint
 ```
 GET /app-api/<site_id>/get_requested_battery_usage
 ```
@@ -1573,7 +1621,7 @@ Observed notes:
 - The only observed value so far is `null`.
 - Semantics remain unclear; preserve future non-null values verbatim until more captures exist.
 
-### 2.9.3.d Site Performance Widget Flags
+### 2.9.3.e Site Performance Widget Flags
 ```
 GET /app-api/<site_id>/performance_widgets
 ```
@@ -1590,7 +1638,7 @@ Example response:
 }
 ```
 
-### 2.9.3.e PowerMatch UI Flags
+### 2.9.3.f PowerMatch UI Flags
 ```
 GET /app-api/<site_id>/powermatch_details
 ```
@@ -1607,7 +1655,7 @@ Example response:
 Observed notes:
 - The HAR does not establish backend semantics for `enabled` versus `show`; document them as UI flags only until more evidence exists.
 
-### 2.9.3.f Legacy Site Tariff Flags
+### 2.9.3.g Legacy Site Tariff Flags
 ```
 GET /app-api/<site_id>/tariff.json?country=<country>
 ```

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -2469,6 +2469,63 @@ async def test_devices_inventory_returns_empty_when_payload_not_dict() -> None:
 
 
 @pytest.mark.asyncio
+async def test_phase_map_multiple_envoy_uses_app_api_endpoint() -> None:
+    client = _make_client()
+    payload = {"GW-2": {"isDefaultGateway": True, "totalPhase": 3}}
+    client._json = AsyncMock(return_value=payload)
+
+    result = await client.phase_map_multiple_envoy()
+
+    assert result == payload
+    client._json.assert_awaited_once_with(
+        "GET",
+        f"{api.BASE_URL}/app-api/SITE/phase_map_multiple_envoy",
+        headers=client._history_headers(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_phase_map_multiple_envoy_rejects_non_mapping_payload() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value=[])
+
+    assert await client.phase_map_multiple_envoy() is None
+
+
+@pytest.mark.asyncio
+async def test_phase_map_multiple_envoy_wraps_optional_html_payload() -> None:
+    client = _make_client()
+    error = api.InvalidPayloadError(
+        "HTML response",
+        status=200,
+        content_type="text/html",
+        endpoint="/app-api/SITE/phase_map_multiple_envoy",
+        failure_kind="html",
+        body_preview_redacted="<html></html>",
+    )
+    client._json = AsyncMock(side_effect=error)
+
+    with pytest.raises(api.OptionalEndpointUnavailable):
+        await client.phase_map_multiple_envoy()
+
+
+@pytest.mark.asyncio
+async def test_phase_map_multiple_envoy_reraises_json_payload_error() -> None:
+    client = _make_client()
+    error = api.InvalidPayloadError(
+        "JSON response failed",
+        status=500,
+        content_type="application/json",
+        endpoint="/app-api/SITE/phase_map_multiple_envoy",
+        failure_kind="decode",
+    )
+    client._json = AsyncMock(side_effect=error)
+
+    with pytest.raises(api.InvalidPayloadError):
+        await client.phase_map_multiple_envoy()
+
+
+@pytest.mark.asyncio
 async def test_devices_tree_uses_system_dashboard_endpoint_and_headers() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"devices": []})

--- a/tests/components/enphase_ev/test_gateway_phase_map.py
+++ b/tests/components/enphase_ev/test_gateway_phase_map.py
@@ -1,0 +1,318 @@
+"""Tests for multi-gateway phase-map topology support."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.enphase_ev.inventory_runtime import (
+    GATEWAY_PHASE_MAP_CACHE_TTL,
+    GATEWAY_PHASE_MAP_FAILURE_BACKOFF_S,
+    InventoryRuntime,
+)
+from custom_components.enphase_ev.sensor import EnphaseGatewayConnectivityStatusSensor
+
+PHASE_MAP = {
+    "GW-1": {
+        "isPrimaryGateway": False,
+        "isDefaultGateway": False,
+        "isProductionOnly": True,
+        "isConsumptionOnly": False,
+        "isSplitPhase": False,
+        "totalPhase": 1,
+        "hasIqBattery": False,
+        "hasEncharge": False,
+        "showStorage": False,
+        "gatewayStatus": "normal",
+        "phases": {"0": True, "1": False},
+        "any": True,
+        "all": False,
+    },
+    "GW-2": {
+        "isPrimaryGateway": True,
+        "isDefaultGateway": True,
+        "isProductionOnly": False,
+        "isConsumptionOnly": False,
+        "isSplitPhase": False,
+        "totalPhase": 3,
+        "hasIqBattery": True,
+        "hasEncharge": True,
+        "showStorage": True,
+        "hasEnpower": True,
+        "isEnsemble": True,
+        "gatewayStatus": "normal",
+        "phases": {"0": True, "1": True, "2": True},
+        "any": True,
+        "all": True,
+    },
+}
+
+
+def _set_gateway_members(coord) -> None:
+    coord._type_device_buckets = {  # noqa: SLF001
+        "envoy": {
+            "type_key": "envoy",
+            "type_label": "IQ Gateway",
+            "count": 2,
+            "devices": [
+                {"name": "Gateway One", "serial_number": "GW-1"},
+                {"name": "Gateway Two", "serial_number": "GW-2"},
+            ],
+        }
+    }
+    coord._type_device_order = ["envoy"]  # noqa: SLF001
+    coord._devices_inventory_ready = True  # noqa: SLF001
+
+
+def test_normalize_gateway_phase_map() -> None:
+    normalized = InventoryRuntime._normalize_gateway_phase_map(
+        PHASE_MAP
+    )  # noqa: SLF001
+
+    assert normalized["GW-2"] == {
+        "has_iq_battery": True,
+        "is_split_phase": False,
+        "is_production_only": False,
+        "is_consumption_only": False,
+        "has_enpower": True,
+        "has_encharge": True,
+        "show_storage": True,
+        "is_ensemble": True,
+        "is_default_gateway": True,
+        "is_primary_gateway": True,
+        "any_phase": True,
+        "all_phases": True,
+        "total_phase": 3,
+        "gateway_status": "normal",
+        "phases": {"0": True, "1": True, "2": True},
+    }
+
+
+def test_normalize_gateway_phase_map_skips_invalid_values() -> None:
+    class _BadText:
+        def __str__(self) -> str:
+            raise RuntimeError("bad")
+
+    payload = {
+        _BadText(): {},
+        "": {},
+        "GW": {
+            "totalPhase": "bad",
+            "gatewayStatus": " ",
+            "phases": {"0": "yes", _BadText(): True, "1": "unknown"},
+        },
+        "BAD": [],
+    }
+
+    assert InventoryRuntime._normalize_gateway_phase_map(payload) == {  # noqa: SLF001
+        "GW": {"phases": {"0": True}}
+    }
+    assert InventoryRuntime._normalize_gateway_phase_map([]) == {}  # noqa: SLF001
+
+
+def test_phase_map_prefers_primary_gateway_for_inventory_and_grid_control(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _set_gateway_members(coord)
+    coord.inventory_runtime._gateway_phase_map = (  # noqa: SLF001
+        coord.inventory_runtime._normalize_gateway_phase_map(PHASE_MAP)  # noqa: SLF001
+    )
+
+    assert coord.inventory_view.primary_gateway_serial() == "GW-2"
+    assert coord.battery_runtime.grid_envoy_serial() == "GW-2"
+
+
+def test_phase_map_falls_back_to_default_then_single_gateway(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _set_gateway_members(coord)
+    coord.inventory_runtime._gateway_phase_map = {  # noqa: SLF001
+        "GW-1": {"is_default_gateway": True},
+        "GW-2": {"is_primary_gateway": False},
+    }
+    assert coord.inventory_view.primary_gateway_serial() == "GW-1"
+
+    coord.inventory_runtime._gateway_phase_map = {  # noqa: SLF001
+        "GW-2": {"total_phase": 3}
+    }
+    assert coord.inventory_runtime.gateway_phase_map_preferred_serial() == "GW-2"
+
+
+def test_gateway_phase_map_summary_and_sensor_attributes(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    _set_gateway_members(coord)
+    coord.inventory_runtime._gateway_phase_map = (  # noqa: SLF001
+        coord.inventory_runtime._normalize_gateway_phase_map(PHASE_MAP)  # noqa: SLF001
+    )
+
+    summary = coord.inventory_runtime.gateway_phase_map_summary()
+    assert summary == {
+        "gateway_count": 2,
+        "multi_gateway": True,
+        "primary_gateway_serial": "GW-2",
+        "default_gateway_serial": "GW-2",
+        "preferred_gateway_serial": "GW-2",
+        "preferred_gateway_phase_count": 3,
+        "split_phase_gateway_count": 0,
+        "three_phase_gateway_count": 1,
+        "production_only_gateway_count": 1,
+        "consumption_only_gateway_count": 0,
+        "storage_gateway_count": 1,
+    }
+
+    sensor = EnphaseGatewayConnectivityStatusSensor(coord)
+    attributes = sensor.extra_state_attributes
+    assert attributes["gateway_count"] == 2
+    assert attributes["multi_gateway"] is True
+    assert attributes["preferred_gateway_serial"] == "GW-2"
+    assert attributes["preferred_gateway_phase_count"] == 3
+    assert attributes["storage_gateway_count"] == 1
+
+
+def test_gateway_phase_map_accessors_return_defensive_copies(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.inventory_runtime._gateway_phase_map = {  # noqa: SLF001
+        "GW-1": {"phases": {"0": True}}
+    }
+
+    copied = coord.inventory_runtime.gateway_phase_map()
+    copied["GW-1"]["total_phase"] = 3
+
+    assert coord.inventory_runtime.gateway_phase_map_for_serial("GW-1") == {
+        "phases": {"0": True}
+    }
+    assert coord.inventory_runtime.gateway_phase_map_for_serial("missing") is None
+    assert coord.inventory_runtime.gateway_phase_map_for_serial(None) is None
+
+    coord.inventory_runtime._gateway_phase_map = "bad"  # type: ignore[assignment]  # noqa: SLF001
+    assert coord.inventory_runtime.gateway_phase_map() == {}
+    coord.inventory_runtime._gateway_phase_map = {"GW-1": "bad"}  # type: ignore[dict-item]  # noqa: SLF001
+    assert coord.inventory_runtime.gateway_phase_map() == {}
+
+
+@pytest.mark.asyncio
+async def test_refresh_gateway_phase_map_success(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    fetcher = AsyncMock(return_value=PHASE_MAP)
+    coord.client = SimpleNamespace(phase_map_multiple_envoy=fetcher)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.inventory_runtime.time.monotonic", lambda: 100.0
+    )
+
+    await coord.inventory_runtime._async_refresh_gateway_phase_map()  # noqa: SLF001
+
+    fetcher.assert_awaited_once_with()
+    assert coord.inventory_runtime.gateway_phase_map_preferred_serial() == "GW-2"
+    assert coord._gateway_phase_map_cache_until == (  # noqa: SLF001
+        100.0 + GATEWAY_PHASE_MAP_CACHE_TTL
+    )
+    assert coord._gateway_phase_map_failure_backoff_until is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_refresh_gateway_phase_map_preserves_stale_on_error(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord.inventory_runtime._gateway_phase_map = {  # noqa: SLF001
+        "GW-OLD": {"is_default_gateway": True}
+    }
+    coord.client = SimpleNamespace(
+        phase_map_multiple_envoy=AsyncMock(side_effect=RuntimeError("network"))
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.inventory_runtime.time.monotonic", lambda: 200.0
+    )
+
+    await coord.inventory_runtime._async_refresh_gateway_phase_map()  # noqa: SLF001
+
+    assert coord.inventory_runtime.gateway_phase_map_preferred_serial() == "GW-OLD"
+    assert coord._gateway_phase_map_failure_backoff_until == (  # noqa: SLF001
+        200.0 + GATEWAY_PHASE_MAP_FAILURE_BACKOFF_S
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_gateway_phase_map_invalid_payload_sets_backoff(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord.client = SimpleNamespace(
+        phase_map_multiple_envoy=AsyncMock(return_value=["bad"])
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.inventory_runtime.time.monotonic", lambda: 300.0
+    )
+
+    await coord.inventory_runtime._async_refresh_gateway_phase_map()  # noqa: SLF001
+
+    assert coord._gateway_phase_map_failure_backoff_until == (  # noqa: SLF001
+        300.0 + GATEWAY_PHASE_MAP_FAILURE_BACKOFF_S
+    )
+
+
+@pytest.mark.asyncio
+async def test_inventory_refresh_runs_due_phase_map_inside_inventory_cache(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    phase_fetcher = AsyncMock(return_value=PHASE_MAP)
+    inventory_fetcher = AsyncMock(return_value={"result": []})
+    coord.client = SimpleNamespace(
+        phase_map_multiple_envoy=phase_fetcher,
+        devices_inventory=inventory_fetcher,
+    )
+    coord.inventory_runtime._devices_inventory_cache_until = 1000.0  # noqa: SLF001
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.inventory_runtime.time.monotonic", lambda: 100.0
+    )
+
+    await coord.inventory_runtime._async_refresh_devices_inventory()  # noqa: SLF001
+
+    phase_fetcher.assert_awaited_once_with()
+    inventory_fetcher.assert_not_awaited()
+
+
+def test_devices_inventory_refresh_due_when_only_phase_map_is_due(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord.client = SimpleNamespace(phase_map_multiple_envoy=AsyncMock())
+    coord.inventory_runtime._devices_inventory_cache_until = 1000.0  # noqa: SLF001
+    coord.inventory_runtime._gateway_phase_map_cache_until = None  # noqa: SLF001
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.inventory_runtime.time.monotonic", lambda: 100.0
+    )
+    monkeypatch.setattr(coord, "_endpoint_family_should_run", lambda *_a, **_k: False)
+
+    assert coord.inventory_runtime.devices_inventory_refresh_due() is True
+
+
+def test_gateway_phase_map_refresh_due_cache_backoff_and_missing_fetcher(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.inventory_runtime.time.monotonic", lambda: 100.0
+    )
+    coord.client = SimpleNamespace()
+    assert coord.inventory_runtime.gateway_phase_map_refresh_due() is False
+
+    coord.client = SimpleNamespace(phase_map_multiple_envoy=AsyncMock())
+    coord.inventory_runtime._gateway_phase_map_cache_until = 101.0  # noqa: SLF001
+    assert coord.inventory_runtime.gateway_phase_map_refresh_due() is False
+
+    coord.inventory_runtime._gateway_phase_map_cache_until = None  # noqa: SLF001
+    coord.inventory_runtime._gateway_phase_map_failure_backoff_until = (  # noqa: SLF001
+        101.0
+    )
+    assert coord.inventory_runtime.gateway_phase_map_refresh_due() is False
+    assert coord.inventory_runtime.gateway_phase_map_refresh_due(force=True) is True

--- a/tests/components/enphase_ev/test_gateway_phase_map.py
+++ b/tests/components/enphase_ev/test_gateway_phase_map.py
@@ -177,6 +177,11 @@ def test_gateway_phase_map_accessors_return_defensive_copies(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
+    assert coord.inventory_runtime.gateway_phase_map_summary() == {}
+    assert (
+        "gateway_count"
+        not in EnphaseGatewayConnectivityStatusSensor(coord).extra_state_attributes
+    )
     coord.inventory_runtime._gateway_phase_map = {  # noqa: SLF001
         "GW-1": {"phases": {"0": True}}
     }
@@ -245,8 +250,11 @@ async def test_refresh_gateway_phase_map_invalid_payload_sets_backoff(
     coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory()
+    coord.inventory_runtime._gateway_phase_map = {  # noqa: SLF001
+        "GW-OLD": {"is_default_gateway": True}
+    }
     coord.client = SimpleNamespace(
-        phase_map_multiple_envoy=AsyncMock(return_value=["bad"])
+        phase_map_multiple_envoy=AsyncMock(side_effect=[["bad"], None])
     )
     monkeypatch.setattr(
         "custom_components.enphase_ev.inventory_runtime.time.monotonic", lambda: 300.0
@@ -257,6 +265,12 @@ async def test_refresh_gateway_phase_map_invalid_payload_sets_backoff(
     assert coord._gateway_phase_map_failure_backoff_until == (  # noqa: SLF001
         300.0 + GATEWAY_PHASE_MAP_FAILURE_BACKOFF_S
     )
+    assert coord.inventory_runtime.gateway_phase_map_preferred_serial() == "GW-OLD"
+
+    await coord.inventory_runtime._async_refresh_gateway_phase_map(  # noqa: SLF001
+        force=True
+    )
+    assert coord.inventory_runtime.gateway_phase_map_preferred_serial() == "GW-OLD"
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -1092,6 +1092,7 @@ def test_inventory_runtime_devices_inventory_refresh_due_respects_cache(
     coord = coordinator_factory()
     runtime = coord.inventory_runtime
     runtime._devices_inventory_cache_until = 150.0  # noqa: SLF001
+    runtime._gateway_phase_map_cache_until = 150.0  # noqa: SLF001
     coord.client.devices_inventory = AsyncMock(side_effect=AssertionError("unused"))
     monkeypatch.setattr(inventory_runtime_mod.time, "monotonic", lambda: 100.0)
 


### PR DESCRIPTION
## Summary

Adds read-only multi-gateway phase-map discovery and normalized per-gateway topology/capability metadata.

Primary or default Gateway selection now informs site controls and Grid Control routing. Gateway Status exposes compact phase/topology diagnostics while high-cardinality serial attributes remain excluded from Recorder history. Follow-up review preserves stale topology on malformed/null responses and omits phase-map counts until authoritative data exists.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [x] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/inventory_view.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_gateway_phase_map.py tests/components/enphase_ev/test_inventory_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/pr-feature4.coverage python -m coverage erase && COVERAGE_FILE=/tmp/pr-feature4.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/pr-feature4.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/inventory_runtime.py,custom_components/enphase_ev/inventory_view.py,custom_components/enphase_ev/sensor.py --fail-under=100"
```

Post-rebase full suite: 3,675 passed. Touched modules: 14,856/14,856 statements covered.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, `docs/`) when behaviour or options changed.
- [x] I verified translations; no new user-facing translation keys were required.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results.
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The endpoint is optional, cached for six hours, backed off for one hour after failure, and cannot fail the authoritative inventory refresh.
