### PR TITLE
Monitor IQ Gateway software update progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ All notable changes to this project will be documented in this file.
   after Enphase returns a matching explicitly resolved event. The event entity is
   created only after the installer endpoint responds successfully, so owner-only
   accounts do not receive an unavailable installer-only entity.
+- Added read-only IQ Gateway software-update progress monitoring to the existing
+  advisory update entity, including Home Assistant in-progress/percentage state,
+  timing, installed image version, and sanitized component transfer details.
 
 ### 🐛 Bug fixes
 - Fixed Enlighten authentication after Enphase retired the Entrez token mint by
@@ -42,6 +45,9 @@ All notable changes to this project will be documented in this file.
 - Bound optional Enlighten request queueing and startup warmup stages, reserve
   cloud-read capacity for core status traffic, and retain the last current-power
   sample with retry backoff when that optional endpoint is unavailable.
+- Added bounded live-debug timeouts, active/idle cache intervals, failure backoff,
+  stale-state preservation, and cancellation-safe background refresh for gateway
+  software-update monitoring.
 - Documented the IQ EV Charger device automation triggers and the integration's
   use of standard Home Assistant conditions.
 - Reused a Home Assistant-managed stateless HTTP session for cookie-authenticated

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Guided onboarding for site selection and device-category enablement
 - Unified support for EV chargers, gateway, battery, and microinverter entities
 - EV charging controls and session telemetry, including charge-mode aware behavior and persistent default charge-level controls when exposed by Enphase
-- Advisory firmware update entities for gateway and EV charger devices with locale-aware release-note links
+- Advisory firmware update entities for gateway and EV charger devices with locale-aware release-note links; the gateway entity also monitors read-only live update progress, percentage, timing, and sanitized component status when Enphase exposes it
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
 - Site tariff visibility for next billing date, Energy-dashboard-ready current import/export price sensors, editable tariff rate number entities, and a service for billing-cycle, rate, and guided structural tariff updates when Enphase exposes tariff data

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1504,6 +1504,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     from .evse_schedule_editor import EvseScheduleEditorManager
     from .evse_firmware import EvseFirmwareDetailsManager
     from .firmware_catalog import FirmwareCatalogManager
+    from .gateway_software_update import GatewaySoftwareUpdateManager
     from .labels import async_prime_label_translations
 
     coord = EnphaseCoordinator(
@@ -1518,6 +1519,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     )
     firmware_catalog = FirmwareCatalogManager(hass)
     evse_firmware_details = EvseFirmwareDetailsManager(lambda: coord.client)
+    gateway_software_update = GatewaySoftwareUpdateManager(
+        lambda: coord.client,
+        lambda: coord.inventory_view.type_device_serial_number("envoy"),
+    )
     battery_schedule_editor = BatteryScheduleEditorManager(coord)
     evse_schedule_editor = EvseScheduleEditorManager(coord)
     setattr(coord, "firmware_catalog_manager", firmware_catalog)
@@ -1526,6 +1531,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
         coordinator=coord,
         firmware_catalog=firmware_catalog,
         evse_firmware_details=evse_firmware_details,
+        gateway_software_update=gateway_software_update,
         battery_schedule_editor=battery_schedule_editor,
         evse_schedule_editor=evse_schedule_editor,
     )

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -6367,7 +6367,12 @@ class EnphaseEVClient:
         query: dict[str, str] = {"serial_num": str(serial_num)}
         if live_debug:
             query["live_debug"] = "true"
-        url = URL(f"{BASE_URL}/pv/aws_sigv4/livestream.json").with_query(query)
+        endpoint = (
+            "/service/system_dashboard/api_internal/cs/sites/livestream"
+            if live_debug
+            else "/pv/aws_sigv4/livestream.json"
+        )
+        url = URL(f"{BASE_URL}{endpoint}").with_query(query)
         headers = self._today_headers()
         headers["X-Requested-With"] = "XMLHttpRequest"
         try:

--- a/custom_components/enphase_ev/gateway_software_update.py
+++ b/custom_components/enphase_ev/gateway_software_update.py
@@ -1,0 +1,402 @@
+"""Read-only IQ Gateway software-update progress monitoring."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from typing import Any
+
+from homeassistant.util import dt as dt_util
+
+from .log_redaction import redact_text
+from .parsing_helpers import coerce_optional_text as _text
+from .runtime_helpers import (
+    iso_or_none as _iso_or_none,
+    monotonic_deadline_to_utc_iso as _mono_to_utc_iso,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+GATEWAY_UPDATE_IDLE_TTL_SECONDS = 15 * 60
+GATEWAY_UPDATE_ACTIVE_TTL_SECONDS = 30
+GATEWAY_UPDATE_RETRY_BACKOFF_SECONDS = 15 * 60
+GATEWAY_UPDATE_FETCH_TIMEOUT_SECONDS = 15
+
+_ACTIVE_STATUS_WORDS = (
+    "download",
+    "install",
+    "transfer",
+    "updat",
+    "upgrade",
+    "in progress",
+)
+_TERMINAL_STATUS_WORDS = (
+    "up to date",
+    "complete",
+    "completed",
+    "done",
+    "fail",
+    "error",
+    "cancel",
+    "idle",
+    "success",
+)
+_DURATION_PART_RE = re.compile(
+    r"(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>days?|d|hours?|hrs?|h|minutes?|mins?|m|seconds?|secs?|s)",
+    re.IGNORECASE,
+)
+
+
+class GatewaySoftwareUpdateManager:
+    """Cache sanitized gateway update progress with stale-on-error behavior."""
+
+    def __init__(
+        self,
+        client_getter: Callable[[], Any],
+        serial_getter: Callable[[], str | None],
+        *,
+        idle_ttl_seconds: int = GATEWAY_UPDATE_IDLE_TTL_SECONDS,
+        active_ttl_seconds: int = GATEWAY_UPDATE_ACTIVE_TTL_SECONDS,
+        retry_backoff_seconds: int = GATEWAY_UPDATE_RETRY_BACKOFF_SECONDS,
+        fetch_timeout_seconds: int = GATEWAY_UPDATE_FETCH_TIMEOUT_SECONDS,
+    ) -> None:
+        self._client_getter = client_getter
+        self._serial_getter = serial_getter
+        self._idle_ttl_seconds = max(60, int(idle_ttl_seconds))
+        self._active_ttl_seconds = max(15, int(active_ttl_seconds))
+        self._retry_backoff_seconds = max(60, int(retry_backoff_seconds))
+        self._fetch_timeout_seconds = max(5, int(fetch_timeout_seconds))
+
+        self._status: dict[str, Any] | None = None
+        self._expires_mono = 0.0
+        self._last_fetch_utc: datetime | None = None
+        self._last_success_utc: datetime | None = None
+        self._last_error: str | None = None
+        self._using_stale = False
+        self._lock = asyncio.Lock()
+
+    @property
+    def cached_status(self) -> dict[str, Any] | None:
+        """Return the current normalized status."""
+        return self._status
+
+    @property
+    def next_refresh_seconds(self) -> float:
+        """Return the bounded delay until another network refresh is useful."""
+        return max(1.0, self._expires_mono - time.monotonic())
+
+    async def async_get_status(
+        self, *, force_refresh: bool = False
+    ) -> dict[str, Any] | None:
+        """Fetch and normalize one live-debug update message."""
+        now = time.monotonic()
+        if not force_refresh and now < self._expires_mono:
+            return self._status
+
+        async with self._lock:
+            now = time.monotonic()
+            if not force_refresh and now < self._expires_mono:
+                return self._status
+
+            self._last_fetch_utc = dt_util.utcnow()
+            try:
+                client = self._client_getter()
+                serial = _text(self._serial_getter())
+                if client is None:
+                    raise RuntimeError("client unavailable")
+                if serial is None:
+                    raise RuntimeError("gateway serial unavailable")
+                payload = await asyncio.wait_for(
+                    client.site_livestream_payload(
+                        serial,
+                        live_debug=True,
+                        timeout_s=float(self._fetch_timeout_seconds),
+                    ),
+                    timeout=float(self._fetch_timeout_seconds + 2),
+                )
+                status = normalize_gateway_software_update(payload)
+                if status is None:
+                    raise RuntimeError("software-update status unavailable")
+            except Exception as err:  # noqa: BLE001
+                self._last_error = redact_text(err)
+                self._using_stale = self._status is not None
+                self._expires_mono = time.monotonic() + self._retry_backoff_seconds
+                _LOGGER.debug(
+                    "Gateway software-update progress refresh failed: %s",
+                    self._last_error,
+                )
+                return self._status
+
+            self._status = status
+            self._last_success_utc = dt_util.utcnow()
+            self._last_error = None
+            self._using_stale = False
+            ttl = (
+                self._active_ttl_seconds
+                if status.get("in_progress") is True
+                else self._idle_ttl_seconds
+            )
+            self._expires_mono = time.monotonic() + ttl
+            return self._status
+
+    def status_snapshot(self) -> dict[str, Any]:
+        """Return diagnostics-safe cache metadata."""
+        return {
+            "cache_expires_utc": _mono_to_utc_iso(self._expires_mono),
+            "last_fetch_utc": _iso_or_none(self._last_fetch_utc),
+            "last_success_utc": _iso_or_none(self._last_success_utc),
+            "last_error": self._last_error,
+            "using_stale": self._using_stale,
+        }
+
+
+def normalize_gateway_software_update(payload: Any) -> dict[str, Any] | None:
+    """Extract sanitized software-update fields from a live-debug message."""
+    if not isinstance(payload, Mapping):
+        return None
+
+    site = _first_mapping(payload.get("site"))
+    if site is None:
+        return None
+    update_info = _first_mapping(site.get("site_update_info"))
+    components, device_statuses, e3_progress = _normalize_device_updates(
+        payload.get("devices")
+    )
+    if update_info is None and not components and not device_statuses:
+        return None
+
+    current_status = _number_or_text(
+        update_info.get("Current_Status") if update_info else None
+    )
+    current_status_text = _text(
+        update_info.get("Current_Status_str") if update_info else None
+    )
+    last_status = _number_or_text(
+        update_info.get("Last_Status") if update_info else None
+    )
+    last_status_text = _text(
+        update_info.get("Last_Status_str") if update_info else None
+    )
+    estimated = _text(update_info.get("Estimated Time Left") if update_info else None)
+    total = _text(update_info.get("Total Duration") if update_info else None)
+    installed_image_version = _text(
+        update_info.get("Current essimg version") if update_info else None
+    )
+    percentage = _overall_percentage(components, e3_progress)
+    in_progress = _update_in_progress(
+        current_status=current_status,
+        current_status_text=current_status_text,
+        device_statuses=device_statuses,
+        components=components,
+        percentage=percentage,
+    )
+
+    return {
+        "current_status": current_status,
+        "current_status_text": current_status_text,
+        "last_status": last_status,
+        "last_status_text": last_status_text,
+        "estimated_time_left": estimated,
+        "estimated_time_left_seconds": duration_seconds(estimated),
+        "total_duration": total,
+        "total_duration_seconds": duration_seconds(total),
+        "installed_image_version": installed_image_version,
+        "last_reported_at": _text(site.get("timestamp")),
+        "device_statuses": device_statuses,
+        "component_updates": components,
+        "e3_progress": e3_progress,
+        "transfer_speed_bps": _transfer_speed(components),
+        "in_progress": in_progress,
+        "update_percentage": percentage if in_progress is True else None,
+    }
+
+
+def duration_seconds(value: Any) -> int | None:
+    """Convert common live-debug duration strings to whole seconds."""
+    text = _text(value)
+    if text is None:
+        return None
+    if text.isdigit():
+        return int(text)
+    colon_parts = text.split(":")
+    if len(colon_parts) in (2, 3) and all(
+        part.strip().isdigit() for part in colon_parts
+    ):
+        numbers = [int(part) for part in colon_parts]
+        if len(numbers) == 2:
+            return numbers[0] * 60 + numbers[1]
+        return numbers[0] * 3600 + numbers[1] * 60 + numbers[2]
+
+    seconds = 0.0
+    matches = list(_DURATION_PART_RE.finditer(text))
+    if not matches:
+        return None
+    for match in matches:
+        amount = float(match.group("value"))
+        unit = match.group("unit").lower()
+        if unit.startswith("d"):
+            seconds += amount * 86400
+        elif unit.startswith("h"):
+            seconds += amount * 3600
+        elif unit.startswith("m"):
+            seconds += amount * 60
+        else:
+            seconds += amount
+    return round(seconds)
+
+
+def _first_mapping(value: Any) -> Mapping[str, Any] | None:
+    if isinstance(value, Mapping):
+        return value
+    if isinstance(value, list):
+        return next((item for item in value if isinstance(item, Mapping)), None)
+    return None
+
+
+def _mapping_list(value: Any) -> list[Mapping[str, Any]]:
+    if isinstance(value, Mapping):
+        return [value]
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, Mapping)]
+    return []
+
+
+def _number_or_text(value: Any) -> int | float | str | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    return _text(value)
+
+
+def _normalize_device_updates(
+    devices_value: Any,
+) -> tuple[list[dict[str, Any]], list[str], float | None]:
+    components: list[dict[str, Any]] = []
+    statuses: list[str] = []
+    e3_values: list[float] = []
+    for device in _mapping_list(devices_value):
+        update_info = device.get("update_info")
+        parts = update_info if isinstance(update_info, list) else [update_info]
+        for part in parts:
+            if isinstance(part, str):
+                status = _text(part)
+                if status:
+                    statuses.append(status)
+                continue
+            if isinstance(part, list):
+                components.extend(_normalize_components(part))
+                continue
+            if not isinstance(part, Mapping):
+                continue
+            progress = _percentage(part.get("e3_progress"))
+            if progress is not None:
+                e3_values.append(progress)
+            if any(key in part for key in ("name", "type", "status_str", "progress")):
+                components.extend(_normalize_components([part]))
+    return components, statuses, max(e3_values) if e3_values else None
+
+
+def _normalize_components(values: list[Any]) -> list[dict[str, Any]]:
+    components: list[dict[str, Any]] = []
+    for value in values:
+        if not isinstance(value, Mapping):
+            continue
+        component = {
+            "name": _text(value.get("name")),
+            "type": _text(value.get("type")),
+            "status": _number_or_text(value.get("status")),
+            "status_text": _text(value.get("status_str")),
+            "progress": _percentage(value.get("progress")),
+            "latest_speed_bps": _non_negative_number(value.get("latest_speed_bps")),
+        }
+        if any(item is not None for item in component.values()):
+            components.append(component)
+    return components
+
+
+def _non_negative_number(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number < 0:
+        return None
+    return int(number) if number.is_integer() else number
+
+
+def _percentage(value: Any) -> float | None:
+    if isinstance(value, str):
+        value = value.strip().rstrip("%")
+    number = _non_negative_number(value)
+    if number is None:
+        return None
+    return float(min(100, number))
+
+
+def _overall_percentage(
+    components: list[dict[str, Any]], e3_progress: float | None
+) -> float | None:
+    if e3_progress is not None:
+        return e3_progress
+    values = [
+        component["progress"]
+        for component in components
+        if isinstance(component.get("progress"), (int, float))
+    ]
+    if not values:
+        return None
+    return round(sum(values) / len(values), 1)
+
+
+def _transfer_speed(components: list[dict[str, Any]]) -> int | float | None:
+    values = [
+        component["latest_speed_bps"]
+        for component in components
+        if isinstance(component.get("latest_speed_bps"), (int, float))
+    ]
+    return sum(values) if values else None
+
+
+def _update_in_progress(
+    *,
+    current_status: int | float | str | None,
+    current_status_text: str | None,
+    device_statuses: list[str],
+    components: list[dict[str, Any]],
+    percentage: float | None,
+) -> bool | None:
+    current_state = _classify_status_text(current_status_text)
+    if current_state is not None:
+        return current_state
+    other_texts = [*device_statuses]
+    other_texts.extend(_text(component.get("status_text")) for component in components)
+    other_states = [
+        state
+        for text in other_texts
+        if (state := _classify_status_text(text)) is not None
+    ]
+    if any(other_states):
+        return True
+    if other_states:
+        return False
+    if percentage is not None and 0 < percentage < 100:
+        return True
+    if current_status == 0 or percentage == 100:
+        return False
+    return None
+
+
+def _classify_status_text(value: str | None) -> bool | None:
+    text = value.lower() if value else ""
+    if any(word in text for word in _TERMINAL_STATUS_WORDS):
+        return False
+    if any(word in text for word in _ACTIVE_STATUS_WORDS):
+        return True
+    return None

--- a/custom_components/enphase_ev/gateway_software_update.py
+++ b/custom_components/enphase_ev/gateway_software_update.py
@@ -25,12 +25,16 @@ GATEWAY_UPDATE_IDLE_TTL_SECONDS = 15 * 60
 GATEWAY_UPDATE_ACTIVE_TTL_SECONDS = 30
 GATEWAY_UPDATE_RETRY_BACKOFF_SECONDS = 15 * 60
 GATEWAY_UPDATE_FETCH_TIMEOUT_SECONDS = 15
+GATEWAY_UPDATE_MAX_COMPONENTS = 32
+GATEWAY_UPDATE_MAX_DEVICE_STATUSES = 32
+GATEWAY_UPDATE_MAX_STATUS_TEXT = 160
 
 _ACTIVE_STATUS_WORDS = (
     "download",
     "install",
     "transfer",
-    "updat",
+    "update",
+    "updating",
     "upgrade",
     "in progress",
 )
@@ -103,6 +107,7 @@ class GatewaySoftwareUpdateManager:
                 return self._status
 
             self._last_fetch_utc = dt_util.utcnow()
+            serial: str | None = None
             try:
                 client = self._client_getter()
                 serial = _text(self._serial_getter())
@@ -118,11 +123,17 @@ class GatewaySoftwareUpdateManager:
                     ),
                     timeout=float(self._fetch_timeout_seconds + 2),
                 )
-                status = normalize_gateway_software_update(payload)
+                status = normalize_gateway_software_update(
+                    payload,
+                    identifiers=(serial,),
+                )
                 if status is None:
                     raise RuntimeError("software-update status unavailable")
             except Exception as err:  # noqa: BLE001
-                self._last_error = redact_text(err)
+                self._last_error = redact_text(
+                    err,
+                    identifiers=(serial,) if serial else (),
+                )
                 self._using_stale = self._status is not None
                 self._expires_mono = time.monotonic() + self._retry_backoff_seconds
                 _LOGGER.debug(
@@ -154,7 +165,11 @@ class GatewaySoftwareUpdateManager:
         }
 
 
-def normalize_gateway_software_update(payload: Any) -> dict[str, Any] | None:
+def normalize_gateway_software_update(
+    payload: Any,
+    *,
+    identifiers: tuple[object, ...] = (),
+) -> dict[str, Any] | None:
     """Extract sanitized software-update fields from a live-debug message."""
     if not isinstance(payload, Mapping):
         return None
@@ -164,27 +179,41 @@ def normalize_gateway_software_update(payload: Any) -> dict[str, Any] | None:
         return None
     update_info = _first_mapping(site.get("site_update_info"))
     components, device_statuses, e3_progress = _normalize_device_updates(
-        payload.get("devices")
+        payload.get("devices"), identifiers=identifiers
     )
     if update_info is None and not components and not device_statuses:
         return None
 
     current_status = _number_or_text(
-        update_info.get("Current_Status") if update_info else None
+        update_info.get("Current_Status") if update_info else None,
+        identifiers=identifiers,
     )
-    current_status_text = _text(
-        update_info.get("Current_Status_str") if update_info else None
+    current_status_text = _safe_text(
+        update_info.get("Current_Status_str") if update_info else None,
+        identifiers=identifiers,
     )
     last_status = _number_or_text(
-        update_info.get("Last_Status") if update_info else None
+        update_info.get("Last_Status") if update_info else None,
+        identifiers=identifiers,
     )
-    last_status_text = _text(
-        update_info.get("Last_Status_str") if update_info else None
+    last_status_text = _safe_text(
+        update_info.get("Last_Status_str") if update_info else None,
+        identifiers=identifiers,
     )
-    estimated = _text(update_info.get("Estimated Time Left") if update_info else None)
-    total = _text(update_info.get("Total Duration") if update_info else None)
-    installed_image_version = _text(
-        update_info.get("Current essimg version") if update_info else None
+    estimated = _safe_text(
+        update_info.get("Estimated Time Left") if update_info else None,
+        identifiers=identifiers,
+        max_length=80,
+    )
+    total = _safe_text(
+        update_info.get("Total Duration") if update_info else None,
+        identifiers=identifiers,
+        max_length=80,
+    )
+    installed_image_version = _safe_text(
+        update_info.get("Current essimg version") if update_info else None,
+        identifiers=identifiers,
+        max_length=80,
     )
     percentage = _overall_percentage(components, e3_progress)
     in_progress = _update_in_progress(
@@ -205,7 +234,9 @@ def normalize_gateway_software_update(payload: Any) -> dict[str, Any] | None:
         "total_duration": total,
         "total_duration_seconds": duration_seconds(total),
         "installed_image_version": installed_image_version,
-        "last_reported_at": _text(site.get("timestamp")),
+        "last_reported_at": _safe_text(
+            site.get("timestamp"), identifiers=identifiers, max_length=80
+        ),
         "device_statuses": device_statuses,
         "component_updates": components,
         "e3_progress": e3_progress,
@@ -265,16 +296,34 @@ def _mapping_list(value: Any) -> list[Mapping[str, Any]]:
     return []
 
 
-def _number_or_text(value: Any) -> int | float | str | None:
+def _safe_text(
+    value: Any,
+    *,
+    identifiers: tuple[object, ...] = (),
+    max_length: int = GATEWAY_UPDATE_MAX_STATUS_TEXT,
+) -> str | None:
+    text = _text(value)
+    if text is None:
+        return None
+    return redact_text(text, identifiers=identifiers, max_length=max_length) or None
+
+
+def _number_or_text(
+    value: Any,
+    *,
+    identifiers: tuple[object, ...] = (),
+) -> int | float | str | None:
     if isinstance(value, bool) or value is None:
         return None
     if isinstance(value, (int, float)):
         return value
-    return _text(value)
+    return _safe_text(value, identifiers=identifiers)
 
 
 def _normalize_device_updates(
     devices_value: Any,
+    *,
+    identifiers: tuple[object, ...] = (),
 ) -> tuple[list[dict[str, Any]], list[str], float | None]:
     components: list[dict[str, Any]] = []
     statuses: list[str] = []
@@ -284,12 +333,13 @@ def _normalize_device_updates(
         parts = update_info if isinstance(update_info, list) else [update_info]
         for part in parts:
             if isinstance(part, str):
-                status = _text(part)
-                if status:
+                status = _safe_text(part, identifiers=identifiers)
+                if status and len(statuses) < GATEWAY_UPDATE_MAX_DEVICE_STATUSES:
                     statuses.append(status)
                 continue
             if isinstance(part, list):
-                components.extend(_normalize_components(part))
+                components.extend(_normalize_components(part, identifiers=identifiers))
+                components = components[:GATEWAY_UPDATE_MAX_COMPONENTS]
                 continue
             if not isinstance(part, Mapping):
                 continue
@@ -297,25 +347,34 @@ def _normalize_device_updates(
             if progress is not None:
                 e3_values.append(progress)
             if any(key in part for key in ("name", "type", "status_str", "progress")):
-                components.extend(_normalize_components([part]))
+                components.extend(
+                    _normalize_components([part], identifiers=identifiers)
+                )
+                components = components[:GATEWAY_UPDATE_MAX_COMPONENTS]
     return components, statuses, max(e3_values) if e3_values else None
 
 
-def _normalize_components(values: list[Any]) -> list[dict[str, Any]]:
+def _normalize_components(
+    values: list[Any],
+    *,
+    identifiers: tuple[object, ...] = (),
+) -> list[dict[str, Any]]:
     components: list[dict[str, Any]] = []
     for value in values:
         if not isinstance(value, Mapping):
             continue
         component = {
-            "name": _text(value.get("name")),
-            "type": _text(value.get("type")),
-            "status": _number_or_text(value.get("status")),
-            "status_text": _text(value.get("status_str")),
+            "name": _safe_text(value.get("name"), identifiers=identifiers),
+            "type": _safe_text(value.get("type"), identifiers=identifiers),
+            "status": _number_or_text(value.get("status"), identifiers=identifiers),
+            "status_text": _safe_text(value.get("status_str"), identifiers=identifiers),
             "progress": _percentage(value.get("progress")),
             "latest_speed_bps": _non_negative_number(value.get("latest_speed_bps")),
         }
         if any(item is not None for item in component.values()):
             components.append(component)
+            if len(components) >= GATEWAY_UPDATE_MAX_COMPONENTS:
+                break
     return components
 
 

--- a/custom_components/enphase_ev/gateway_software_update.py
+++ b/custom_components/enphase_ev/gateway_software_update.py
@@ -404,10 +404,10 @@ def _overall_percentage(
 ) -> float | None:
     if e3_progress is not None:
         return e3_progress
-    values = [
-        component["progress"]
+    values: list[float] = [
+        float(progress)
         for component in components
-        if isinstance(component.get("progress"), (int, float))
+        if isinstance((progress := component.get("progress")), (int, float))
     ]
     if not values:
         return None
@@ -435,7 +435,11 @@ def _update_in_progress(
     if current_state is not None:
         return current_state
     other_texts = [*device_statuses]
-    other_texts.extend(_text(component.get("status_text")) for component in components)
+    other_texts.extend(
+        text
+        for component in components
+        if (text := _text(component.get("status_text"))) is not None
+    )
     other_states = [
         state
         for text in other_texts

--- a/custom_components/enphase_ev/runtime_data.py
+++ b/custom_components/enphase_ev/runtime_data.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
+
 from .const import DOMAIN
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -16,6 +17,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .evse_schedule_editor import EvseScheduleEditorManager
     from .evse_firmware import EvseFirmwareDetailsManager
     from .firmware_catalog import FirmwareCatalogManager
+    from .gateway_software_update import GatewaySoftwareUpdateManager
 
 
 @dataclass(slots=True)
@@ -25,6 +27,7 @@ class EnphaseRuntimeData:
     coordinator: EnphaseCoordinator
     firmware_catalog: FirmwareCatalogManager | None = None
     evse_firmware_details: EvseFirmwareDetailsManager | None = None
+    gateway_software_update: GatewaySoftwareUpdateManager | None = None
     battery_schedule_editor: BatteryScheduleEditorManager | None = None
     evse_schedule_editor: EvseScheduleEditorManager | None = None
     reload_suppression_count: int = 0

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -31,6 +32,7 @@ from .firmware_catalog import (
     resolve_country_and_locale,
     select_catalog_entry,
 )
+from .gateway_software_update import GatewaySoftwareUpdateManager
 from .log_redaction import redact_identifier, redact_text
 from .parsing_helpers import coerce_optional_text as _text
 from .runtime_helpers import (
@@ -187,6 +189,13 @@ async def async_setup_entry(
     evse_manager = runtime_data.evse_firmware_details or EvseFirmwareDetailsManager(
         lambda: coord.client
     )
+    gateway_update_manager = (
+        runtime_data.gateway_software_update
+        or GatewaySoftwareUpdateManager(
+            lambda: coord.client,
+            lambda: coord.inventory_view.type_device_serial_number("envoy"),
+        )
+    )
     version_history = FirmwareVersionHistoryStore(hass)
     await version_history.async_load()
     ent_reg = er.async_get(hass)
@@ -206,6 +215,7 @@ async def async_setup_entry(
                 ),
                 installed_version_getter=_gateway_installed_version,
                 version_history=version_history,
+                progress_manager=gateway_update_manager,
             )
         )
 
@@ -282,6 +292,7 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
         description: UpdateEntityDescription,
         installed_version_getter: Callable[[EnphaseCoordinator], str | None],
         version_history: FirmwareVersionHistoryStore | None = None,
+        progress_manager: GatewaySoftwareUpdateManager | None = None,
     ) -> None:
         super().__init__(coordinator)
         self.entity_description = description
@@ -290,7 +301,9 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
         self._device_type = device_type
         self._installed_version_getter = installed_version_getter
         self._version_history = version_history
+        self._progress_manager = progress_manager
         self._refresh_task = None
+        self._progress_refresh_task = None
 
         self._attr_translation_key = translation_key
         self._attr_unique_id = (
@@ -305,6 +318,7 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
         self._raw_latest_version: str | None = None
         self._catalog_generated_at: str | None = None
         self._installed_version_history: list[dict[str, str | None]] = []
+        self._gateway_update_status: dict[str, Any] | None = None
 
         self._refresh_from_catalog(self._manager.cached_catalog)
 
@@ -330,21 +344,95 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         status = self._manager.status_snapshot()
-        return {
+        attributes = {
             "catalog_source_scope": self._source_scope,
             "catalog_generated_at": self._catalog_generated_at,
             "catalog_last_error": status.get("last_error"),
             "installed_version_history": self._installed_version_history,
         }
+        if self._progress_manager is None:
+            return attributes
+        progress_cache = self._progress_manager.status_snapshot()
+        attributes.update(
+            {
+                "software_update_last_fetch_utc": progress_cache.get("last_fetch_utc"),
+                "software_update_last_success_utc": progress_cache.get(
+                    "last_success_utc"
+                ),
+                "software_update_last_error": progress_cache.get("last_error"),
+                "software_update_using_stale": progress_cache.get("using_stale"),
+            }
+        )
+        if not isinstance(self._gateway_update_status, dict):
+            return attributes
+        progress_attributes = {
+            "software_update_current_status": _status_value(
+                self._gateway_update_status, "current_status_text"
+            ),
+            "software_update_current_status_code": _status_value(
+                self._gateway_update_status, "current_status"
+            ),
+            "software_update_last_status": _status_value(
+                self._gateway_update_status, "last_status_text"
+            ),
+            "software_update_last_status_code": _status_value(
+                self._gateway_update_status, "last_status"
+            ),
+            "estimated_time_left": _status_value(
+                self._gateway_update_status, "estimated_time_left"
+            ),
+            "estimated_time_left_seconds": _status_value(
+                self._gateway_update_status, "estimated_time_left_seconds"
+            ),
+            "total_update_duration": _status_value(
+                self._gateway_update_status, "total_duration"
+            ),
+            "total_update_duration_seconds": _status_value(
+                self._gateway_update_status, "total_duration_seconds"
+            ),
+            "installed_image_version": _status_value(
+                self._gateway_update_status, "installed_image_version"
+            ),
+            "software_update_last_reported_at": _status_value(
+                self._gateway_update_status, "last_reported_at"
+            ),
+            "software_update_device_statuses": _status_value(
+                self._gateway_update_status, "device_statuses"
+            ),
+            "software_update_components": _status_value(
+                self._gateway_update_status, "component_updates"
+            ),
+            "software_update_e3_progress": _status_value(
+                self._gateway_update_status, "e3_progress"
+            ),
+            "software_update_transfer_speed_bps": _status_value(
+                self._gateway_update_status, "transfer_speed_bps"
+            ),
+        }
+        attributes.update(
+            {
+                key: value
+                for key, value in progress_attributes.items()
+                if value is not None and value != []
+            }
+        )
+        return attributes
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         await self._async_refresh_catalog()
+        self._schedule_progress_refresh()
 
     async def async_will_remove_from_hass(self) -> None:
         if self._refresh_task is not None and not self._refresh_task.done():
             self._refresh_task.cancel()
         self._refresh_task = None
+        if (
+            self._progress_refresh_task is not None
+            and not self._progress_refresh_task.done()
+        ):
+            self._progress_refresh_task.cancel()
+        self._progress_refresh_task = None
         await super().async_will_remove_from_hass()
 
     async def async_install(
@@ -360,8 +448,39 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         self._refresh_from_catalog(self._manager.cached_catalog)
+        if self._progress_manager is not None:
+            self._apply_progress(self._progress_manager.cached_status)
         self._schedule_catalog_refresh()
+        self._schedule_progress_refresh()
         super()._handle_coordinator_update()
+
+    def _schedule_progress_refresh(self) -> None:
+        if self.hass is None or self._progress_manager is None:
+            return
+        if (
+            self._progress_refresh_task is not None
+            and not self._progress_refresh_task.done()
+        ):
+            return
+        self._progress_refresh_task = self.hass.async_create_task(
+            self._async_refresh_progress_loop(),
+            name=f"{DOMAIN}_gateway_software_update_progress",
+        )
+
+    async def _async_refresh_progress_loop(self) -> None:
+        assert self._progress_manager is not None
+        while True:
+            update_status = await self._progress_manager.async_get_status()
+            self._apply_progress(update_status)
+            self.async_write_ha_state()
+            await asyncio.sleep(self._progress_manager.next_refresh_seconds)
+
+    def _apply_progress(self, status: dict[str, Any] | None) -> None:
+        self._gateway_update_status = status
+        self._attr_in_progress = cast(bool | None, _status_value(status, "in_progress"))
+        self._attr_update_percentage = cast(
+            int | float | None, _status_value(status, "update_percentage")
+        )
 
     def _schedule_catalog_refresh(self) -> None:
         if self.hass is None:
@@ -794,6 +913,16 @@ def _async_prune_removed_charger_updates(
 
 def _gateway_installed_version(coord: EnphaseCoordinator) -> str | None:
     return _text(coord.inventory_view.type_device_sw_version("envoy"))
+
+
+def _status_value(
+    status: dict[str, Any] | None,
+    key: str,
+    default: Any = None,
+) -> Any:
+    if not isinstance(status, dict):
+        return default
+    return status.get(key, default)
 
 
 def _charger_installed_version(coord: EnphaseCoordinator, serial: str) -> str | None:

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -424,15 +424,23 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
         self._schedule_progress_refresh()
 
     async def async_will_remove_from_hass(self) -> None:
-        if self._refresh_task is not None and not self._refresh_task.done():
-            self._refresh_task.cancel()
+        refresh_task = self._refresh_task
         self._refresh_task = None
-        if (
-            self._progress_refresh_task is not None
-            and not self._progress_refresh_task.done()
-        ):
-            self._progress_refresh_task.cancel()
+        if refresh_task is not None and not refresh_task.done():
+            refresh_task.cancel()
+            try:
+                await refresh_task
+            except asyncio.CancelledError:
+                pass
+
+        progress_refresh_task = self._progress_refresh_task
         self._progress_refresh_task = None
+        if progress_refresh_task is not None and not progress_refresh_task.done():
+            progress_refresh_task.cancel()
+            try:
+                await progress_refresh_task
+            except asyncio.CancelledError:
+                pass
         await super().async_will_remove_from_hass()
 
     async def async_install(

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -109,7 +109,7 @@ Status labels:
 | Filtered site-device inventory | `POST` | `/service/site-device/api/v2/devices/list` | `e-auth-token` + cookies | Browser capture only |
 | Site live-stream flags | `GET` | `/app-api/<site_id>/show_livestream` | authenticated session cookies | Runtime |
 | Site live-status MQTT authorizer | `GET` | `/pv/aws_sigv4/livestream.json?serial_num=<gateway_sn>` | authenticated Enlighten session cookies + `e-auth-token`; browser capture used `Accept: */*`, `Referer: /web/<site_id>/today/graph/hours?v=3.4.0`, `X-Requested-With: XMLHttpRequest` | Runtime |
-| Site live-vitals MQTT authorizer | `GET` | `/pv/aws_sigv4/livestream.json?serial_num=<gateway_sn>&live_debug=true` | authenticated Enlighten session cookies + `e-auth-token`; same browser XHR shape as the live-status authorizer | Browser capture only |
+| Site live-debug MQTT authorizer | `GET` | `/service/system_dashboard/api_internal/cs/sites/livestream?serial_num=<gateway_sn>&live_debug=true` | authenticated Enlighten session cookies + `e-auth-token`; browser XHR request | Runtime (gateway update progress) |
 | Site latest power | `GET` | `/app-api/<site_id>/get_latest_power` | `e-auth-token` + cookies | Runtime |
 | Site currency conversion settings | `GET` | `/app-api/<site_id>/get_currency_conversion.json` | authenticated session cookies + `e-auth-token` | Browser capture only |
 | Requested battery usage hint | `GET` | `/app-api/<site_id>/get_requested_battery_usage` | authenticated session cookies + `e-auth-token` | Browser capture only |
@@ -1335,11 +1335,11 @@ Implementation notes:
 - Keep captures bounded and disconnect explicitly even when the server advertises a 15-minute duration.
 - The BatteryConfig MQTT authorizer at `5.1` returned a `v1/server/response-stream/<stream_id>` topic and emitted no passive telemetry in a 60-second local capture; do not conflate that response stream with this `v1/live-stream/<stream_id>` site telemetry stream.
 
-### 2.9.2.b Site Live-Vitals MQTT Authorizer
+### 2.9.2.b Site Live-Debug MQTT Authorizer
 ```
-GET /pv/aws_sigv4/livestream.json?serial_num=<gateway_sn>&live_debug=true
+GET /service/system_dashboard/api_internal/cs/sites/livestream?serial_num=<gateway_sn>&live_debug=true
 ```
-Returns an AWS IoT custom-authorizer payload for the Enlighten web-app **Live Vitals** view. This is a separate topic from the Live Status stream in `2.9.2.a`, even though both authorizers use the same base route.
+Returns an AWS IoT custom-authorizer payload used by the System Dashboard **Software Updates** page and Enlighten live-vitals surfaces. This is a separate topic from the Live Status stream in `2.9.2.a`. An older capture used `/pv/aws_sigv4/livestream.json?...&live_debug=true`; the runtime uses the newer confirmed System Dashboard route.
 
 Example response (anonymized):
 ```json
@@ -1370,6 +1370,8 @@ Observed payload format:
 - Captured frames were approximately 8-9 KB.
 - Top-level keys observed: `data_ingest_type`, `site`, `meters`, and `devices`.
 - Captured JSON contains account/site/device identifiers and exact serial numbers. Store only redacted fixtures or schema summaries.
+- Gateway update state is carried in `site[].site_update_info[]`, including numeric/string current and last statuses, estimated time left, total duration, and `Current essimg version`. The enclosing `site[].timestamp` identifies the source observation time.
+- Per-component progress is carried in `devices[].update_info`, including component name/type, status, progress, transfer speed, and `e3_progress`. The adjacent `fw_image` contains a gateway-local path and image hash and must not be retained in state, diagnostics, fixtures, or logs.
 - During an active charging capture, Live Vitals emitted one JSON message roughly every 5 seconds and still only exposed `enpower` and `encharge` device objects. No explicit EVSE/charger object was observed.
 
 Example payload shape (anonymized and abbreviated):

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -8582,7 +8582,10 @@ async def test_site_livestream_authorizer_returns_payload() -> None:
     )
 
     await client.site_livestream_authorizer("GW-1", live_debug=True)
-    assert "live_debug=true" in client._json.await_args.args[1]
+    assert client._json.await_args.args[1] == (
+        f"{api.BASE_URL}/service/system_dashboard/api_internal/cs/sites/livestream"
+        "?serial_num=GW-1&live_debug=true"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_gateway_software_update.py
+++ b/tests/components/enphase_ev/test_gateway_software_update.py
@@ -1,0 +1,386 @@
+"""Tests for read-only gateway software-update progress."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.enphase_ev.gateway_software_update import (
+    GatewaySoftwareUpdateManager,
+    duration_seconds,
+    normalize_gateway_software_update,
+)
+
+
+def _payload(
+    *,
+    current_status: int = 2,
+    current_status_text: str = "Installing software update",
+) -> dict:
+    return {
+        "site": [
+            {
+                "timestamp": "2026-07-11T05:06:07Z",
+                "site_update_info": [
+                    {
+                        "Current_Status": current_status,
+                        "Current_Status_str": current_status_text,
+                        "Last_Status": 0,
+                        "Last_Status_str": "Previous update completed",
+                        "Estimated Time Left": "1 min 30 sec",
+                        "Total Duration": "00:04:00",
+                        "Current essimg version": "8.3.6000",
+                    }
+                ],
+            }
+        ],
+        "devices": [
+            {
+                "serial_num": "must-not-be-retained",
+                "update_info": [
+                    "Gateway components updating",
+                    [
+                        {
+                            "fw_image": "/tmp/private/image-hash.bin",
+                            "name": "Gateway OS",
+                            "type": "essimg",
+                            "status": 2,
+                            "status_str": "Installing",
+                            "progress": "40%",
+                            "latest_speed_bps": "1024",
+                        },
+                        {
+                            "name": "Controller",
+                            "type": "e3",
+                            "status": "running",
+                            "status_str": "Transferring",
+                            "progress": 60,
+                            "latest_speed_bps": 512.5,
+                        },
+                        None,
+                    ],
+                    {"e3_progress": "55%"},
+                ],
+            }
+        ],
+    }
+
+
+def test_normalize_gateway_software_update_active_payload_is_sanitized() -> None:
+    status = normalize_gateway_software_update(_payload())
+
+    assert status == {
+        "current_status": 2,
+        "current_status_text": "Installing software update",
+        "last_status": 0,
+        "last_status_text": "Previous update completed",
+        "estimated_time_left": "1 min 30 sec",
+        "estimated_time_left_seconds": 90,
+        "total_duration": "00:04:00",
+        "total_duration_seconds": 240,
+        "installed_image_version": "8.3.6000",
+        "last_reported_at": "2026-07-11T05:06:07Z",
+        "device_statuses": ["Gateway components updating"],
+        "component_updates": [
+            {
+                "name": "Gateway OS",
+                "type": "essimg",
+                "status": 2,
+                "status_text": "Installing",
+                "progress": 40.0,
+                "latest_speed_bps": 1024,
+            },
+            {
+                "name": "Controller",
+                "type": "e3",
+                "status": "running",
+                "status_text": "Transferring",
+                "progress": 60.0,
+                "latest_speed_bps": 512.5,
+            },
+        ],
+        "e3_progress": 55.0,
+        "transfer_speed_bps": 1536.5,
+        "in_progress": True,
+        "update_percentage": 55.0,
+    }
+    serialized = repr(status)
+    assert "serial_num" not in serialized
+    assert "private" not in serialized
+    assert "image-hash" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("90", 90),
+        ("01:30", 90),
+        ("01:02:03", 3723),
+        ("1 day 2 hrs 3 minutes 4 seconds", 93784),
+        ("1.5 h", 5400),
+        ("unknown", None),
+    ],
+)
+def test_duration_seconds(value, expected) -> None:
+    assert duration_seconds(value) == expected
+
+
+def test_normalize_gateway_software_update_terminal_and_shape_variants() -> None:
+    payload = _payload(current_status=0, current_status_text="Software is up to date")
+    payload["site"] = payload["site"][0]
+    payload["site"]["site_update_info"] = payload["site"]["site_update_info"][0]
+    payload["devices"] = {
+        "update_info": {
+            "name": "Gateway",
+            "status_str": "Complete",
+            "progress": 120,
+            "latest_speed_bps": -1,
+            "e3_progress": 100,
+        }
+    }
+
+    status = normalize_gateway_software_update(payload)
+
+    assert status is not None
+    assert status["in_progress"] is False
+    assert status["update_percentage"] is None
+    assert status["e3_progress"] == 100
+    assert status["component_updates"][0]["progress"] == 100
+    assert status["component_updates"][0]["latest_speed_bps"] is None
+
+
+def test_normalize_gateway_software_update_infers_average_and_unknown_state() -> None:
+    average_payload = {
+        "site": {"site_update_info": {"Current_Status": "unknown"}},
+        "devices": [
+            {
+                "update_info": [
+                    [{"name": "A", "progress": 20}, {"name": "B", "progress": 40}]
+                ]
+            }
+        ],
+    }
+    averaged = normalize_gateway_software_update(average_payload)
+    assert averaged is not None
+    assert averaged["update_percentage"] == 30
+    assert averaged["in_progress"] is True
+
+    unknown = normalize_gateway_software_update(
+        {
+            "site": {"site_update_info": {"Current_Status": "unknown"}},
+            "devices": [],
+        }
+    )
+    assert unknown is not None
+    assert unknown["in_progress"] is None
+    assert unknown["update_percentage"] is None
+
+    idle = normalize_gateway_software_update(
+        {
+            "site": {"site_update_info": {"Current_Status": 0}},
+            "devices": 123,
+        }
+    )
+    assert idle is not None
+    assert idle["in_progress"] is False
+
+
+def test_normalize_gateway_software_update_ignores_invalid_numeric_values() -> None:
+    status = normalize_gateway_software_update(
+        {
+            "site": {"site_update_info": {"Current_Status": True}},
+            "devices": {
+                "update_info": {
+                    "name": "Gateway",
+                    "progress": "unknown",
+                    "latest_speed_bps": True,
+                }
+            },
+        }
+    )
+    assert status is not None
+    assert status["current_status"] is None
+    assert status["component_updates"][0]["progress"] is None
+    assert status["component_updates"][0]["latest_speed_bps"] is None
+    assert status["transfer_speed_bps"] is None
+
+
+def test_normalize_gateway_software_update_prefers_active_component() -> None:
+    status = normalize_gateway_software_update(
+        {
+            "site": {"site_update_info": {"Current_Status": "unknown"}},
+            "devices": {
+                "update_info": [
+                    [
+                        {"name": "A", "status_str": "Completed", "progress": 100},
+                        {"name": "B", "status_str": "Installing", "progress": 20},
+                    ]
+                ]
+            },
+        }
+    )
+    assert status is not None
+    assert status["in_progress"] is True
+
+    failed = normalize_gateway_software_update(
+        {
+            "site": {
+                "site_update_info": {"Current_Status_str": "Software update failed"}
+            },
+            "devices": [],
+        }
+    )
+    assert failed is not None
+    assert failed["in_progress"] is False
+
+    completed_component = normalize_gateway_software_update(
+        {
+            "site": {"site_update_info": {"Current_Status": "unknown"}},
+            "devices": {"update_info": [[{"name": "A", "status_str": "Completed"}]]},
+        }
+    )
+    assert completed_component is not None
+    assert completed_component["in_progress"] is False
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        {},
+        {"site": []},
+        {"site": [{}], "devices": [None, {"update_info": [None, 1]}]},
+    ],
+)
+def test_normalize_gateway_software_update_rejects_missing_status(payload) -> None:
+    assert normalize_gateway_software_update(payload) is None
+
+
+@pytest.mark.asyncio
+async def test_manager_caches_active_status_and_force_refreshes() -> None:
+    client = AsyncMock()
+    client.site_livestream_payload.return_value = _payload()
+    manager = GatewaySoftwareUpdateManager(
+        lambda: client,
+        lambda: "GW-SERIAL",
+        active_ttl_seconds=15,
+        idle_ttl_seconds=60,
+    )
+
+    first = await manager.async_get_status()
+    second = await manager.async_get_status()
+    forced = await manager.async_get_status(force_refresh=True)
+
+    assert first == second == forced
+    assert client.site_livestream_payload.await_count == 2
+    client.site_livestream_payload.assert_awaited_with(
+        "GW-SERIAL", live_debug=True, timeout_s=15.0
+    )
+    assert manager.cached_status == first
+    assert 0 < manager.next_refresh_seconds <= 15
+    snapshot = manager.status_snapshot()
+    assert snapshot["last_fetch_utc"] is not None
+    assert snapshot["last_success_utc"] is not None
+    assert snapshot["last_error"] is None
+    assert snapshot["using_stale"] is False
+
+
+@pytest.mark.asyncio
+async def test_manager_rechecks_cache_after_waiting_for_refresh_lock() -> None:
+    client = AsyncMock()
+    release = asyncio.Event()
+
+    async def _payload_after_release(*args, **kwargs):  # noqa: ARG001
+        await release.wait()
+        return _payload()
+
+    client.site_livestream_payload.side_effect = _payload_after_release
+    manager = GatewaySoftwareUpdateManager(lambda: client, lambda: "GW-SERIAL")
+
+    first_task = asyncio.create_task(manager.async_get_status())
+    await asyncio.sleep(0)
+    second_task = asyncio.create_task(manager.async_get_status())
+    await asyncio.sleep(0)
+    release.set()
+
+    first, second = await asyncio.gather(first_task, second_task)
+    assert first == second
+    assert client.site_livestream_payload.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_manager_uses_idle_ttl_and_stale_status_on_error() -> None:
+    client = AsyncMock()
+    client.site_livestream_payload.side_effect = [
+        _payload(current_status=0, current_status_text="Software is up to date"),
+        RuntimeError("request failed for private gateway"),
+    ]
+    manager = GatewaySoftwareUpdateManager(
+        lambda: client,
+        lambda: "GW-SERIAL",
+        idle_ttl_seconds=60,
+        retry_backoff_seconds=60,
+    )
+
+    status = await manager.async_get_status()
+    stale = await manager.async_get_status(force_refresh=True)
+
+    assert stale == status
+    snapshot = manager.status_snapshot()
+    assert snapshot["using_stale"] is True
+    assert snapshot["last_error"] == "request failed for private gateway"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("client", "serial", "error"),
+    [
+        (None, "GW-SERIAL", "client unavailable"),
+        (AsyncMock(), None, "gateway serial unavailable"),
+    ],
+)
+async def test_manager_backs_off_when_dependencies_are_unavailable(
+    client, serial, error
+) -> None:
+    manager = GatewaySoftwareUpdateManager(
+        lambda: client,
+        lambda: serial,
+        retry_backoff_seconds=60,
+    )
+
+    assert await manager.async_get_status() is None
+    assert manager.status_snapshot()["last_error"] == error
+
+
+@pytest.mark.asyncio
+async def test_manager_rejects_empty_payload_and_bounds_constructor_values() -> None:
+    client = AsyncMock()
+    client.site_livestream_payload.return_value = {"site": []}
+    manager = GatewaySoftwareUpdateManager(
+        lambda: client,
+        lambda: "GW-SERIAL",
+        idle_ttl_seconds=1,
+        active_ttl_seconds=1,
+        retry_backoff_seconds=1,
+        fetch_timeout_seconds=1,
+    )
+
+    assert await manager.async_get_status() is None
+    assert manager.status_snapshot()["last_error"] == (
+        "software-update status unavailable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_manager_propagates_cancellation() -> None:
+    client = AsyncMock()
+    client.site_livestream_payload.side_effect = asyncio.CancelledError
+    manager = GatewaySoftwareUpdateManager(lambda: client, lambda: "GW-SERIAL")
+
+    with pytest.raises(asyncio.CancelledError):
+        await manager.async_get_status()

--- a/tests/components/enphase_ev/test_gateway_software_update.py
+++ b/tests/components/enphase_ev/test_gateway_software_update.py
@@ -8,6 +8,9 @@ from unittest.mock import AsyncMock
 import pytest
 
 from custom_components.enphase_ev.gateway_software_update import (
+    GATEWAY_UPDATE_MAX_COMPONENTS,
+    GATEWAY_UPDATE_MAX_DEVICE_STATUSES,
+    GATEWAY_UPDATE_MAX_STATUS_TEXT,
     GatewaySoftwareUpdateManager,
     duration_seconds,
     normalize_gateway_software_update,
@@ -110,6 +113,38 @@ def test_normalize_gateway_software_update_active_payload_is_sanitized() -> None
     assert "serial_num" not in serialized
     assert "private" not in serialized
     assert "image-hash" not in serialized
+
+
+def test_normalize_gateway_software_update_redacts_and_bounds_free_text() -> None:
+    payload = _payload()
+    update_info = payload["site"][0]["site_update_info"][0]
+    update_info["Current_Status_str"] = "Installing GW-SERIAL " + ("x" * 300)
+    payload["devices"] = [
+        {
+            "update_info": [
+                *(f"GW-SERIAL status {index}" for index in range(40)),
+                [
+                    {
+                        "name": f"GW-SERIAL component {index}",
+                        "status_str": "Installing",
+                        "progress": index,
+                    }
+                    for index in range(40)
+                ],
+            ]
+        }
+    ]
+
+    status = normalize_gateway_software_update(
+        payload,
+        identifiers=("GW-SERIAL",),
+    )
+
+    assert status is not None
+    assert "GW-SERIAL" not in repr(status)
+    assert len(status["current_status_text"]) <= GATEWAY_UPDATE_MAX_STATUS_TEXT + 3
+    assert len(status["device_statuses"]) == GATEWAY_UPDATE_MAX_DEVICE_STATUSES
+    assert len(status["component_updates"]) == GATEWAY_UPDATE_MAX_COMPONENTS
 
 
 @pytest.mark.parametrize(
@@ -318,7 +353,7 @@ async def test_manager_uses_idle_ttl_and_stale_status_on_error() -> None:
     client = AsyncMock()
     client.site_livestream_payload.side_effect = [
         _payload(current_status=0, current_status_text="Software is up to date"),
-        RuntimeError("request failed for private gateway"),
+        RuntimeError("request failed for GW-SERIAL"),
     ]
     manager = GatewaySoftwareUpdateManager(
         lambda: client,
@@ -333,7 +368,7 @@ async def test_manager_uses_idle_ttl_and_stale_status_on_error() -> None:
     assert stale == status
     snapshot = manager.status_snapshot()
     assert snapshot["using_stale"] is True
-    assert snapshot["last_error"] == "request failed for private gateway"
+    assert snapshot["last_error"] == "request failed for GW-S...RIAL"
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -394,6 +394,7 @@ async def test_gateway_update_entity_progress_task_lifecycle(hass, monkeypatch) 
     assert entity.in_progress is False
 
     await entity.async_will_remove_from_hass()
+    assert task.done()
     with pytest.raises(asyncio.CancelledError):
         await task
     assert entity._progress_refresh_task is None

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -70,6 +70,22 @@ class DummyEvseFirmwareManager:
         return dict(self._status)
 
 
+class DummyGatewayUpdateManager:
+    def __init__(self, status=None):
+        self.cached_status = status
+        self.next_refresh_seconds = 60
+        self._status = {
+            "last_fetch_utc": "2026-07-11T05:06:08+00:00",
+            "last_success_utc": "2026-07-11T05:06:08+00:00",
+            "last_error": None,
+            "using_stale": False,
+        }
+        self.async_get_status = AsyncMock(return_value=status)
+
+    def status_snapshot(self):
+        return dict(self._status)
+
+
 class DummyCoordinator:
     def __init__(self) -> None:
         self.site_id = "12345"
@@ -234,6 +250,7 @@ async def test_async_setup_entry_adds_firmware_update_entities(
         coordinator=coord,
         firmware_catalog=catalog_manager,
         evse_firmware_details=evse_manager,
+        gateway_software_update=DummyGatewayUpdateManager(),
     )
 
     added = []
@@ -247,6 +264,144 @@ async def test_async_setup_entry_adds_firmware_update_entities(
     unique_ids = {entity.unique_id for entity in added}
     assert f"enphase_ev_site_{coord.site_id}_envoy_firmware" in unique_ids
     assert f"enphase_ev_{TEST_EVSE_SERIAL}_charger_firmware" in unique_ids
+    gateway = next(
+        entity for entity in added if isinstance(entity, FirmwareUpdateEntity)
+    )
+    assert (
+        gateway._progress_manager is config_entry.runtime_data.gateway_software_update
+    )
+
+
+@pytest.mark.asyncio
+async def test_gateway_update_entity_exposes_live_progress_and_sanitized_details(
+    hass, monkeypatch
+) -> None:
+    progress_status = {
+        "current_status": 2,
+        "current_status_text": "Installing",
+        "last_status": 0,
+        "last_status_text": "Completed",
+        "estimated_time_left": "1 min",
+        "estimated_time_left_seconds": 60,
+        "total_duration": "5 min",
+        "total_duration_seconds": 300,
+        "installed_image_version": "8.3.6000",
+        "last_reported_at": "2026-07-11T05:06:07Z",
+        "device_statuses": ["Gateway updating"],
+        "component_updates": [
+            {
+                "name": "Gateway OS",
+                "type": "essimg",
+                "status": 2,
+                "status_text": "Installing",
+                "progress": 55.0,
+                "latest_speed_bps": 1024,
+            }
+        ],
+        "e3_progress": 55.0,
+        "transfer_speed_bps": 1024,
+        "in_progress": True,
+        "update_percentage": 55.0,
+    }
+    progress_manager = DummyGatewayUpdateManager(progress_status)
+    entity = FirmwareUpdateEntity(
+        coordinator=DummyCoordinator(),
+        manager=DummyCatalogManager(_catalog_payload()),
+        device_type="envoy",
+        translation_key="gateway_firmware",
+        description=UpdateEntityDescription(key="gateway_firmware"),
+        installed_version_getter=_gateway_installed_version,
+        progress_manager=progress_manager,
+    )
+    entity.hass = hass
+    entity._apply_progress(progress_status)
+
+    assert entity.in_progress is True
+    assert entity.update_percentage == 55
+    attrs = entity.extra_state_attributes
+    assert attrs["software_update_current_status"] == "Installing"
+    assert attrs["software_update_current_status_code"] == 2
+    assert attrs["software_update_last_status"] == "Completed"
+    assert attrs["software_update_last_status_code"] == 0
+    assert attrs["estimated_time_left"] == "1 min"
+    assert attrs["estimated_time_left_seconds"] == 60
+    assert attrs["total_update_duration"] == "5 min"
+    assert attrs["total_update_duration_seconds"] == 300
+    assert attrs["installed_image_version"] == "8.3.6000"
+    assert attrs["software_update_last_reported_at"] == "2026-07-11T05:06:07Z"
+    assert attrs["software_update_device_statuses"] == ["Gateway updating"]
+    assert attrs["software_update_components"][0]["name"] == "Gateway OS"
+    assert attrs["software_update_e3_progress"] == 55
+    assert attrs["software_update_transfer_speed_bps"] == 1024
+    assert attrs["software_update_last_error"] is None
+    assert attrs["software_update_using_stale"] is False
+    assert "fw_image" not in repr(attrs)
+
+    refresh_started = asyncio.Event()
+
+    async def _get_status():
+        refresh_started.set()
+        return progress_status
+
+    progress_manager.async_get_status = AsyncMock(side_effect=_get_status)
+    write_state = MagicMock()
+    monkeypatch.setattr(entity, "async_write_ha_state", write_state)
+    refresh_task = hass.async_create_task(entity._async_refresh_progress_loop())
+    await refresh_started.wait()
+    await asyncio.sleep(0)
+    refresh_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await refresh_task
+    progress_manager.async_get_status.assert_awaited_once_with()
+    write_state.assert_called_once_with()
+
+    entity._apply_progress(None)
+    assert entity.in_progress is None
+    assert entity.update_percentage is None
+    assert "software_update_components" not in entity.extra_state_attributes
+
+
+@pytest.mark.asyncio
+async def test_gateway_update_entity_progress_task_lifecycle(hass, monkeypatch) -> None:
+    progress_manager = DummyGatewayUpdateManager(
+        {"in_progress": False, "update_percentage": None}
+    )
+    entity = FirmwareUpdateEntity(
+        coordinator=DummyCoordinator(),
+        manager=DummyCatalogManager(_catalog_payload()),
+        device_type="envoy",
+        translation_key="gateway_firmware",
+        description=UpdateEntityDescription(key="gateway_firmware"),
+        installed_version_getter=_gateway_installed_version,
+        progress_manager=progress_manager,
+    )
+    entity.hass = hass
+    monkeypatch.setattr(entity, "async_write_ha_state", lambda: None)
+    monkeypatch.setattr(
+        CoordinatorEntity, "_handle_coordinator_update", lambda self: None
+    )
+    remove = AsyncMock(return_value=None)
+    monkeypatch.setattr(CoordinatorEntity, "async_will_remove_from_hass", remove)
+
+    entity._schedule_progress_refresh()
+    task = entity._progress_refresh_task
+    assert task is not None
+    await asyncio.sleep(0)
+    entity._schedule_progress_refresh()
+    assert entity._progress_refresh_task is task
+
+    entity._handle_coordinator_update()
+    assert entity.in_progress is False
+
+    await entity.async_will_remove_from_hass()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert entity._progress_refresh_task is None
+    remove.assert_awaited_once_with()
+
+    entity.hass = None
+    entity._schedule_progress_refresh()
+    assert entity._progress_refresh_task is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds read-only IQ Gateway software-update progress monitoring to the existing advisory update entity using the confirmed System Dashboard live-debug bootstrap and bounded MQTT reads.

The entity reports Home Assistant in-progress and percentage state plus sanitized timing, installed image version, component progress, and transfer details. Follow-up review added explicit gateway-identifier redaction, text-size limits, bounded component/status collections, stale preservation, and cancellation-safe polling.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/api.py custom_components/enphase_ev/gateway_software_update.py custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/update.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_gateway_software_update.py tests/components/enphase_ev/test_update_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/config_flow.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/pr-feature2.coverage python -m coverage erase && COVERAGE_FILE=/tmp/pr-feature2.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/pr-feature2.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/api.py,custom_components/enphase_ev/gateway_software_update.py,custom_components/enphase_ev/runtime_data.py,custom_components/enphase_ev/update.py --fail-under=100"
```

Post-rebase full suite: 3,659 passed. Touched modules: 5,493/5,493 statements covered.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, `docs/`) when behaviour or options changed.
- [x] I verified translations; no new user-facing translation keys were required.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results.
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This PR is monitoring-only. It does not expose or call an update-start route and does not retain MQTT credentials, topics, serials, or firmware image paths.
