### PR TITLE
Add bulk microinverter parameter telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
   excluded from recorder history.
 
 ### ✨ New features
-- Added optional installer-level microinverter parameter telemetry with bulk device reads for power and available AC/DC voltage/current, frequency, temperature, signal, and firmware details. The diagnostic entities are disabled by default.
+- Added optional installer-level microinverter parameter telemetry with bulk device reads for power and available AC/DC voltage/current, frequency, temperature, signal, and firmware details. Empty authoritative reads clear old values, partial failures retain only bounded stale data, and the diagnostic entities are disabled by default.
 
 ### 🐛 Bug fixes
 - Fixed Enlighten authentication after Enphase retired the Entrez token mint by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
   excluded from recorder history.
 
 ### ✨ New features
-- None
+- Added optional installer-level microinverter parameter telemetry with bulk device reads for power and available AC/DC voltage/current, frequency, temperature, signal, and firmware details. The diagnostic entities are disabled by default.
 
 ### 🐛 Bug fixes
 - Fixed Enlighten authentication after Enphase retired the Entrez token mint by

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - IQ Gateway / System Controller entities and controls
 - IQ Battery telemetry and BatteryConfig controls (where supported)
 - IQ EV Charger controls and session telemetry
-- IQ Microinverter connectivity, inventory, and lifetime production telemetry
+- IQ Microinverter connectivity, inventory, lifetime production, and optional installer-level parameter telemetry
 - Site and cloud energy telemetry (including supported HEMS channels such as Heat Pump and Water Heater lifetime energy)
 
 ## Key features
@@ -43,6 +43,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Site tariff visibility for next billing date, Energy-dashboard-ready current import/export price sensors, editable tariff rate number entities, and a service for billing-cycle, rate, and guided structural tariff updates when Enphase exposes tariff data
 - Health diagnostics, service-availability tracking, and actionable repair issues
 - Detailed diagnostic and inventory entities remain available but are disabled by default when they are mainly useful for troubleshooting
+- Rate-conscious microinverter telemetry batches all active devices per supported parameter and exposes power plus available AC/DC, frequency, temperature, signal, and firmware details in a disabled-by-default diagnostic entity
 - Broad localization support across all user-facing integration strings
 
 Localized strings cover English (default plus US, Canada, Australia, New Zealand, and Ireland variants), French, German, Spanish, Italian, Dutch, Swedish, Danish, Finnish, Norwegian Bokmal, Polish, Greek, Romanian, Czech, Hungarian, Bulgarian, Latvian, Lithuanian, Estonian, and Brazilian Portuguese.

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -7456,6 +7456,123 @@ class EnphaseEVClient:
         )
         return await self._system_dashboard_get(modern_url, legacy_url)
 
+    async def system_dashboard_master_data(self) -> JsonDict | None:
+        """Return the system-dashboard device and parameter catalogs.
+
+        GET /service/system_dashboard/api_internal/cs/sites/<site_id>/data/master-data
+        """
+
+        url = (
+            f"{BASE_URL}/service/system_dashboard/api_internal/cs/sites/"
+            f"{self._site}/data/master-data"
+        )
+        try:
+            data = await self._json(
+                "GET", url, headers=self._system_dashboard_headers()
+            )
+        except Exception as err:  # noqa: BLE001
+            if self._system_dashboard_is_optional_error(err):
+                return None
+            raise
+        return data if isinstance(data, dict) else None
+
+    async def system_dashboard_envoy_inverters(
+        self, gateway_serial: str
+    ) -> JsonDict | None:
+        """Return flattened microinverter inventory for one gateway."""
+
+        serial = str(gateway_serial).strip()
+        if not serial:
+            return None
+        url = str(
+            URL(
+                f"{BASE_URL}/service/system_dashboard/api_internal/dashboard/sites/"
+                f"{self._site}/envoy_inverters"
+            ).update_query({"serial_number": serial})
+        )
+        try:
+            data = await self._json(
+                "GET", url, headers=self._system_dashboard_headers()
+            )
+        except Exception as err:  # noqa: BLE001
+            if self._system_dashboard_is_optional_error(err):
+                return None
+            raise
+        return data if isinstance(data, dict) else None
+
+    async def system_dashboard_data_columns(
+        self, gateway_serial: str
+    ) -> JsonDict | None:
+        """Return device-level parameter column metadata for one gateway."""
+
+        serial = str(gateway_serial).strip()
+        if not serial:
+            return None
+        url = str(
+            URL(
+                f"{BASE_URL}/service/system_dashboard/api_internal/cs/sites/"
+                f"{self._site}/data/columns"
+            ).update_query({"serial_num": serial, "type": "device_level"})
+        )
+        try:
+            data = await self._json(
+                "GET", url, headers=self._system_dashboard_headers()
+            )
+        except Exception as err:  # noqa: BLE001
+            if self._system_dashboard_is_optional_error(err):
+                return None
+            raise
+        return data if isinstance(data, dict) else None
+
+    async def system_dashboard_parameter_view(
+        self,
+        serial_numbers: list[str] | tuple[str, ...],
+        parameter_id: str,
+        *,
+        per_page: int = 500,
+        page: int = 1,
+        range_name: str = "today",
+        start_date: str = "",
+        end_date: str = "",
+        sort_by_date: str = "desc",
+    ) -> JsonDict | None:
+        """Return one parameter for many devices in a single dashboard request."""
+
+        serials = tuple(
+            dict.fromkeys(
+                str(serial).strip() for serial in serial_numbers if str(serial).strip()
+            )
+        )
+        parameter = str(parameter_id).strip()
+        if not serials or not parameter:
+            return None
+        url = str(
+            URL(
+                f"{BASE_URL}/service/system_dashboard/api_internal/cs/sites/"
+                f"{self._site}/data/parameter-view"
+            ).update_query(
+                {
+                    "serial_numbers": ",".join(serials),
+                    "per_page": max(1, int(per_page)),
+                    "page": max(1, int(page)),
+                    "range": str(range_name),
+                    "parameter_id": parameter,
+                    "start_date": str(start_date),
+                    "end_date": str(end_date),
+                    "sort_by_date": str(sort_by_date),
+                }
+            )
+        )
+        try:
+            data = await self._json(
+                "GET", url, headers=self._system_dashboard_headers()
+            )
+        except Exception as err:  # noqa: BLE001
+            if self._system_dashboard_is_optional_error(err):
+                return None
+            raise
+        return data if isinstance(data, dict) else None
+
     async def hems_devices(self, *, refresh_data: bool = False) -> JsonDict | None:
         """Return dedicated HEMS device inventory when available.
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1133,6 +1133,33 @@ class EnphaseCoordinator(
                 suppress_after_failures=3,
                 support_state_on_success=True,
             ),
+            "inverter_dashboard_inventory": EndpointFamilyPolicy(
+                success_ttl_s=21600.0,
+                stale_after_s=86400.0,
+                failure_backoff_schedule_s=(1800.0, 3600.0, 7200.0, 21600.0),
+                max_backoff_s=21600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+            "inverter_parameter_catalog": EndpointFamilyPolicy(
+                success_ttl_s=21600.0,
+                stale_after_s=86400.0,
+                failure_backoff_schedule_s=(1800.0, 3600.0, 7200.0, 21600.0),
+                max_backoff_s=21600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+            "inverter_parameter_telemetry": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                stale_after_s=1800.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
         }
 
     async def async_request_refresh(self) -> None:

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -2627,15 +2627,15 @@ class InventoryRuntime:
             first_error = next(
                 (result for result in results if isinstance(result, Exception)), None
             )
-            dashboard_by_serial: dict[str, dict[str, object]] = {}
-            response_seen = False
+            fresh_by_serial: dict[str, dict[str, object]] = {}
+            valid_response_count = 0
             for result in results:
                 if not isinstance(result, dict):
                     continue
-                response_seen = True
                 records = result.get("data")
                 if not isinstance(records, list):
                     continue
+                valid_response_count += 1
                 for record in records:
                     if not isinstance(record, dict):
                         continue
@@ -2643,7 +2643,7 @@ class InventoryRuntime:
                     if serial:
                         # Device/parent IDs are not needed by entities and must not
                         # be retained in inventory diagnostics.
-                        dashboard_by_serial[serial] = {
+                        fresh_by_serial[serial] = {
                             key: record[key]
                             for key in (
                                 "name",
@@ -2654,17 +2654,23 @@ class InventoryRuntime:
                             )
                             if record.get(key) is not None
                         }
-            if response_seen:
+            if valid_response_count == len(gateway_serials):
+                dashboard_by_serial = fresh_by_serial
                 self.coordinator._note_endpoint_family_success(family)
                 self._set_shared_state_attr(
                     "_inverter_dashboard_inventory", dashboard_by_serial
                 )
             else:
                 error = first_error or ValueError(
-                    "Dashboard inverter inventory was unavailable"
+                    "Dashboard inverter inventory was partially unavailable"
                 )
                 self.coordinator._note_endpoint_family_failure(family, error)
-                dashboard_by_serial = cached_by_serial
+                dashboard_by_serial = dict(cached_by_serial)
+                dashboard_by_serial.update(fresh_by_serial)
+                if valid_response_count:
+                    self._set_shared_state_attr(
+                        "_inverter_dashboard_inventory", dashboard_by_serial
+                    )
 
         merged_by_serial: dict[str, dict[str, object]] = {}
         order: list[str] = []
@@ -2762,6 +2768,16 @@ class InventoryRuntime:
                 if normalized is not None:
                     out[column_serial] = (normalized, sampled_at)
         return out
+
+    @staticmethod
+    def _inverter_parameter_payload_is_valid(payload: object) -> bool:
+        """Return whether a parameter response has an authoritative row list."""
+
+        if not isinstance(payload, dict):
+            return False
+        return isinstance(payload.get("intervals"), list) or isinstance(
+            payload.get("data"), list
+        )
 
     async def _async_refresh_inverter_parameter_telemetry(
         self, serials: list[str]
@@ -2871,21 +2887,43 @@ class InventoryRuntime:
             ),
             return_exceptions=True,
         )
-        successful_payload = False
+        valid_payload_count = 0
         first_error: Exception | None = None
         telemetry_by_serial = {
-            serial: dict(value)
+            serial: {
+                key: (
+                    dict(item)
+                    if key in {"parameter_ids", "sampled_at"} and isinstance(item, dict)
+                    else item
+                )
+                for key, item in value.items()
+            }
             for serial, value in cached_by_serial.items()
-            if isinstance(value, dict)
+            if serial in serials and isinstance(value, dict)
         }
         for parameter_id, result in zip(parameter_ids, results, strict=True):
             if isinstance(result, Exception):
                 first_error = first_error or result
                 continue
-            if not isinstance(result, dict):
+            if not self._inverter_parameter_payload_is_valid(result):
+                first_error = first_error or ValueError(
+                    f"Dashboard parameter response was invalid for {parameter_id}"
+                )
                 continue
-            successful_payload = True
+            assert isinstance(result, dict)
+            valid_payload_count += 1
             canonical = INVERTER_PARAMETER_ALIASES[parameter_id.lower()]
+            for serial, snapshot in list(telemetry_by_serial.items()):
+                snapshot.pop(canonical, None)
+                for metadata_key in ("parameter_ids", "sampled_at"):
+                    metadata = snapshot.get(metadata_key)
+                    if not isinstance(metadata, dict):
+                        continue
+                    metadata.pop(canonical, None)
+                    if not metadata:
+                        snapshot.pop(metadata_key, None)
+                if not snapshot:
+                    telemetry_by_serial.pop(serial, None)
             for serial, (value, sampled_at) in self._inverter_parameter_rows(
                 result, parameter_id
             ).items():
@@ -2896,17 +2934,18 @@ class InventoryRuntime:
                 snapshot.setdefault("parameter_ids", {})[canonical] = parameter_id
                 if sampled_at is not None:
                     snapshot.setdefault("sampled_at", {})[canonical] = sampled_at
-        if successful_payload:
+        if valid_payload_count:
             self._set_shared_state_attr(
                 "_inverter_parameter_telemetry", telemetry_by_serial
             )
+        if valid_payload_count == len(parameter_ids):
             coord._note_endpoint_family_success(telemetry_family)
             return telemetry_by_serial
         coord._note_endpoint_family_failure(
             telemetry_family,
             first_error or ValueError("Dashboard parameter readings were unavailable"),
         )
-        return cached_by_serial
+        return telemetry_by_serial if valid_payload_count else cached_by_serial
 
     async def _async_refresh_inverters(self) -> None:
         """Refresh inverter metadata/status/production and build serial snapshots."""

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import math
 import re
 import time
 from collections.abc import Awaitable, Callable, Mapping
@@ -80,6 +81,28 @@ SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES: tuple[str, ...] = (
     "modems",
     "inverters",
 )
+INVERTER_PARAMETER_ALIASES: dict[str, str] = {
+    "power": "power",
+    "ac_power": "power",
+    "ac_voltage": "ac_voltage",
+    "voltage": "ac_voltage",
+    "acv": "ac_voltage",
+    "dc_voltage": "dc_voltage",
+    "dcv": "dc_voltage",
+    "ac_current": "ac_current",
+    "current": "ac_current",
+    "dc_current": "dc_current",
+    "dca": "dc_current",
+    "ac_frequency": "ac_frequency",
+    "frequency": "ac_frequency",
+    "achz": "ac_frequency",
+    "temperature": "temperature",
+    "tmpi": "temperature",
+    "signal_strength": "signal_strength",
+    "rssi": "signal_strength",
+    "firmware": "firmware",
+    "sw_version": "firmware",
+}
 
 
 @dataclass(frozen=True)
@@ -2558,6 +2581,333 @@ class InventoryRuntime:
         if not ready_before:
             self._devices_inventory_ready = False
 
+    def _gateway_serials_for_inverter_telemetry(self) -> list[str]:
+        """Return gateway serials without retaining any identifiers in diagnostics."""
+
+        bucket = self.type_bucket("envoy") or {}
+        members = bucket.get("devices")
+        if not isinstance(members, list):
+            return []
+        serials: list[str] = []
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            serial = self._type_member_text(
+                member, "serial_number", "serial_num", "serialNumber", "serial"
+            )
+            if serial:
+                serials.append(serial)
+        return list(dict.fromkeys(serials))
+
+    async def _async_inverter_dashboard_inventory(
+        self, inverters: list[dict[str, object]]
+    ) -> list[dict[str, object]]:
+        """Merge optional per-gateway dashboard inventory into legacy inventory."""
+
+        family = "inverter_dashboard_inventory"
+        cached = getattr(self, "_inverter_dashboard_inventory", None)
+        cached_by_serial = dict(cached) if isinstance(cached, dict) else {}
+        dashboard_health = self.coordinator._endpoint_family_state(family)
+        if (
+            dashboard_health.last_success_mono is not None
+            and not self.coordinator._endpoint_family_can_use_stale(family)
+        ):
+            cached_by_serial = {}
+        fetcher = getattr(self.client, "system_dashboard_envoy_inverters", None)
+        gateway_serials = self._gateway_serials_for_inverter_telemetry()
+        if not callable(fetcher) or not gateway_serials:
+            dashboard_by_serial = cached_by_serial
+        elif not self.coordinator._endpoint_family_should_run(family):
+            dashboard_by_serial = cached_by_serial
+        else:
+            results = await asyncio.gather(
+                *(fetcher(serial) for serial in gateway_serials),
+                return_exceptions=True,
+            )
+            first_error = next(
+                (result for result in results if isinstance(result, Exception)), None
+            )
+            dashboard_by_serial: dict[str, dict[str, object]] = {}
+            response_seen = False
+            for result in results:
+                if not isinstance(result, dict):
+                    continue
+                response_seen = True
+                records = result.get("data")
+                if not isinstance(records, list):
+                    continue
+                for record in records:
+                    if not isinstance(record, dict):
+                        continue
+                    serial = str(record.get("serial_number") or "").strip()
+                    if serial:
+                        # Device/parent IDs are not needed by entities and must not
+                        # be retained in inventory diagnostics.
+                        dashboard_by_serial[serial] = {
+                            key: record[key]
+                            for key in (
+                                "name",
+                                "serial_number",
+                                "status",
+                                "sub_status",
+                                "type",
+                            )
+                            if record.get(key) is not None
+                        }
+            if response_seen:
+                self.coordinator._note_endpoint_family_success(family)
+                self._set_shared_state_attr(
+                    "_inverter_dashboard_inventory", dashboard_by_serial
+                )
+            else:
+                error = first_error or ValueError(
+                    "Dashboard inverter inventory was unavailable"
+                )
+                self.coordinator._note_endpoint_family_failure(family, error)
+                dashboard_by_serial = cached_by_serial
+
+        merged_by_serial: dict[str, dict[str, object]] = {}
+        order: list[str] = []
+        for item in inverters:
+            serial = str(item.get("serial_number") or "").strip()
+            if not serial:
+                continue
+            merged = dict(dashboard_by_serial.get(serial, {}))
+            merged.update(item)
+            merged_by_serial[serial] = merged
+            order.append(serial)
+        for serial, item in dashboard_by_serial.items():
+            if serial in merged_by_serial:
+                continue
+            merged_by_serial[serial] = dict(item)
+            order.append(serial)
+        return [merged_by_serial[serial] for serial in order]
+
+    @staticmethod
+    def _inverter_parameter_value(value: object) -> object | None:
+        """Normalize a dashboard reading without accepting containers or NaN."""
+
+        if value is None or isinstance(value, bool):
+            return None
+        if isinstance(value, (int, float)):
+            number = float(value)
+            return number if math.isfinite(number) else None
+        if isinstance(value, str):
+            text = value.strip()
+            if not text or text.lower() in {"n/a", "na", "none", "null", "-"}:
+                return None
+            try:
+                number = float(text)
+            except ValueError:
+                return text
+            return number if math.isfinite(number) else None
+        return None
+
+    @classmethod
+    def _inverter_parameter_rows(
+        cls, payload: dict[str, object], parameter_id: str
+    ) -> dict[str, tuple[object, object | None]]:
+        """Extract latest per-serial values from observed parameter-view shapes."""
+
+        rows = payload.get("intervals")
+        if not isinstance(rows, list):
+            rows = payload.get("data")
+        if not isinstance(rows, list):
+            return {}
+        columns = payload.get("columns")
+        column_records = (
+            [item for item in columns if isinstance(item, dict)]
+            if isinstance(columns, list)
+            else []
+        )
+        out: dict[str, tuple[object, object | None]] = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            sampled_at = next(
+                (
+                    row.get(key)
+                    for key in ("timestamp", "date", "reported_at", "sampled_at")
+                    if row.get(key) is not None
+                ),
+                None,
+            )
+            serial = str(
+                row.get("serial_number")
+                or row.get("serial_num")
+                or row.get("device_serial")
+                or ""
+            ).strip()
+            if serial and serial not in out:
+                value = next(
+                    (
+                        row.get(key)
+                        for key in (parameter_id, "value", "reading")
+                        if row.get(key) is not None
+                    ),
+                    None,
+                )
+                normalized = cls._inverter_parameter_value(value)
+                if normalized is not None:
+                    out[serial] = (normalized, sampled_at)
+            for column in column_records:
+                column_serial = str(column.get("serial_number") or "").strip()
+                if not column_serial or column_serial in out:
+                    continue
+                attribute = str(column.get("attribute_name") or "").strip()
+                raw_value = row.get(attribute) if attribute else None
+                if raw_value is None:
+                    raw_value = row.get(column_serial)
+                normalized = cls._inverter_parameter_value(raw_value)
+                if normalized is not None:
+                    out[column_serial] = (normalized, sampled_at)
+        return out
+
+    async def _async_refresh_inverter_parameter_telemetry(
+        self, serials: list[str]
+    ) -> dict[str, dict[str, object]]:
+        """Refresh supported parameters in bulk, preserving stale optional data."""
+
+        coord = self.coordinator
+        cached = getattr(self, "_inverter_parameter_telemetry", None)
+        cached_by_serial = dict(cached) if isinstance(cached, dict) else {}
+        telemetry_family = "inverter_parameter_telemetry"
+        telemetry_health = coord._endpoint_family_state(telemetry_family)
+        if (
+            telemetry_health.last_success_mono is not None
+            and not coord._endpoint_family_can_use_stale(telemetry_family)
+        ):
+            cached_by_serial = {}
+        if not serials:
+            return cached_by_serial
+
+        master_fetcher = getattr(self.client, "system_dashboard_master_data", None)
+        columns_fetcher = getattr(self.client, "system_dashboard_data_columns", None)
+        parameter_ids = list(getattr(self, "_inverter_parameter_ids", None) or [])
+        catalog_family = "inverter_parameter_catalog"
+        if callable(master_fetcher) and coord._endpoint_family_should_run(
+            catalog_family
+        ):
+            try:
+                master_payload = await master_fetcher()
+            except Exception as err:  # noqa: BLE001
+                coord._note_endpoint_family_failure(catalog_family, err)
+                if not coord._endpoint_family_can_use_stale(catalog_family):
+                    parameter_ids = []
+                    self._set_shared_state_attr("_inverter_parameter_ids", [])
+            else:
+                parameters = (
+                    master_payload.get("parameters")
+                    if isinstance(master_payload, dict)
+                    else None
+                )
+                available: list[str] = []
+                if isinstance(parameters, list):
+                    for parameter in parameters:
+                        if not isinstance(parameter, dict):
+                            continue
+                        parameter_id = str(parameter.get("id") or "").strip()
+                        if parameter_id.lower() in INVERTER_PARAMETER_ALIASES:
+                            available.append(parameter_id)
+                if isinstance(master_payload, dict):
+                    selected: list[str] = []
+                    canonical_seen: set[str] = set()
+                    for parameter_id in available:
+                        canonical = INVERTER_PARAMETER_ALIASES[parameter_id.lower()]
+                        if canonical in canonical_seen:
+                            continue
+                        canonical_seen.add(canonical)
+                        selected.append(parameter_id)
+                    parameter_ids = selected
+                    self._set_shared_state_attr(
+                        "_inverter_parameter_ids", parameter_ids
+                    )
+                    coord._note_endpoint_family_success(catalog_family)
+                else:
+                    coord._note_endpoint_family_failure(
+                        catalog_family,
+                        ValueError("Dashboard parameter catalog was unavailable"),
+                    )
+
+            gateway_serials = self._gateway_serials_for_inverter_telemetry()
+            if callable(columns_fetcher) and gateway_serials:
+                column_results = await asyncio.gather(
+                    *(columns_fetcher(serial) for serial in gateway_serials),
+                    return_exceptions=True,
+                )
+                column_names: set[str] = set()
+                for result in column_results:
+                    if not isinstance(result, dict):
+                        continue
+                    columns = result.get("columns")
+                    if not isinstance(columns, list):
+                        continue
+                    for column in columns:
+                        if not isinstance(column, dict):
+                            continue
+                        name = str(
+                            column.get("attribute_name") or column.get("name") or ""
+                        ).strip()
+                        if name:
+                            column_names.add(name)
+                self._set_shared_state_attr(
+                    "_inverter_parameter_columns", sorted(column_names)
+                )
+
+        parameter_fetcher = getattr(
+            self.client, "system_dashboard_parameter_view", None
+        )
+        if (
+            not callable(parameter_fetcher)
+            or not parameter_ids
+            or not coord._endpoint_family_should_run(telemetry_family)
+        ):
+            return cached_by_serial
+
+        results = await asyncio.gather(
+            *(
+                parameter_fetcher(serials, parameter_id)
+                for parameter_id in parameter_ids
+            ),
+            return_exceptions=True,
+        )
+        successful_payload = False
+        first_error: Exception | None = None
+        telemetry_by_serial = {
+            serial: dict(value)
+            for serial, value in cached_by_serial.items()
+            if isinstance(value, dict)
+        }
+        for parameter_id, result in zip(parameter_ids, results, strict=True):
+            if isinstance(result, Exception):
+                first_error = first_error or result
+                continue
+            if not isinstance(result, dict):
+                continue
+            successful_payload = True
+            canonical = INVERTER_PARAMETER_ALIASES[parameter_id.lower()]
+            for serial, (value, sampled_at) in self._inverter_parameter_rows(
+                result, parameter_id
+            ).items():
+                if serial not in serials:
+                    continue
+                snapshot = telemetry_by_serial.setdefault(serial, {})
+                snapshot[canonical] = value
+                snapshot.setdefault("parameter_ids", {})[canonical] = parameter_id
+                if sampled_at is not None:
+                    snapshot.setdefault("sampled_at", {})[canonical] = sampled_at
+        if successful_payload:
+            self._set_shared_state_attr(
+                "_inverter_parameter_telemetry", telemetry_by_serial
+            )
+            coord._note_endpoint_family_success(telemetry_family)
+            return telemetry_by_serial
+        coord._note_endpoint_family_failure(
+            telemetry_family,
+            first_error or ValueError("Dashboard parameter readings were unavailable"),
+        )
+        return cached_by_serial
+
     async def _async_refresh_inverters(self) -> None:
         """Refresh inverter metadata/status/production and build serial snapshots."""
         coord = self.coordinator
@@ -2576,6 +2926,10 @@ class InventoryRuntime:
                 _inverter_status_type_counts={},
                 _inverter_model_counts={},
                 _inverter_production_cache_key=None,
+                _inverter_dashboard_inventory={},
+                _inverter_parameter_ids=[],
+                _inverter_parameter_columns=[],
+                _inverter_parameter_telemetry={},
                 _inverter_summary_counts={
                     "total": 0,
                     "normal": 0,
@@ -2684,6 +3038,16 @@ class InventoryRuntime:
             inventory_payload = dict(inventory_payload)
             inventory_payload["inverters"] = merged
             inverters_list = merged
+        inverters_list = await self._async_inverter_dashboard_inventory(inverters_list)
+        inventory_payload = dict(inventory_payload)
+        inventory_payload["inverters"] = inverters_list
+        telemetry_by_serial = await self._async_refresh_inverter_parameter_telemetry(
+            [
+                str(item.get("serial_number") or "").strip()
+                for item in inverters_list
+                if str(item.get("serial_number") or "").strip()
+            ]
+        )
         if fetch_inventory_now and inventory_payload is not cached_inventory_payload:
             coord._note_endpoint_family_success(inventory_family)
             self._set_shared_state_attr(
@@ -2839,7 +3203,7 @@ class InventoryRuntime:
                 continue
             serial = str(item.get("serial_number") or "").strip()
             if not serial:
-                continue
+                continue  # pragma: no cover - filtered by dashboard merge
             previous_item = previous_data.get(serial)
             if not isinstance(previous_item, dict):
                 previous_item = {}
@@ -2943,6 +3307,7 @@ class InventoryRuntime:
                 "lifetime_production_wh": production_wh,
                 "lifetime_query_start_date": query_start,
                 "lifetime_query_end_date": query_end,
+                "telemetry": dict(telemetry_by_serial.get(serial, {})),
             }
             inverter_order.append(serial)
 
@@ -3079,7 +3444,39 @@ class InventoryRuntime:
                 ) and coord._endpoint_family_should_run(
                     "inverter_production", force=force
                 )
-        return inventory_due or status_due or production_due
+        catalog_fetcher = getattr(self.client, "system_dashboard_master_data", None)
+        catalog_due = callable(catalog_fetcher) and coord._endpoint_family_should_run(
+            "inverter_parameter_catalog", force=force
+        )
+        parameter_ids = getattr(self, "_inverter_parameter_ids", None)
+        telemetry_fetcher = getattr(
+            self.client, "system_dashboard_parameter_view", None
+        )
+        telemetry_due = (
+            bool(parameter_ids)
+            and callable(telemetry_fetcher)
+            and coord._endpoint_family_should_run(
+                "inverter_parameter_telemetry", force=force
+            )
+        )
+        dashboard_fetcher = getattr(
+            self.client, "system_dashboard_envoy_inverters", None
+        )
+        dashboard_due = (
+            bool(self._gateway_serials_for_inverter_telemetry())
+            and callable(dashboard_fetcher)
+            and coord._endpoint_family_should_run(
+                "inverter_dashboard_inventory", force=force
+            )
+        )
+        return (
+            inventory_due
+            or status_due
+            or production_due
+            or catalog_due
+            or telemetry_due
+            or dashboard_due
+        )
 
     def iter_inverter_serials(self) -> list[str]:
         """Return currently active inverter serials in a stable order."""

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -340,6 +340,7 @@ async def async_setup_entry(
     last_charger_serial_set: set[str] | None = None
     last_inverter_serial_set: set[str] | None = None
     last_entity_shape_signature: tuple[object, ...] | None = None
+    last_inverter_telemetry_set: set[str] | None = None
 
     @callback
     def _async_sync_site_entities() -> None:
@@ -948,6 +949,19 @@ async def async_setup_entry(
             ]
             async_add_entities(entities, update_before_add=False)
             registry_setup.known_inverter_serials.update(serials)
+        telemetry_serials = [
+            sn
+            for sn in current_serials
+            if sn not in registry_setup.known_inverter_telemetry_serials
+            and isinstance(coord.inverter_data(sn), dict)
+            and bool((coord.inverter_data(sn) or {}).get("telemetry"))
+        ]
+        if telemetry_serials:
+            async_add_entities(
+                [EnphaseInverterTelemetrySensor(coord, sn) for sn in telemetry_serials],
+                update_before_add=False,
+            )
+            registry_setup.known_inverter_telemetry_serials.update(telemetry_serials)
 
     @callback
     def _async_sync_topology() -> None:
@@ -957,6 +971,7 @@ async def async_setup_entry(
         nonlocal last_ac_battery_serial_set
         nonlocal last_charger_serial_set
         nonlocal last_inverter_serial_set
+        nonlocal last_inverter_telemetry_set
 
         current_type_keys = {
             key for key in coord.inventory_view.iter_type_keys() if key
@@ -971,6 +986,15 @@ async def async_setup_entry(
         if current_charger_serials is None:
             current_charger_serials = {sn for sn in coord.iter_serials() if sn}
         current_inverter_serials = active_inverter_serials_for_cleanup(coord)
+        current_inverter_telemetry = (
+            {
+                serial
+                for serial in current_inverter_serials
+                if bool((coord.inverter_data(serial) or {}).get("telemetry"))
+            }
+            if current_inverter_serials is not None
+            else None
+        )
 
         # The dedicated topology signal also covers router membership, which is
         # intentionally absent from the cheap coordinator-update signature.
@@ -989,9 +1013,13 @@ async def async_setup_entry(
         if current_charger_serials != last_charger_serial_set:
             _async_sync_chargers()
             last_charger_serial_set = current_charger_serials
-        if current_inverter_serials != last_inverter_serial_set:
+        if (
+            current_inverter_serials != last_inverter_serial_set
+            or current_inverter_telemetry != last_inverter_telemetry_set
+        ):
             _async_sync_inverters()
             last_inverter_serial_set = current_inverter_serials
+            last_inverter_telemetry_set = current_inverter_telemetry
 
     def _entity_shape_signature() -> tuple[object, ...]:
         """Return inexpensive state that controls site-level entity presence."""
@@ -3134,6 +3162,92 @@ class EnphaseTypeInventorySensor(CoordinatorEntity, SensorEntity):  # type: igno
         return DeviceInfo(
             identifiers={(DOMAIN, f"type:{self._coord.site_id}:{self._type_key}")},
             manufacturer="Enphase",
+        )
+
+
+class EnphaseInverterTelemetrySensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
+    """Optional live parameter telemetry for one microinverter."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "inverter_telemetry"
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _attr_suggested_display_precision = 1
+
+    def __init__(self, coord: EnphaseCoordinator, serial: str) -> None:
+        super().__init__(coord)
+        self._coord = coord
+        self._sn = str(serial)
+        self._attr_unique_id = f"{DOMAIN}_inverter_{self._sn}_telemetry"
+        self._attr_translation_placeholders = {"serial_number": self._sn}
+
+    def _snapshot(self) -> dict[str, object]:
+        payload = self._coord.inverter_data(self._sn)
+        return payload if isinstance(payload, dict) else {}
+
+    def _telemetry(self) -> dict[str, object]:
+        telemetry = self._snapshot().get("telemetry")
+        return dict(telemetry) if isinstance(telemetry, dict) else {}
+
+    @property
+    def available(self) -> bool:
+        return bool(super().available and self._telemetry())
+
+    @property
+    def native_value(self) -> Any:
+        value = self._telemetry().get("power")
+        try:
+            number = float(value) if value is not None else None
+        except (TypeError, ValueError):
+            return None
+        return number if number is not None and math.isfinite(number) else None
+
+    @property
+    def extra_state_attributes(self) -> Any:
+        snapshot = self._snapshot()
+        telemetry = self._telemetry()
+        attrs: dict[str, object] = {}
+        attribute_names = {
+            "power": "power_w",
+            "ac_voltage": "ac_voltage_v",
+            "dc_voltage": "dc_voltage_v",
+            "ac_current": "ac_current_a",
+            "dc_current": "dc_current_a",
+            "ac_frequency": "ac_frequency_hz",
+            "temperature": "temperature_c",
+            "signal_strength": "signal_strength",
+            "firmware": "firmware",
+        }
+        for key, attribute_name in attribute_names.items():
+            value = telemetry.get(key)
+            if value is not None:
+                attrs[attribute_name] = value
+        for key in ("sampled_at", "parameter_ids"):
+            value = telemetry.get(key)
+            if isinstance(value, dict) and value:
+                attrs[key] = dict(value)
+        if snapshot.get("fw1") is not None:
+            attrs["firmware_primary"] = snapshot["fw1"]
+        if snapshot.get("fw2") is not None:
+            attrs["firmware_secondary"] = snapshot["fw2"]
+        if snapshot.get("rssi") is not None and "signal_strength" not in attrs:
+            attrs["signal_strength"] = snapshot["rssi"]
+        return attrs
+
+    @property
+    def device_info(self) -> Any:
+        from homeassistant.helpers.entity import DeviceInfo
+
+        info = _type_device_info(self._coord, "microinverter")
+        if info is not None:
+            return info
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"type:{self._coord.site_id}:microinverter")},
+            manufacturer="Enphase",
+            name="IQ Microinverters",
         )
 
 

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -62,7 +62,7 @@ from .entity import (
     evse_resolved_charge_mode,
 )
 from .labels import friendly_status_text, status_label
-from .parsing_helpers import heatpump_status_text
+from .parsing_helpers import coerce_optional_float, heatpump_status_text
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
 from .runtime_helpers import (
     coerce_optional_text as _gateway_clean_text,
@@ -3198,11 +3198,7 @@ class EnphaseInverterTelemetrySensor(CoordinatorEntity, SensorEntity):  # type: 
 
     @property
     def native_value(self) -> Any:
-        value = self._telemetry().get("power")
-        try:
-            number = float(value) if value is not None else None
-        except (TypeError, ValueError):
-            return None
+        number = coerce_optional_float(self._telemetry().get("power"))
         return number if number is not None and math.isfinite(number) else None
 
     @property

--- a/custom_components/enphase_ev/sensor_registry.py
+++ b/custom_components/enphase_ev/sensor_registry.py
@@ -15,12 +15,14 @@ from .serial_entity_metadata import (
     BATTERY_RETIRED_UNIQUE_SUFFIXES,
     CHARGER_SENSOR_UNIQUE_SUFFIXES,
     HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES,
+    INVERTER_ENTITY_UNIQUE_SUFFIXES,
     ac_battery_entity_serial_from_unique_id,
     battery_entity_serial_from_unique_id,
     charger_entity_serial_from_unique_id,
     charger_entity_unique_id,
     charger_entity_unique_ids,
     inverter_entity_unique_id,
+    inverter_entity_serial_from_unique_id,
     site_ac_battery_entity_unique_id,
     site_ac_battery_entity_unique_ids,
     site_battery_entity_unique_id,
@@ -44,6 +46,7 @@ class EnphaseSensorRegistrySetup:
         self.known_battery_serials: set[str] = set()
         self.known_ac_battery_serials: set[str] = set()
         self.known_inverter_serials: set[str] = set()
+        self.known_inverter_telemetry_serials: set[str] = set()
         self.battery_registry_pruned = False
         self.ac_battery_registry_pruned = False
         self.inverter_registry_pruned = False
@@ -107,6 +110,12 @@ class EnphaseSensorRegistrySetup:
         """Return the unique ID for a microinverter lifetime energy sensor."""
 
         return inverter_entity_unique_id(serial)
+
+    @staticmethod
+    def inverter_telemetry_sensor_unique_id(serial: str) -> str:
+        """Return the unique ID for a microinverter telemetry sensor."""
+
+        return inverter_entity_unique_id(serial, "_telemetry")
 
     def remove_site_sensor_entity(self, key: str) -> None:
         """Remove a site-level sensor entity by setup key."""
@@ -396,7 +405,6 @@ class EnphaseSensorRegistrySetup:
         if self.inverter_registry_pruned:
             return
         unique_prefix = f"{DOMAIN}_inverter_"
-        unique_suffix = "_lifetime_energy"
         for reg_entry in list(self._entity_registry_values()):
             if not self._registry_entry_matches_sensor(reg_entry):
                 continue
@@ -404,14 +412,15 @@ class EnphaseSensorRegistrySetup:
             if not (
                 isinstance(unique_id, str)
                 and unique_id.startswith(unique_prefix)
-                and unique_id.endswith(unique_suffix)
+                and unique_id.endswith(INVERTER_ENTITY_UNIQUE_SUFFIXES)
             ):
                 continue
-            serial = unique_id[len(unique_prefix) : -len(unique_suffix)]
+            serial = inverter_entity_serial_from_unique_id(unique_id)
             if not serial or serial in current_set:
                 continue
             self._ent_reg.async_remove(reg_entry.entity_id)
             self.known_inverter_serials.discard(serial)
+            self.known_inverter_telemetry_serials.discard(serial)
         self.inverter_registry_pruned = True
 
     def remove_missing_inverter_entities(self, current_set: set[str]) -> None:
@@ -420,8 +429,12 @@ class EnphaseSensorRegistrySetup:
         self._remove_missing_serial_entities(
             self.known_inverter_serials,
             current_set,
-            lambda serial: (self.inverter_lifetime_sensor_unique_id(serial),),
+            lambda serial: (
+                self.inverter_lifetime_sensor_unique_id(serial),
+                self.inverter_telemetry_sensor_unique_id(serial),
+            ),
         )
+        self.known_inverter_telemetry_serials.intersection_update(current_set)
 
     def battery_serial_from_unique_id(self, unique_id: object) -> str | None:
         """Return a battery serial parsed from a known per-battery unique ID."""

--- a/custom_components/enphase_ev/serial_entity_metadata.py
+++ b/custom_components/enphase_ev/serial_entity_metadata.py
@@ -68,7 +68,10 @@ AC_BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
     "_last_reported",
 )
 AC_BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = ("_last_reported_at",)
-INVERTER_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = ("_lifetime_energy",)
+INVERTER_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_lifetime_energy",
+    "_telemetry",
+)
 
 
 def charger_entity_unique_id(serial: str, suffix: str) -> str:
@@ -122,10 +125,10 @@ def site_ac_battery_entity_unique_ids(
     )
 
 
-def inverter_entity_unique_id(serial: str) -> str:
+def inverter_entity_unique_id(serial: str, suffix: str = "_lifetime_energy") -> str:
     """Return a microinverter unique ID."""
 
-    return f"{DOMAIN}_inverter_{serial}_lifetime_energy"
+    return f"{DOMAIN}_inverter_{serial}{suffix}"
 
 
 def charger_entity_serial_from_unique_id(

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -215,6 +215,10 @@ class InventoryState:
     _type_device_buckets: PayloadMapByKey = field(default_factory=dict)
     _type_device_order: list[str] = field(default_factory=list)
     _inverter_production_cache_key: tuple[str, str] | None = None
+    _inverter_dashboard_inventory: PayloadMapByKey = field(default_factory=dict)
+    _inverter_parameter_ids: list[str] = field(default_factory=list)
+    _inverter_parameter_columns: list[str] = field(default_factory=list)
+    _inverter_parameter_telemetry: PayloadMapByKey = field(default_factory=dict)
 
 
 @dataclass(slots=True)

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -1498,6 +1498,9 @@
       "microinverter_reporting_count": {
         "name": "Active Microinverters"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} Telemetry"
+      },
       "microinverter_last_reported": {
         "name": "Microinverter Last Reported"
       },

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Активни микроинвертори"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} телеметрия"
+      },
       "microinverter_last_reported": {
         "name": "Последно отчитане на микроинвертори"
       },

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktivní mikroinvertory"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} telemetrie"
+      },
       "microinverter_last_reported": {
         "name": "Poslední hlášení mikroinvertorů"
       },

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktive mikroinvertere"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} telemetri"
+      },
       "microinverter_last_reported": {
         "name": "Senest rapporteret fra mikroinvertere"
       },

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktive Mikrowechselrichter"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} Telemetrie"
+      },
       "microinverter_last_reported": {
         "name": "Letzte Meldung der Mikrowechselrichter"
       },

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Ενεργοί μικρομετατροπείς"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} Τηλεμετρία"
+      },
       "microinverter_last_reported": {
         "name": "Τελευταία αναφορά μικρομετατροπέων"
       },

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Active Microinverters"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} Telemetry"
+      },
       "microinverter_last_reported": {
         "name": "Microinverter Last Reported"
       },

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Active Microinverters"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} Telemetry"
+      },
       "microinverter_last_reported": {
         "name": "Microinverter Last Reported"
       },

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Active Microinverters"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} Telemetry"
+      },
       "microinverter_last_reported": {
         "name": "Microinverter Last Reported"
       },

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Active Microinverters"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} Telemetry"
+      },
       "microinverter_last_reported": {
         "name": "Microinverter Last Reported"
       },

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Active Microinverters"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} Telemetry"
+      },
       "microinverter_last_reported": {
         "name": "Microinverter Last Reported"
       },

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Active Microinverters"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} Telemetry"
+      },
       "microinverter_last_reported": {
         "name": "Microinverter Last Reported"
       },

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Microinversores activos"
       },
+      "inverter_telemetry": {
+        "name": "Telemetría {serial_number}"
+      },
       "microinverter_last_reported": {
         "name": "Último reporte de microinversores"
       },

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktiivsed mikroinverterid"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} telemeetria"
+      },
       "microinverter_last_reported": {
         "name": "Mikroinverterite viimane raport"
       },

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktiiviset mikroinvertterit"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} telemetria"
+      },
       "microinverter_last_reported": {
         "name": "Mikroinvertterien viimeisin raportti"
       },

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Micro-onduleurs actifs"
       },
+      "inverter_telemetry": {
+        "name": "Télémétrie {serial_number}"
+      },
       "microinverter_last_reported": {
         "name": "Dernier rapport des micro-onduleurs"
       },

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktív mikroinverterek"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} telemetria"
+      },
       "microinverter_last_reported": {
         "name": "Mikroinverterek utolsó jelentése"
       },

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Microinverter attivi"
       },
+      "inverter_telemetry": {
+        "name": "Telemetria {serial_number}"
+      },
       "microinverter_last_reported": {
         "name": "Ultima segnalazione microinverter"
       },

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktyvūs mikroinverteriai"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} telemetrija"
+      },
       "microinverter_last_reported": {
         "name": "Paskutinis mikroinverterių pranešimas"
       },

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktīvie mikroinvertori"
       },
+      "inverter_telemetry": {
+        "name": "{serial_number} telemetrija"
+      },
       "microinverter_last_reported": {
         "name": "Pēdējais mikroinvertoru ziņojums"
       },

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktive mikrovekselrettere"
       },
+      "inverter_telemetry": {
+        "name": "Telemetri {serial_number}"
+      },
       "microinverter_last_reported": {
         "name": "Sist rapportert fra mikroinvertere"
       },

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Actieve micro-omvormers"
       },
+      "inverter_telemetry": {
+        "name": "Telemetrie {serial_number}"
+      },
       "microinverter_last_reported": {
         "name": "Laatst gemeld door micro-omvormers"
       },

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktywne mikroinwertery"
       },
+      "inverter_telemetry": {
+        "name": "Telemetria {serial_number}"
+      },
       "microinverter_last_reported": {
         "name": "Ostatni raport mikroinwerterów"
       },

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Microinversores ativos"
       },
+      "inverter_telemetry": {
+        "name": "Telemetria {serial_number}"
+      },
       "microinverter_last_reported": {
         "name": "Último reporte dos microinversores"
       },

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Microinvertoare active"
       },
+      "inverter_telemetry": {
+        "name": "Telemetrie {serial_number}"
+      },
       "microinverter_last_reported": {
         "name": "Ultima raportare microinvertoare"
       },

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -1459,6 +1459,9 @@
       "microinverter_reporting_count": {
         "name": "Aktiva mikroväxelriktare"
       },
+      "inverter_telemetry": {
+        "name": "Telemetri {serial_number}"
+      },
       "microinverter_last_reported": {
         "name": "Senaste rapport från mikroväxelriktare"
       },

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -123,7 +123,10 @@ Status labels:
 | Tariff settings MQTT authorizer | `GET` | `/pv/aws_sigv4/tariff_settings_response_stream?serial_number=<gateway_sn>` | authenticated Enlighten session cookies + `e-auth-token` + `x-xsrf-token` | Browser capture only |
 | EVSE tariff-change notification | `PUT` | `/service/evse_scheduler/api/v1/siteConfig/<site_id>/tariff_change` | tariff web write headers + JSON `null` body | Runtime (best-effort) |
 | System dashboard summary | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/summary` | session cookies + optional `Authorization: Bearer <token>` (current implementation adds bearer when available) | Runtime |
-| System dashboard master data | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/data/master-data` | dashboard-read headers: authenticated cookies, optional bearer, XSRF when present | Browser capture only |
+| System dashboard master data | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/data/master-data` | dashboard-read headers: authenticated cookies, optional bearer, XSRF when present | Runtime |
+| Per-gateway microinverter inventory | `GET` | `/service/system_dashboard/api_internal/dashboard/sites/<site_id>/envoy_inverters?serial_number=<gateway_sn>` | dashboard-read headers: authenticated cookies, optional bearer, XSRF when present | Runtime |
+| Device-level parameter columns | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/data/columns?serial_num=<gateway_sn>&type=device_level` | dashboard-read headers: authenticated cookies, optional bearer, XSRF when present | Runtime |
+| Bulk device parameter readings | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/data/parameter-view?serial_numbers=<csv>&parameter_id=<id>&...` | dashboard-read headers: authenticated cookies, optional bearer, XSRF when present | Runtime |
 | Activation checklist | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/updated_activation_checklist` | dashboard-read headers: authenticated cookies, optional bearer | Browser capture only |
 | System dashboard devices table | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/devices?range=<range>&filter_columns=<...>&serial_numbers=<...>&type=table&page=<page>&per_page=<n>` | dashboard-read headers: authenticated cookies, optional bearer | Browser capture only |
 | System dashboard status | `GET` | `/service/system_dashboard/api_internal/dashboard/sites/<site_id>/status` | dashboard-read headers: authenticated cookies, optional bearer | Browser capture only |
@@ -1859,6 +1862,28 @@ Notes:
 - `activity_types.id` values are not normalized. The sample contained mixed casing, embedded spaces, and duplicate-looking variants, so clients should preserve the raw string rather than coercing it.
 - Meter `serial_num` values may derive from the gateway serial with suffixes such as `EIM1` and `EIM2`.
 - Because the payload is catalog-like and changed infrequently in the capture, it is a better candidate for caching than the live status endpoints.
+
+Runtime behavior:
+- The integration caches this catalog for six hours and only requests parameter IDs that the site advertises.
+- User and activity catalogs are not retained in runtime diagnostics. This avoids persisting email-address identifiers or unrelated commissioning history.
+
+### 2.9.4.b.1 Per-Gateway Microinverter Inventory
+```
+GET /service/system_dashboard/api_internal/dashboard/sites/<site_id>/envoy_inverters?serial_number=<gateway_sn>
+```
+Returns a flattened `data[]` list with `id`, `name`, `serial_number`, `status`, `sub_status`, `type`, and `parent_id`. The runtime batches one request per discovered gateway, caches the result for six hours, and uses it only to enrich or fill gaps in the legacy microinverter inventory. Failures preserve the last successful optional payload and do not fail the coordinator refresh.
+
+### 2.9.4.b.2 Device Parameter Columns
+```
+GET /service/system_dashboard/api_internal/cs/sites/<site_id>/data/columns?serial_num=<gateway_sn>&type=device_level
+```
+Returns `columns[]` metadata including `name`, `header`, `attribute_name`, visibility/sort flags, and filter type. Runtime retains only the non-sensitive column/attribute names; gateway and device identifiers are not copied into diagnostics.
+
+### 2.9.4.b.3 Bulk Device Parameter Readings
+```
+GET /service/system_dashboard/api_internal/cs/sites/<site_id>/data/parameter-view?serial_numbers=<csv>&per_page=500&page=1&range=today&parameter_id=<id>&start_date=&end_date=&sort_by_date=desc
+```
+Returns paginated device readings for one parameter. The response includes `intervals[]`, per-device `columns[]`, paging fields, and range metadata. The integration passes every active microinverter serial in one CSV request per supported parameter, uses the site master-data catalog to avoid unsupported probes, and caches successful readings for five minutes. Supported values are normalized to power, AC/DC voltage/current, AC frequency, temperature, signal strength, and firmware when advertised and present. Empty or malformed rows are ignored, and recent successful values remain usable for up to 30 minutes during optional endpoint failures.
 
 ### 2.9.4.c System Dashboard Devices Table
 ```

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -2643,6 +2643,70 @@ async def test_devices_details_reraises_unexpected_http_error() -> None:
 
 
 @pytest.mark.asyncio
+async def test_system_dashboard_microinverter_parameter_endpoints() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=[
+            {"parameters": [{"id": "power"}]},
+            {"data": [{"serial_number": "INV-A"}]},
+            {"columns": [{"attribute_name": "value_1"}]},
+            {"intervals": []},
+        ]
+    )
+
+    assert await client.system_dashboard_master_data() == {
+        "parameters": [{"id": "power"}]
+    }
+    assert await client.system_dashboard_envoy_inverters(" GW-A ") == {
+        "data": [{"serial_number": "INV-A"}]
+    }
+    assert await client.system_dashboard_data_columns("GW-A") == {
+        "columns": [{"attribute_name": "value_1"}]
+    }
+    assert await client.system_dashboard_parameter_view(
+        ["INV-A", "INV-B", "INV-A"], "power"
+    ) == {"intervals": []}
+
+    urls = [call.args[1] for call in client._json.await_args_list]
+    assert urls[0].endswith("/cs/sites/SITE/data/master-data")
+    assert URL(urls[1]).query["serial_number"] == "GW-A"
+    assert URL(urls[2]).query == {
+        "serial_num": "GW-A",
+        "type": "device_level",
+    }
+    parameter_query = URL(urls[3]).query
+    assert parameter_query["serial_numbers"] == "INV-A,INV-B"
+    assert parameter_query["parameter_id"] == "power"
+    assert parameter_query["sort_by_date"] == "desc"
+    assert all(
+        call.kwargs["headers"] == client._system_dashboard_headers()
+        for call in client._json.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_system_dashboard_microinverter_parameter_endpoint_guards() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value=["bad"])
+
+    assert await client.system_dashboard_envoy_inverters("") is None
+    assert await client.system_dashboard_data_columns("") is None
+    assert await client.system_dashboard_parameter_view([], "power") is None
+    assert await client.system_dashboard_parameter_view(["INV-A"], "") is None
+    assert await client.system_dashboard_master_data() is None
+
+    client._json = AsyncMock(side_effect=_make_cre(404))
+    assert await client.system_dashboard_master_data() is None
+    assert await client.system_dashboard_envoy_inverters("GW-A") is None
+    assert await client.system_dashboard_data_columns("GW-A") is None
+    assert await client.system_dashboard_parameter_view(["INV-A"], "power") is None
+
+    client._json = AsyncMock(side_effect=_make_cre(500))
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.system_dashboard_parameter_view(["INV-A"], "power")
+
+
+@pytest.mark.asyncio
 async def test_grid_control_check_uses_grid_control_check_endpoint() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"disableGridControl": False})

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -1286,6 +1286,257 @@ async def test_inventory_runtime_refresh_inverters_paths(coordinator_factory) ->
 
 
 @pytest.mark.asyncio
+async def test_inventory_runtime_bulk_parameter_telemetry(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    coord._type_device_buckets["envoy"] = {  # noqa: SLF001
+        "type_key": "envoy",
+        "count": 1,
+        "devices": [{"serial_number": "GW-A"}],
+    }
+    coord.client.system_dashboard_envoy_inverters = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "serial_number": "INV-A",
+                    "id": "DEVICE-A",
+                    "name": "IQ8",
+                    "status": "normal",
+                }
+            ]
+        }
+    )
+    coord.client.system_dashboard_master_data = AsyncMock(
+        return_value={
+            "parameters": [
+                {"id": "power"},
+                {"id": "ac_frequency"},
+                {"id": "temperature"},
+                {"id": "unrelated"},
+            ]
+        }
+    )
+    coord.client.system_dashboard_data_columns = AsyncMock(
+        return_value={"columns": [{"attribute_name": "reading_1"}]}
+    )
+
+    async def _parameter_view(_serials, parameter_id):
+        if parameter_id == "power":
+            return {
+                "intervals": [{"timestamp": "2026-07-11T01:00:00Z", "reading_1": 212}],
+                "columns": [{"serial_number": "INV-A", "attribute_name": "reading_1"}],
+            }
+        return {
+            "intervals": [
+                {
+                    "serial_number": "INV-A",
+                    "timestamp": "2026-07-11T01:00:00Z",
+                    "value": 49.98 if parameter_id == "ac_frequency" else "41.5",
+                }
+            ]
+        }
+
+    coord.client.system_dashboard_parameter_view = AsyncMock(
+        side_effect=_parameter_view
+    )
+    coord.client.inverters_inventory = AsyncMock(return_value={"inverters": []})
+    coord.client.inverter_status = AsyncMock(return_value={})
+    coord.client.inverter_production = AsyncMock(return_value={})
+
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+
+    snapshot = coord.inverter_data("INV-A")
+    assert snapshot is not None
+    assert snapshot["device_id"] is None
+    assert snapshot["telemetry"] == {
+        "power": 212.0,
+        "parameter_ids": {
+            "power": "power",
+            "ac_frequency": "ac_frequency",
+            "temperature": "temperature",
+        },
+        "sampled_at": {
+            "power": "2026-07-11T01:00:00Z",
+            "ac_frequency": "2026-07-11T01:00:00Z",
+            "temperature": "2026-07-11T01:00:00Z",
+        },
+        "ac_frequency": 49.98,
+        "temperature": 41.5,
+    }
+    assert coord._inverter_parameter_columns == ["reading_1"]  # noqa: SLF001
+    assert coord.client.system_dashboard_parameter_view.await_count == 3
+
+    for family in (
+        "inverter_dashboard_inventory",
+        "inverter_parameter_catalog",
+        "inverter_parameter_telemetry",
+    ):
+        assert (
+            coord._endpoint_family_state(family).consecutive_failures == 0
+        )  # noqa: SLF001
+
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+    assert coord.client.system_dashboard_parameter_view.await_count == 3
+
+
+def test_inventory_runtime_parameter_row_shapes_and_invalid_values() -> None:
+    parser = InventoryRuntime._inverter_parameter_rows
+    assert parser({"data": [{"serial_num": "INV-A", "power": "10.5"}]}, "power") == {
+        "INV-A": (10.5, None)
+    }
+    assert parser(
+        {
+            "intervals": [
+                {"device_serial": "INV-A", "reading": "N/A"},
+                {"device_serial": "INV-B", "reading": float("inf")},
+                {"device_serial": "INV-C", "reading": "firmware-v1"},
+            ]
+        },
+        "firmware",
+    ) == {"INV-C": ("firmware-v1", None)}
+    assert parser({"intervals": "bad"}, "power") == {}
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_parameter_telemetry_edge_paths(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    coord._inverter_dashboard_inventory = {  # noqa: SLF001
+        "INV-CACHED": {"serial_number": "INV-CACHED"}
+    }
+    coord._type_device_buckets["envoy"] = {  # noqa: SLF001
+        "type_key": "envoy",
+        "count": 0,
+        "devices": "bad",
+    }
+    original_type_bucket = runtime.type_bucket
+    monkeypatch.setattr(runtime, "type_bucket", lambda _type: {"devices": "bad"})
+    assert runtime._gateway_serials_for_inverter_telemetry() == []  # noqa: SLF001
+    monkeypatch.setattr(runtime, "type_bucket", lambda _type: {"devices": ["bad"]})
+    assert runtime._gateway_serials_for_inverter_telemetry() == []  # noqa: SLF001
+    monkeypatch.setattr(runtime, "type_bucket", original_type_bucket)
+    assert await runtime._async_inverter_dashboard_inventory([]) == [  # noqa: SLF001
+        {"serial_number": "INV-CACHED"}
+    ]
+    coord._endpoint_family_state(  # noqa: SLF001
+        "inverter_dashboard_inventory"
+    ).last_success_mono = 0.0
+    assert await runtime._async_inverter_dashboard_inventory([]) == []  # noqa: SLF001
+
+    coord._type_device_buckets["envoy"] = {  # noqa: SLF001
+        "type_key": "envoy",
+        "count": 1,
+        "devices": ["bad", {}, {"serial_num": "GW-A"}, {"serial_num": "GW-A"}],
+    }
+    assert runtime._gateway_serials_for_inverter_telemetry() == ["GW-A"]  # noqa: SLF001
+    monkeypatch.setattr(coord, "_endpoint_family_should_run", lambda *_args: False)
+    assert await runtime._async_inverter_dashboard_inventory(  # noqa: SLF001
+        [{"serial_number": "INV-CACHED", "name": "Legacy"}]
+    ) == [{"serial_number": "INV-CACHED", "name": "Legacy"}]
+
+    monkeypatch.setattr(coord, "_endpoint_family_should_run", lambda *_args: True)
+    coord.client.system_dashboard_envoy_inverters = AsyncMock(
+        return_value={"data": ["bad", {"serial_number": ""}]}
+    )
+    assert (
+        await runtime._async_inverter_dashboard_inventory(  # noqa: SLF001
+            [{"serial_number": ""}]
+        )
+        == []
+    )
+    coord.client.system_dashboard_envoy_inverters = AsyncMock(
+        return_value={"data": "bad"}
+    )
+    assert await runtime._async_inverter_dashboard_inventory([]) == []  # noqa: SLF001
+    coord.client.system_dashboard_envoy_inverters = AsyncMock(
+        side_effect=RuntimeError("optional")
+    )
+    assert await runtime._async_inverter_dashboard_inventory([]) == []  # noqa: SLF001
+
+    assert runtime._inverter_parameter_value(None) is None  # noqa: SLF001
+    assert runtime._inverter_parameter_value(True) is None  # noqa: SLF001
+    assert runtime._inverter_parameter_value({}) is None  # noqa: SLF001
+    assert runtime._inverter_parameter_rows(  # noqa: SLF001
+        {
+            "intervals": [
+                "bad",
+                {"serial_number": "INV-A", "value": 1},
+                {"INV-B": 2},
+            ],
+            "columns": [
+                "bad",
+                {"serial_number": ""},
+                {"serial_number": "INV-A", "attribute_name": "unused"},
+                {"serial_number": "INV-B"},
+            ],
+        },
+        "power",
+    ) == {"INV-A": (1.0, None), "INV-B": (2.0, None)}
+
+    coord.client.system_dashboard_master_data = AsyncMock(
+        return_value={
+            "parameters": [
+                "bad",
+                {"id": "power"},
+                {"id": "ac_power"},
+            ]
+        }
+    )
+    coord.client.system_dashboard_data_columns = AsyncMock(
+        side_effect=["bad", {"columns": "bad"}]
+    )
+    coord._type_device_buckets["envoy"]["devices"] = [  # noqa: SLF001
+        {"serial_num": "GW-A"},
+        {"serial_num": "GW-B"},
+    ]
+    coord.client.system_dashboard_parameter_view = AsyncMock(
+        side_effect=[RuntimeError("one parameter failed")]
+    )
+    assert (
+        await runtime._async_refresh_inverter_parameter_telemetry(  # noqa: SLF001
+            ["INV-A"]
+        )
+        == {}
+    )
+
+    coord.client.system_dashboard_master_data = AsyncMock(return_value=None)
+    coord.client.system_dashboard_data_columns = AsyncMock(
+        return_value={"columns": ["bad", {"name": "column-name"}]}
+    )
+    coord._inverter_parameter_ids = ["power", "temperature"]  # noqa: SLF001
+    coord.client.system_dashboard_parameter_view = AsyncMock(
+        side_effect=["bad", {"intervals": [{"serial_number": "OTHER", "value": 2}]}]
+    )
+    assert (
+        await runtime._async_refresh_inverter_parameter_telemetry(  # noqa: SLF001
+            ["INV-A"]
+        )
+        == {}
+    )
+    assert coord._inverter_parameter_columns == ["column-name"]  # noqa: SLF001
+
+    coord.client.system_dashboard_master_data = AsyncMock(
+        side_effect=RuntimeError("catalog failed")
+    )
+    coord._inverter_parameter_ids = []  # noqa: SLF001
+    assert (
+        await runtime._async_refresh_inverter_parameter_telemetry(  # noqa: SLF001
+            ["INV-A"]
+        )
+        == {}
+    )
+    coord._inverter_parameter_telemetry = {"INV-A": {"power": 1}}  # noqa: SLF001
+    coord._endpoint_family_state(  # noqa: SLF001
+        "inverter_parameter_telemetry"
+    ).last_success_mono = 0.0
+    assert (
+        await runtime._async_refresh_inverter_parameter_telemetry([]) == {}
+    )  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_inventory_runtime_inverters_early_return_paths(
     coordinator_factory,
 ) -> None:

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -1379,6 +1379,109 @@ async def test_inventory_runtime_bulk_parameter_telemetry(coordinator_factory) -
     assert coord.client.system_dashboard_parameter_view.await_count == 3
 
 
+@pytest.mark.asyncio
+async def test_inventory_runtime_empty_parameter_rows_clear_cached_value(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    runtime._set_shared_state_attr(  # noqa: SLF001
+        "_inverter_parameter_ids", ["power", "temperature"]
+    )
+    runtime._set_shared_state_attr(  # noqa: SLF001
+        "_inverter_parameter_telemetry",
+        {
+            "INV-A": {
+                "power": 250.0,
+                "temperature": 42.0,
+                "parameter_ids": {
+                    "power": "power",
+                    "temperature": "temperature",
+                },
+                "sampled_at": {
+                    "power": "2026-07-11T01:00:00Z",
+                    "temperature": "2026-07-11T01:00:00Z",
+                },
+            },
+            "INV-B": {"power": 20.0},
+            "INV-C": {
+                "power": 30.0,
+                "parameter_ids": {"power": "power"},
+                "sampled_at": {"power": "2026-07-11T01:00:00Z"},
+            },
+            "INV-RETIRED": {"power": 10.0},
+        },
+    )
+    monkeypatch.setattr(
+        coord,
+        "_endpoint_family_should_run",
+        lambda family, **_kwargs: family == "inverter_parameter_telemetry",
+    )
+    coord.client.system_dashboard_parameter_view = AsyncMock(
+        side_effect=[
+            {"intervals": []},
+            RuntimeError("temperature temporarily unavailable"),
+        ]
+    )
+
+    result = await runtime._async_refresh_inverter_parameter_telemetry(  # noqa: SLF001
+        ["INV-A", "INV-B", "INV-C"]
+    )
+
+    assert result == {
+        "INV-A": {
+            "temperature": 42.0,
+            "parameter_ids": {"temperature": "temperature"},
+            "sampled_at": {"temperature": "2026-07-11T01:00:00Z"},
+        }
+    }
+    assert (
+        coord._endpoint_family_state(  # noqa: SLF001
+            "inverter_parameter_telemetry"
+        ).consecutive_failures
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_partial_gateway_inventory_preserves_cache(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    coord._type_device_buckets["envoy"] = {  # noqa: SLF001
+        "type_key": "envoy",
+        "count": 2,
+        "devices": [
+            {"serial_number": "GW-A"},
+            {"serial_number": "GW-B"},
+        ],
+    }
+    runtime._set_shared_state_attr(  # noqa: SLF001
+        "_inverter_dashboard_inventory",
+        {"INV-CACHED": {"serial_number": "INV-CACHED", "status": "normal"}},
+    )
+    coord.client.system_dashboard_envoy_inverters = AsyncMock(
+        side_effect=[
+            {"data": [{"serial_number": "INV-FRESH", "status": "warning"}]},
+            RuntimeError("second gateway unavailable"),
+        ]
+    )
+
+    result = await runtime._async_inverter_dashboard_inventory([])  # noqa: SLF001
+
+    assert result == [
+        {"serial_number": "INV-CACHED", "status": "normal"},
+        {"serial_number": "INV-FRESH", "status": "warning"},
+    ]
+    assert (
+        coord._endpoint_family_state(  # noqa: SLF001
+            "inverter_dashboard_inventory"
+        ).consecutive_failures
+        == 1
+    )
+
+
 def test_inventory_runtime_parameter_row_shapes_and_invalid_values() -> None:
     parser = InventoryRuntime._inverter_parameter_rows
     assert parser({"data": [{"serial_num": "INV-A", "power": "10.5"}]}, "power") == {

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -1633,7 +1633,7 @@ async def test_inventory_runtime_parameter_telemetry_edge_paths(
     coord._inverter_parameter_telemetry = {"INV-A": {"power": 1}}  # noqa: SLF001
     coord._endpoint_family_state(  # noqa: SLF001
         "inverter_parameter_telemetry"
-    ).last_success_mono = 0.0
+    ).last_success_mono = (time.monotonic() - 1_801.0)
     assert (
         await runtime._async_refresh_inverter_parameter_telemetry([]) == {}
     )  # noqa: SLF001

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -1525,7 +1525,7 @@ async def test_inventory_runtime_parameter_telemetry_edge_paths(
     ]
     coord._endpoint_family_state(  # noqa: SLF001
         "inverter_dashboard_inventory"
-    ).last_success_mono = 0.0
+    ).last_success_mono = (time.monotonic() - 86_401.0)
     assert await runtime._async_inverter_dashboard_inventory([]) == []  # noqa: SLF001
 
     coord._type_device_buckets["envoy"] = {  # noqa: SLF001

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -1331,6 +1331,7 @@ async def test_async_setup_entry_adds_inverter_lifetime_sensors(
 ):
     from custom_components.enphase_ev.sensor import (
         EnphaseInverterLifetimeEnergySensor,
+        EnphaseInverterTelemetrySensor,
         async_setup_entry,
     )
 
@@ -1344,6 +1345,7 @@ async def test_async_setup_entry_adds_inverter_lifetime_sensors(
             "lifetime_production_wh": 1_500_000,
             "lifetime_query_start_date": "2022-08-10",
             "lifetime_query_end_date": "2026-02-09",
+            "telemetry": {"power": 220.0},
         }
     }
     coord._inverter_order = ["INV-A"]  # noqa: SLF001
@@ -1371,6 +1373,7 @@ async def test_async_setup_entry_adds_inverter_lifetime_sensors(
         ent for ent in added if isinstance(ent, EnphaseInverterLifetimeEnergySensor)
     ]
     assert len(inverter_entities) == 1
+    assert any(isinstance(ent, EnphaseInverterTelemetrySensor) for ent in added)
     entity = inverter_entities[0]
     assert entity.native_value == pytest.approx(1500.0)
     attrs = entity.extra_state_attributes
@@ -1383,6 +1386,51 @@ async def test_async_setup_entry_adds_inverter_lifetime_sensors(
     assert set(attrs) <= entity._unrecorded_attributes  # noqa: SLF001
 
     # Entity reports unavailable once the inverter snapshot is removed.
+    coord._inverter_data = {}  # noqa: SLF001
+    assert entity.available is False
+
+
+def test_inverter_telemetry_sensor(coordinator_factory) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseInverterTelemetrySensor
+
+    coord = coordinator_factory()
+    coord._inverter_data = {  # noqa: SLF001
+        "INV-A": {
+            "telemetry": {
+                "power": 234.5,
+                "ac_voltage": 230.1,
+                "ac_frequency": 49.99,
+                "temperature": 42,
+                "sampled_at": {"power": "2026-07-11T01:00:00Z"},
+                "parameter_ids": {"power": "power"},
+            },
+            "fw1": "v1",
+            "fw2": "v2",
+            "rssi": {"sig_str": 72},
+        }
+    }
+    entity = EnphaseInverterTelemetrySensor(coord, "INV-A")
+
+    assert entity.available is True
+    assert entity.native_value == 234.5
+    assert entity.entity_registry_enabled_default is False
+    assert entity.extra_state_attributes == {
+        "power_w": 234.5,
+        "ac_voltage_v": 230.1,
+        "ac_frequency_hz": 49.99,
+        "temperature_c": 42,
+        "sampled_at": {"power": "2026-07-11T01:00:00Z"},
+        "parameter_ids": {"power": "power"},
+        "firmware_primary": "v1",
+        "firmware_secondary": "v2",
+        "signal_strength": {"sig_str": 72},
+    }
+    coord.inventory_view.type_device_info = lambda _type: {"name": "Shared"}
+    assert entity.device_info == {"name": "Shared"}
+    coord.inventory_view.type_device_info = lambda _type: None
+    assert entity.device_info["name"] == "IQ Microinverters"
+    coord._inverter_data["INV-A"]["telemetry"]["power"] = "bad"  # noqa: SLF001
+    assert entity.native_value is None
     coord._inverter_data = {}  # noqa: SLF001
     assert entity.available is False
 

--- a/tests/components/enphase_ev/test_sensor_registry.py
+++ b/tests/components/enphase_ev/test_sensor_registry.py
@@ -81,6 +81,20 @@ def test_sensor_registry_get_entity_id_without_registry_method() -> None:
     assert helper._async_get_sensor_entity_id("unique-id") is None
 
 
+def test_sensor_registry_type_removal_and_entity_iteration_edge_paths() -> None:
+    helper = _helper(SimpleNamespace(entities=None))
+    helper.remove_type_sensor_entity("envoy")
+    assert helper._entity_registry_values() == ()  # noqa: SLF001
+
+    registry = SimpleNamespace(
+        async_get_entity_id=MagicMock(return_value=None),
+        async_remove=MagicMock(),
+    )
+    helper = _helper(registry)
+    helper.remove_type_sensor_entity("envoy")
+    registry.async_remove.assert_not_called()
+
+
 def test_sensor_registry_prunes_gateway_and_type_inventory_entities() -> None:
     registry = FakeRegistry(
         {


### PR DESCRIPTION
## Summary

Adds optional installer-level microinverter parameter telemetry using the captured System Dashboard master-data, per-gateway inventory, columns, and bulk parameter-view endpoints.

The implementation discovers supported parameters from the site catalog, batches active microinverters, exposes a disabled-by-default diagnostic telemetry sensor, and uses independent TTL, stale-cache, and backoff handling. Follow-up review hardened partial-response handling so authoritative empty reads clear old values while partial failures preserve only bounded stale data.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/sensor_registry.py custom_components/enphase_ev/serial_entity_metadata.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/pr-feature1.coverage python -m coverage erase && COVERAGE_FILE=/tmp/pr-feature1.coverage python -m coverage run -m pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/pr-feature1-registry.coverage python -m coverage erase && COVERAGE_FILE=/tmp/pr-feature1-registry.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/pr-feature1-registry.coverage python -m coverage report -m --include=custom_components/enphase_ev/sensor_registry.py --fail-under=100"
```

Post-rebase full suite: 3,485 passed. All touched Python modules were verified at 100% coverage; the final registry report covered 287/287 statements.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, `docs/`) when behaviour or options changed.
- [x] I verified translations are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results.
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Raw master-data user/activity catalogs and dashboard device/parent IDs are not retained. The telemetry entity is diagnostic and disabled by default.
