### PR TITLE
Harden refresh performance and runtime reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ All notable changes to this project will be documented in this file.
 - Added installer-only, cloud-based Grid Profile Control with country-scoped region and profile selection, explicit apply confirmation, current profile monitoring, and follow-up cloud status refreshes.
 
 ### 🐛 Bug fixes
+- Serialized installer Grid Profile writes, expire unconfirmed pending state after
+  the follow-up window, and move steady metadata refreshes off the coordinator's
+  critical path.
+- Kept partial IQ Gateway firmware progress active when status text includes a
+  percentage followed by “complete”.
+- Paginated System Dashboard events so active high-impact events beyond the first
+  200 rows are included in sensors and Repairs, expose bounded-result truncation,
+  and expire missing prior-day Repairs only after a complete six-hour grace period.
 - Prevented multi-megawatt site power spikes during startup by reseeding derived
   power baselines when lifetime-flow sources change, normalizing live-power
   units, and requiring a newer comparable sample before publishing extreme
@@ -45,14 +53,26 @@ All notable changes to this project will be documented in this file.
   falls back to outage-context fields such as `show_grid_connect` only when the
   live relay state is unavailable.
 - Fixed config-entry unload and entity removal leaving delayed backoff, schedule,
-  battery-profile recovery, or firmware refresh work running against retired
-  integration objects.
+  battery-profile recovery, discovery persistence, or firmware refresh work running
+  against retired integration objects, and await task cancellation before closing
+  the API client.
+- Track scheduled refresh, startup, weather discovery, switch failure recovery,
+  reauthentication setup, and EVSE auto-resume work through unload, and bound
+  cancellation waits so a stuck task cannot block config-entry shutdown.
+- Shared firmware version history across config entries so concurrent delayed saves
+  cannot overwrite another site's transitions.
 - Fixed optional or concurrent cloud reads deadlocking credential refresh while
   the initiating request still held the shared Enlighten read limiter.
 - Preserved pending discovery snapshots when a storage write is cancelled so a
   later refresh can retry persistence instead of losing the observed revision.
 
 ### 🔧 Improvements
+- Run bulk microinverter parameter requests serially within an explicit operation
+  deadline so shared optional-read queueing cannot consume every request timeout.
+- Isolated the startup Grid Profile probe behind the optional-read limiter and the
+  same aggregate queue-and-request deadline used by steady metadata refreshes.
+- Persist hourly system-event Repair last-seen checkpoints so integration reloads
+  cannot restart the missing-event grace period.
 - Bound optional Enlighten request queueing and startup warmup stages, reserve
   cloud-read capacity for core status traffic, and retain the last current-power
   sample with retry backoff when that optional endpoint is unavailable.

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1667,11 +1667,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
         entry_create_background = getattr(entry, "async_create_background_task", None)
         hass_create_background = getattr(hass, "async_create_background_task", None)
         if callable(entry_create_background):
-            entry_create_background(hass, coro, name)
+            task = entry_create_background(hass, coro, name)
         elif callable(hass_create_background):
-            hass_create_background(coro, name)
+            task = hass_create_background(coro, name)
         else:
-            hass.async_create_task(coro, name=name)
+            task = hass.async_create_task(coro, name=name)
+        track_background_task = getattr(coord, "track_entry_background_task", None)
+        if callable(track_background_task):
+            track_background_task(task)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _prune_inactive_serial_entities(hass, entry, coord, site_id)
@@ -1679,11 +1682,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
 
     # Start background work only after entities have been forwarded so restored
     # topology can create entities first and warmup can fill in live state later.
-    grid_profile_runtime = getattr(coord, "grid_profile_runtime", None)
-    grid_profile_refresh = getattr(grid_profile_runtime, "async_refresh", None)
-    if callable(grid_profile_refresh):
+    grid_profile_startup_probe = getattr(
+        coord, "async_refresh_grid_profile_metadata", None
+    )
+    if callable(grid_profile_startup_probe):
         _schedule_background_task(
-            grid_profile_refresh(force=True, load_profiles=False),
+            grid_profile_startup_probe(force=True),
             f"{DOMAIN}_grid_profile_startup_probe",
         )
 
@@ -1715,7 +1719,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> 
     if unload_ok:
         if coord is not None and hasattr(coord, "schedule_sync"):
             await coord.schedule_sync.async_stop()
-        if coord is not None and hasattr(coord, "cleanup_runtime_state"):
+        async_cleanup_runtime_state = getattr(
+            coord, "async_cleanup_runtime_state", None
+        )
+        if callable(async_cleanup_runtime_state):
+            await async_cleanup_runtime_state()
+        elif coord is not None and hasattr(coord, "cleanup_runtime_state"):
             coord.cleanup_runtime_state()
         if coord is not None and hasattr(coord, "async_close"):
             await coord.async_close()

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -7697,6 +7697,7 @@ class EnphaseEVClient:
         }
         merged: JsonDict | None = None
         merged_events: list[object] = []
+        last_page_full = False
         for page in range(1, _SYSTEM_EVENTS_MAX_PAGES + 1):
             url = str(base_url.update_query({**query, "page": str(page)}))
             try:
@@ -7721,13 +7722,14 @@ class EnphaseEVClient:
                     if key not in merged and key in data:
                         merged[key] = data[key]
             merged_events.extend(events)
-            if len(events) < _SYSTEM_EVENTS_PAGE_SIZE:
+            last_page_full = len(events) >= _SYSTEM_EVENTS_PAGE_SIZE
+            if not last_page_full:
                 break
         if merged is None:  # pragma: no cover - loop always executes
             return None
         merged["events"] = merged_events
         merged["_enphase_ev_truncated"] = (
-            page == _SYSTEM_EVENTS_MAX_PAGES and len(events) >= _SYSTEM_EVENTS_PAGE_SIZE
+            page == _SYSTEM_EVENTS_MAX_PAGES and last_page_full
         )
         return merged
 

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -76,6 +76,8 @@ _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH = "cookie_eauth_compatible"
 _BATTERY_CONFIG_VARIANT_MIXED = "mixed_auth_compatible"
 _ENLIGHTEN_READ_CONCURRENCY_LIMIT = 2
 _ENLIGHTEN_OPTIONAL_READ_CONCURRENCY_LIMIT = 1
+_SYSTEM_EVENTS_PAGE_SIZE = 200
+_SYSTEM_EVENTS_MAX_PAGES = 10
 _LIVE_STATUS_GRID_RELAY_ENUM = {
     0: "OPER_RELAY_UNKNOWN",
     1: "OPER_RELAY_OPEN",
@@ -7677,37 +7679,57 @@ class EnphaseEVClient:
         GET /service/system_dashboard/api_internal/cs/sites/<site_id>/events
         """
 
-        url = str(
-            URL(
-                f"{BASE_URL}/service/system_dashboard/api_internal/cs/sites/"
-                f"{self._site}/events"
-            ).update_query(
-                {
-                    "range": "today",
-                    "cassandra_toggle": "false",
-                    "filter_columns": (
-                        "serial_number,device_type,event_date,cleared_date,"
-                        "event_type,event_state,details,updated_at,alarm_id"
-                    ),
-                    "serial_numbers": "",
-                    "type": "table",
-                    "event_state": "default",
-                    "page": "1",
-                    "per_page": "200",
-                }
-            )
+        base_url = URL(
+            f"{BASE_URL}/service/system_dashboard/api_internal/cs/sites/"
+            f"{self._site}/events"
         )
-        try:
-            data = await self._json(
-                "GET",
-                url,
-                headers=self._system_dashboard_headers(),
-            )
-        except Exception as err:  # noqa: BLE001
-            if self._system_dashboard_is_optional_error(err):
+        query = {
+            "range": "today",
+            "cassandra_toggle": "false",
+            "filter_columns": (
+                "serial_number,device_type,event_date,cleared_date,"
+                "event_type,event_state,details,updated_at,alarm_id"
+            ),
+            "serial_numbers": "",
+            "type": "table",
+            "event_state": "default",
+            "per_page": str(_SYSTEM_EVENTS_PAGE_SIZE),
+        }
+        merged: JsonDict | None = None
+        merged_events: list[object] = []
+        for page in range(1, _SYSTEM_EVENTS_MAX_PAGES + 1):
+            url = str(base_url.update_query({**query, "page": str(page)}))
+            try:
+                data = await self._json(
+                    "GET",
+                    url,
+                    headers=self._system_dashboard_headers(),
+                )
+            except Exception as err:  # noqa: BLE001
+                if self._system_dashboard_is_optional_error(err):
+                    return None
+                raise
+            if not isinstance(data, dict):
                 return None
-            raise
-        return data if isinstance(data, dict) else None
+            events = data.get("events")
+            if not isinstance(events, list):
+                return None
+            if merged is None:
+                merged = dict(data)
+            else:
+                for key in ("event_types", "event_states", "event_severities"):
+                    if key not in merged and key in data:
+                        merged[key] = data[key]
+            merged_events.extend(events)
+            if len(events) < _SYSTEM_EVENTS_PAGE_SIZE:
+                break
+        if merged is None:  # pragma: no cover - loop always executes
+            return None
+        merged["events"] = merged_events
+        merged["_enphase_ev_truncated"] = (
+            page == _SYSTEM_EVENTS_MAX_PAGES and len(events) >= _SYSTEM_EVENTS_PAGE_SIZE
+        )
+        return merged
 
     async def devices_details(self, type_key: str) -> JsonDict | None:
         """Return system dashboard per-type device details when available.

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1711,14 +1711,14 @@ class EnphaseCoordinator(
             keep_day_keys=keep_day_keys,
         )
 
-    def cleanup_runtime_state(self) -> tuple[asyncio.Future[object], ...]:
+    def cleanup_runtime_state(self) -> tuple[asyncio.Future[Any], ...]:
         """Cancel runtime work and release caches/listeners.
 
         Return cancelled asyncio tasks so the async unload path can wait for
         their cancellation handlers to finish before closing the client.
         """
 
-        cancelled_tasks: list[asyncio.Future[object]] = []
+        cancelled_tasks: list[asyncio.Future[Any]] = []
 
         def _task_done(task: object) -> bool:
             done = getattr(task, "done", None)

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -50,6 +50,7 @@ from .api import (
     InvalidPayloadError,
     OptionalEndpointUnavailable,
     Unauthorized,
+    enlighten_optional_read_scope,
     is_scheduler_unavailable_error,
 )
 from .auth_refresh_runtime import AuthRefreshRuntime, ManualAuthRefreshResult
@@ -223,6 +224,8 @@ SESSION_HISTORY_ACTIVE_SOFT_TTL_S = 120.0
 SESSION_HISTORY_RECENT_STOP_SOFT_TTL_S = 300.0
 SESSION_HISTORY_IDLE_HARD_TTL_GRACE_S = 300.0
 SESSION_HISTORY_RECENT_STOP_WINDOW_S = 600.0
+GRID_PROFILE_METADATA_REFRESH_DEADLINE_S = 15.0
+RUNTIME_CLEANUP_TIMEOUT_S = 10.0
 BATTERY_GRID_MODE_PERMISSIONS = {
     "importexport": (True, True),
     "importonly": (True, False),
@@ -523,6 +526,10 @@ class EnphaseCoordinator(
     last_failure_description: str | None
     _phase_timings: dict[str, float]
     _warmup_task: asyncio.Task[None] | None
+    _grid_profile_metadata_task: asyncio.Task[None] | None
+    _grid_profile_metadata_refresh_lock: asyncio.Lock
+    _entry_background_tasks: set[asyncio.Future[Any]]
+    _auto_resume_tasks: dict[str, asyncio.Future[None]]
     _battery_profile_recovery_restore_task: asyncio.Task[None] | None
     _streaming_stop_task: asyncio.Task[None] | None
     _auth_refresh_task: asyncio.Task[bool] | None
@@ -683,6 +690,7 @@ class EnphaseCoordinator(
                 default=DEFAULT_API_TIMEOUT,
             )
         timeout = min(MAX_API_TIMEOUT, max(MIN_API_TIMEOUT, timeout))
+        self._entry_background_tasks = set()
         self.client = EnphaseEVClient(
             async_get_clientsession(hass),
             self.site_id,
@@ -697,11 +705,12 @@ class EnphaseCoordinator(
             if inspect.isawaitable(result):
                 callback_coro = cast(Coroutine[Any, Any, object], result)
                 try:
-                    self.hass.async_create_task(
+                    task = self.hass.async_create_task(
                         callback_coro, name=f"{DOMAIN}_set_reauth_callback"
                     )
                 except TypeError:
-                    self.hass.async_create_task(callback_coro)
+                    task = self.hass.async_create_task(callback_coro)
+                self.track_entry_background_task(task)
         from .schedule_sync import ScheduleSync
 
         self.schedule_sync = ScheduleSync(hass, self, config_entry)
@@ -733,6 +742,9 @@ class EnphaseCoordinator(
             ),
         )
         self._refresh_lock = asyncio.Lock()
+        self._grid_profile_metadata_task = None
+        self._grid_profile_metadata_refresh_lock = asyncio.Lock()
+        self._auto_resume_tasks = {}
         self._auth_refresh_suspended_until_utc = auth_refresh_suspended_until
         self._auth_blocked_until_utc = auth_blocked_until
         self._auth_block_reason = auth_block_reason
@@ -1699,45 +1711,87 @@ class EnphaseCoordinator(
             keep_day_keys=keep_day_keys,
         )
 
-    def cleanup_runtime_state(self) -> None:
-        """Release runtime caches/listeners to make unload deterministic."""
+    def cleanup_runtime_state(self) -> tuple[asyncio.Future[object], ...]:
+        """Cancel runtime work and release caches/listeners.
+
+        Return cancelled asyncio tasks so the async unload path can wait for
+        their cancellation handlers to finish before closing the client.
+        """
+
+        cancelled_tasks: list[asyncio.Future[object]] = []
 
         def _task_done(task: object) -> bool:
             done = getattr(task, "done", None)
             return callable(done) and done() is True
 
         if self._warmup_task is not None:
-            self._warmup_task.cancel()
+            if not _task_done(self._warmup_task):
+                self._warmup_task.cancel()
+                cancelled_tasks.append(self._warmup_task)
             self._warmup_task = None
+        entry_background_tasks = getattr(self, "_entry_background_tasks", None)
+        for task in tuple(entry_background_tasks or ()):
+            if not _task_done(task):
+                task.cancel()
+                cancelled_tasks.append(task)
+        if entry_background_tasks is not None:
+            entry_background_tasks.clear()
+        grid_profile_metadata_task = getattr(self, "_grid_profile_metadata_task", None)
+        if grid_profile_metadata_task is not None:
+            if not _task_done(grid_profile_metadata_task):
+                grid_profile_metadata_task.cancel()
+                if isinstance(grid_profile_metadata_task, asyncio.Future):
+                    cancelled_tasks.append(grid_profile_metadata_task)
+            self._grid_profile_metadata_task = None
         if self._battery_profile_recovery_restore_task is not None:
             if not _task_done(self._battery_profile_recovery_restore_task):
                 self._battery_profile_recovery_restore_task.cancel()
+                cancelled_tasks.append(self._battery_profile_recovery_restore_task)
             self._battery_profile_recovery_restore_task = None
         for task in list(self._amp_restart_tasks.values()):
             if task is not None and not _task_done(task):
                 task.cancel()
+                if isinstance(task, asyncio.Future):
+                    cancelled_tasks.append(task)
         self._amp_restart_tasks.clear()
+        auto_resume_tasks = getattr(self, "_auto_resume_tasks", None)
+        for task in tuple((auto_resume_tasks or {}).values()):
+            if not _task_done(task):
+                task.cancel()
+                cancelled_tasks.append(task)
+        if auto_resume_tasks is not None:
+            auto_resume_tasks.clear()
         if self._streaming_stop_task is not None:
             if not _task_done(self._streaming_stop_task):
                 self._streaming_stop_task.cancel()
+                cancelled_tasks.append(self._streaming_stop_task)
             self._streaming_stop_task = None
         if self._auth_refresh_task is not None:
             if not _task_done(self._auth_refresh_task):
                 self._auth_refresh_task.cancel()
+                cancelled_tasks.append(self._auth_refresh_task)
             self._auth_refresh_task = None
         self._clear_backoff_timer()
         for task in list(self._backoff_refresh_tasks):
             if not _task_done(task):
                 task.cancel()
+                if isinstance(task, asyncio.Future):
+                    cancelled_tasks.append(task)
         self._backoff_refresh_tasks.clear()
         self._backoff_until = None
         clear_streaming_state = getattr(self, "_clear_streaming_state", None)
         if callable(clear_streaming_state):
             clear_streaming_state()
-        self.discovery_snapshot.cancel_pending_save()
+        snapshot_save_task = self.discovery_snapshot.cancel_pending_save()
+        if isinstance(snapshot_save_task, asyncio.Future):
+            cancelled_tasks.append(snapshot_save_task)
         session_manager = getattr(self, "session_history", None)
         if session_manager is not None and hasattr(session_manager, "clear"):
+            enrichment_tasks = tuple(getattr(session_manager, "_enrichment_tasks", ()))
             session_manager.clear()
+            cancelled_tasks.extend(
+                task for task in enrichment_tasks if isinstance(task, asyncio.Future)
+            )
         grid_profile_runtime = getattr(self, "grid_profile_runtime", None)
         cancel_grid_profile_pending = getattr(
             grid_profile_runtime, "cancel_pending_refresh", None
@@ -1747,6 +1801,32 @@ class EnphaseCoordinator(
         self._session_history_cache_shim.clear()
         self._prune_runtime_caches(active_serials=(), keep_day_keys=())
         self._topology_listeners.clear()
+        return tuple(cancelled_tasks)
+
+    async def async_cleanup_runtime_state(self) -> None:
+        """Cancel and await entry-owned runtime work before client shutdown."""
+
+        cancelled_tasks = self.cleanup_runtime_state()
+        if cancelled_tasks:
+            done, pending = await asyncio.wait(
+                cancelled_tasks,
+                timeout=RUNTIME_CLEANUP_TIMEOUT_S,
+            )
+            if done:
+                await asyncio.gather(*done, return_exceptions=True)
+            if pending:
+                _LOGGER.warning(
+                    "Timed out waiting for %s Enphase runtime task(s) to stop",
+                    len(pending),
+                )
+
+    def track_entry_background_task(self, task: object) -> None:
+        """Track config-entry background work for pre-client-close cancellation."""
+
+        if not isinstance(task, asyncio.Future) or task.done():
+            return
+        self._entry_background_tasks.add(task)
+        task.add_done_callback(self._entry_background_tasks.discard)
 
     @_typed_callback
     def async_add_topology_listener(
@@ -2946,7 +3026,7 @@ class EnphaseCoordinator(
         self._sync_battery_profile_pending_issue()
         self.last_success_utc = dt_util.utcnow()
         self.latency_ms = int((time.monotonic() - context.started_mono) * 1000)
-        await self._async_refresh_grid_profile_metadata(context)
+        self._schedule_grid_profile_metadata_refresh(context)
         self._finish_refresh_pipeline(context)
         return {}
 
@@ -3245,10 +3325,36 @@ class EnphaseCoordinator(
         self._refresh_cached_topology()
         self.discovery_snapshot.schedule_save()
 
-    async def _async_refresh_grid_profile_metadata(
+    async def async_refresh_grid_profile_metadata(self, *, force: bool = False) -> None:
+        """Refresh optional grid-profile status outside the core pipeline."""
+
+        runtime = self.grid_profile_runtime
+        refresh = getattr(runtime, "async_refresh", None)
+        if not callable(refresh):
+            return
+        try:
+            async with asyncio.timeout(GRID_PROFILE_METADATA_REFRESH_DEADLINE_S):
+                async with self._grid_profile_metadata_refresh_lock:
+                    with request_metrics_scope("grid_profile_metadata"):
+                        with enlighten_optional_read_scope():
+                            await refresh(force=force, load_profiles=False)
+        except TimeoutError:
+            _LOGGER.debug(
+                "Stopped optional grid-profile metadata refresh for site %s after %.1f seconds",
+                redact_site_id(self.site_id),
+                GRID_PROFILE_METADATA_REFRESH_DEADLINE_S,
+            )
+
+    def _clear_grid_profile_metadata_task(self, task: asyncio.Task[None]) -> None:
+        """Clear the completed background grid-profile refresh task."""
+
+        if self._grid_profile_metadata_task is task:
+            self._grid_profile_metadata_task = None
+
+    def _schedule_grid_profile_metadata_refresh(
         self, context: RefreshPipelineContext
     ) -> None:
-        """Refresh optional grid-profile status during steady coordinator polls."""
+        """Schedule optional grid-profile status without delaying core state."""
 
         if context.first_refresh:
             return
@@ -3258,12 +3364,15 @@ class EnphaseCoordinator(
             SUPPORT_DENIED,
         }:
             return
-        refresh = getattr(runtime, "async_refresh", None)
-        if not callable(refresh):
+        task = self._grid_profile_metadata_task
+        if task is not None and not task.done():
             return
-        started = time.monotonic()
-        await refresh(force=False, load_profiles=False)
-        context.phase_timings["grid_profile_s"] = round(time.monotonic() - started, 3)
+        task = self.hass.async_create_task(
+            self.async_refresh_grid_profile_metadata(),
+            name=f"{DOMAIN}_grid_profile_metadata_refresh",
+        )
+        self._grid_profile_metadata_task = task
+        task.add_done_callback(self._clear_grid_profile_metadata_task)
 
     async def _async_update_data(self) -> dict[str, dict[str, object]]:
         with request_metrics_scope("core_refresh") as request_metrics:
@@ -4620,7 +4729,7 @@ class EnphaseCoordinator(
         )
         self._apply_refresh_polling_interval(polling_state)
 
-        await self._async_refresh_grid_profile_metadata(context)
+        self._schedule_grid_profile_metadata_refresh(context)
         self._finish_refresh_pipeline(context)
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(

--- a/custom_components/enphase_ev/discovery_snapshot.py
+++ b/custom_components/enphase_ev/discovery_snapshot.py
@@ -223,6 +223,7 @@ class DiscoverySnapshotManager:
         self._pending_signature: str | None = None
         self._pending_revision: int | None = None
         self._save_in_progress = False
+        self._save_task: asyncio.Task[None] | None = None
 
     def _snapshot_signature(self, snapshot: object) -> str:
         compatible = _snapshot_compatible_value(snapshot)
@@ -663,18 +664,34 @@ class DiscoverySnapshotManager:
             self.coordinator._discovery_snapshot_save_cancel = None
             if not self.coordinator._discovery_snapshot_pending:
                 return
-            self.coordinator.hass.async_create_task(
+            task = self.coordinator.hass.async_create_task(
                 self.async_save(), name=f"{DOMAIN}_discovery_snapshot_save"
             )
+            self._save_task = task
+            task.add_done_callback(self._clear_save_task)
 
         self.coordinator._discovery_snapshot_save_cancel = async_call_later(
             self.coordinator.hass, DISCOVERY_SNAPSHOT_SAVE_DELAY_S, _run
         )
 
-    def cancel_pending_save(self) -> None:
+    def _clear_save_task(self, task: asyncio.Task[None]) -> None:
+        """Clear a completed snapshot save task."""
+
+        if self._save_task is task:
+            self._save_task = None
+
+    def cancel_pending_save(self) -> asyncio.Task[None] | None:
+        """Cancel delayed and in-flight snapshot persistence."""
+
         if self.coordinator._discovery_snapshot_save_cancel is not None:
             self.coordinator._discovery_snapshot_save_cancel()
             self.coordinator._discovery_snapshot_save_cancel = None
+        task = self._save_task
+        if task is not None and not task.done():
+            task.cancel()
+            return task
+        self._save_task = None
+        return None
 
     def sync_site_energy_discovery_state(self) -> None:
         energy = getattr(self.coordinator, "energy", None)

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -424,6 +424,16 @@ class EvseRuntime:
                 key_sn = str(key).strip()
                 if key_sn not in keep_serials:
                     cache.pop(key, None)
+        auto_resume_tasks = getattr(coord, "_auto_resume_tasks", {})
+        if isinstance(auto_resume_tasks, dict):
+            for key in list(auto_resume_tasks):
+                if str(key).strip() in keep_serials:
+                    continue
+                task = auto_resume_tasks[key]
+                if task is None or task.done():
+                    auto_resume_tasks.pop(key, None)
+                    continue
+                task.cancel()
         return keep_serials
 
     def prune_runtime_caches(
@@ -489,13 +499,31 @@ class EvseRuntime:
                 status_norm or "unknown",
             )
             snapshot = dict(info)
-            task_name = f"enphase_ev_auto_resume_{sn_str}"
+            auto_resume_tasks = getattr(coord, "_auto_resume_tasks", None)
+            if not isinstance(auto_resume_tasks, dict):
+                auto_resume_tasks = {}
+                coord._auto_resume_tasks = auto_resume_tasks
+            existing_task = auto_resume_tasks.get(sn_str)
+            if existing_task is not None and not existing_task.done():
+                continue
+            task_name = f"enphase_ev_auto_resume_{redact_identifier(sn_str)}"
             try:
-                coord.hass.async_create_task(
+                task = coord.hass.async_create_task(
                     self.async_auto_resume(sn_str, snapshot), name=task_name
                 )
             except TypeError:
-                coord.hass.async_create_task(self.async_auto_resume(sn_str, snapshot))
+                task = coord.hass.async_create_task(
+                    self.async_auto_resume(sn_str, snapshot)
+                )
+            if not isinstance(task, asyncio.Future):
+                continue
+            auto_resume_tasks[sn_str] = task
+
+            def _clear(completed: asyncio.Future[None], serial: str = sn_str) -> None:
+                if auto_resume_tasks.get(serial) is completed:
+                    auto_resume_tasks.pop(serial, None)
+
+            task.add_done_callback(_clear)
 
     async def async_auto_resume(
         self, sn: str, snapshot: dict[str, object] | None = None

--- a/custom_components/enphase_ev/gateway_software_update.py
+++ b/custom_components/enphase_ev/gateway_software_update.py
@@ -49,6 +49,15 @@ _TERMINAL_STATUS_WORDS = (
     "idle",
     "success",
 )
+_NON_PROGRESS_TERMINAL_STATUS_WORDS = (
+    "up to date",
+    "done",
+    "fail",
+    "error",
+    "cancel",
+    "idle",
+    "success",
+)
 _DURATION_PART_RE = re.compile(
     r"(?P<value>\d+(?:\.\d+)?)\s*(?P<unit>days?|d|hours?|hrs?|h|minutes?|mins?|m|seconds?|secs?|s)",
     re.IGNORECASE,
@@ -431,6 +440,11 @@ def _update_in_progress(
     components: list[dict[str, Any]],
     percentage: float | None,
 ) -> bool | None:
+    if percentage is not None and 0 < percentage < 100:
+        status_text = current_status_text.lower() if current_status_text else ""
+        if any(word in status_text for word in _NON_PROGRESS_TERMINAL_STATUS_WORDS):
+            return False
+        return True
     current_state = _classify_status_text(current_status_text)
     if current_state is not None:
         return current_state
@@ -449,8 +463,6 @@ def _update_in_progress(
         return True
     if other_states:
         return False
-    if percentage is not None and 0 < percentage < 100:
-        return True
     if current_status == 0 or percentage == 100:
         return False
     return None

--- a/custom_components/enphase_ev/grid_profile_runtime.py
+++ b/custom_components/enphase_ev/grid_profile_runtime.py
@@ -204,6 +204,7 @@ class GridProfileRuntime:
         self._pending_poll_interval_s = PENDING_PROFILE_POLL_INTERVAL_S
         self._pending_poll_window_s = PENDING_PROFILE_POLL_WINDOW_S
         self._lock = asyncio.Lock()
+        self._apply_lock = asyncio.Lock()
 
     @property
     def installer_access_confirmed(self) -> bool:
@@ -1322,6 +1323,18 @@ class GridProfileRuntime:
         except asyncio.CancelledError:
             raise
         finally:
+            pending_matches = (
+                self.pending_profile_id is not None
+                and _profile_id_for_compare(self.pending_profile_id)
+                == _profile_id_for_compare(profile_id)
+            )
+            if pending_matches and (
+                self.support_state == SUPPORT_DENIED or time.monotonic() >= deadline
+            ):
+                self.pending_profile_id = None
+                self.pending_gateway_serial = None
+                self.pending_started_mono = None
+                self.coordinator.async_update_listeners()
             if self._pending_refresh_task is asyncio.current_task():
                 self._pending_refresh_task = None
 
@@ -1345,6 +1358,22 @@ class GridProfileRuntime:
         )
 
     async def async_apply_grid_profile(
+        self,
+        profile_id: str | None,
+        *,
+        region_code: str | None = None,
+        gateway_serial: str | None = None,
+    ) -> dict[str, object]:
+        """Apply one grid profile while serializing writes for this site."""
+
+        async with self._apply_lock:
+            return await self._async_apply_grid_profile_locked(
+                profile_id,
+                region_code=region_code,
+                gateway_serial=gateway_serial,
+            )
+
+    async def _async_apply_grid_profile_locked(
         self,
         profile_id: str | None,
         *,

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -105,6 +105,7 @@ INVERTER_PARAMETER_ALIASES: dict[str, str] = {
     "firmware": "firmware",
     "sw_version": "firmware",
 }
+INVERTER_PARAMETER_BATCH_DEADLINE_S = 15.0
 
 
 @dataclass(frozen=True)
@@ -3060,9 +3061,11 @@ class InventoryRuntime:
 
             gateway_serials = self._gateway_serials_for_inverter_telemetry()
             if callable(columns_fetcher) and gateway_serials:
-                column_results = await asyncio.gather(
-                    *(columns_fetcher(serial) for serial in gateway_serials),
-                    return_exceptions=True,
+                column_results = await self._async_run_bounded_optional_batch(
+                    [
+                        lambda serial=serial: columns_fetcher(serial)
+                        for serial in gateway_serials
+                    ]
                 )
                 column_names: set[str] = set()
                 for result in column_results:
@@ -3093,12 +3096,13 @@ class InventoryRuntime:
         ):
             return cached_by_serial
 
-        results = await asyncio.gather(
-            *(
-                parameter_fetcher(serials, parameter_id)
+        results = await self._async_run_bounded_optional_batch(
+            [
+                lambda parameter_id=parameter_id: parameter_fetcher(
+                    serials, parameter_id
+                )
                 for parameter_id in parameter_ids
-            ),
-            return_exceptions=True,
+            ]
         )
         valid_payload_count = 0
         first_error: Exception | None = None
@@ -3159,6 +3163,28 @@ class InventoryRuntime:
             first_error or ValueError("Dashboard parameter readings were unavailable"),
         )
         return telemetry_by_serial if valid_payload_count else cached_by_serial
+
+    @staticmethod
+    async def _async_run_bounded_optional_batch(
+        factories: list[Callable[[], Awaitable[object]]],
+        *,
+        deadline_s: float = INVERTER_PARAMETER_BATCH_DEADLINE_S,
+    ) -> list[object]:
+        """Run optional requests serially within one explicit operation budget."""
+
+        deadline = time.monotonic() + max(0.0, deadline_s)
+        results: list[object] = []
+        for index, factory in enumerate(factories):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                results.extend(TimeoutError() for _ in factories[index:])
+                break
+            try:
+                async with asyncio.timeout(remaining):
+                    results.append(await factory())
+            except Exception as err:  # noqa: BLE001 - preserve partial optional data
+                results.append(err)
+        return results
 
     async def _async_refresh_inverters(self) -> None:
         """Refresh inverter metadata/status/production and build serial snapshots."""

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -11,6 +11,7 @@ import time
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from functools import partial
 from typing import TYPE_CHECKING, TypeVar, cast
 from zoneinfo import ZoneInfo
 
@@ -3061,9 +3062,12 @@ class InventoryRuntime:
 
             gateway_serials = self._gateway_serials_for_inverter_telemetry()
             if callable(columns_fetcher) and gateway_serials:
+                typed_columns_fetcher = cast(
+                    Callable[[str], Awaitable[object]], columns_fetcher
+                )
                 column_results = await self._async_run_bounded_optional_batch(
                     [
-                        lambda serial=serial: columns_fetcher(serial)
+                        partial(typed_columns_fetcher, serial)
                         for serial in gateway_serials
                     ]
                 )
@@ -3096,11 +3100,12 @@ class InventoryRuntime:
         ):
             return cached_by_serial
 
+        typed_parameter_fetcher = cast(
+            Callable[[list[str], str], Awaitable[object]], parameter_fetcher
+        )
         results = await self._async_run_bounded_optional_batch(
             [
-                lambda parameter_id=parameter_id: parameter_fetcher(
-                    serials, parameter_id
-                )
+                partial(typed_parameter_fetcher, serials, parameter_id)
                 for parameter_id in parameter_ids
             ]
         )

--- a/custom_components/enphase_ev/schedule_sync.py
+++ b/custom_components/enphase_ev/schedule_sync.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Coroutine, Iterable
 from datetime import datetime, time as dt_time, timedelta
 import inspect
 import json
@@ -63,6 +63,7 @@ SYNC_INTERVAL = timedelta(minutes=5)
 SYNC_REFRESH_CONCURRENCY = 3
 # Scheduler writes often return before reads reflect the new slot state.
 PATCH_REFRESH_DELAY_S = 1.0
+SCHEDULE_SYNC_STOP_TIMEOUT_S = 10.0
 SYNC_CAPTURE_ERRORS = (RuntimeError, TypeError, ValueError, AttributeError)
 
 
@@ -94,6 +95,8 @@ class ScheduleSync:
         self._pending_patch_refresh: set[str] = set()
         self._pending_patch_refresh_cancels: dict[str, Callable[[], None]] = {}
         self._pending_patch_refresh_tasks: dict[str, asyncio.Future[None]] = {}
+        self._refresh_tasks: set[asyncio.Future[None]] = set()
+        self._stopping = False
 
     async def async_start(self) -> None:
         self._disabled_cleanup_done = False
@@ -101,6 +104,8 @@ class ScheduleSync:
             await self._disable_support()
             return
         await self._remove_all_helpers()
+        if self._stopping:
+            return
         self._unsub_interval = async_track_time_interval(
             self.hass, self._handle_interval, SYNC_INTERVAL
         )
@@ -113,6 +118,7 @@ class ScheduleSync:
         await self.async_refresh(reason="startup")
 
     async def async_stop(self) -> None:
+        self._stopping = True
         if self._unsub_interval is not None:
             self._unsub_interval()
             self._unsub_interval = None
@@ -122,13 +128,29 @@ class ScheduleSync:
         for cancel in self._pending_patch_refresh_cancels.values():
             cancel()
         self._pending_patch_refresh_cancels.clear()
-        tasks = tuple(self._pending_patch_refresh_tasks.values())
+        tasks = tuple(
+            {
+                *self._pending_patch_refresh_tasks.values(),
+                *self._refresh_tasks,
+            }
+        )
         for task in tasks:
             task.cancel()
         self._pending_patch_refresh_tasks.clear()
+        self._refresh_tasks.clear()
         self._pending_patch_refresh.clear()
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            done, pending = await asyncio.wait(
+                tasks,
+                timeout=SCHEDULE_SYNC_STOP_TIMEOUT_S,
+            )
+            if done:
+                await asyncio.gather(*done, return_exceptions=True)
+            if pending:
+                _LOGGER.warning(
+                    "Timed out waiting for %s Enphase schedule task(s) to stop",
+                    len(pending),
+                )
 
     def diagnostics(self) -> dict[str, Any]:
         return {
@@ -464,15 +486,33 @@ class ScheduleSync:
 
     @callback
     def _handle_interval(self, *_args: object) -> None:
-        coro = self.async_refresh(reason="interval")
+        self._schedule_refresh_task(
+            self.async_refresh(reason="interval"),
+            f"{DOMAIN}_schedule_interval_refresh",
+            fallback=lambda: self.async_refresh(reason="interval"),
+        )
+
+    def _schedule_refresh_task(
+        self,
+        coro: Coroutine[Any, Any, None],
+        name: str,
+        *,
+        fallback: Callable[[], Coroutine[Any, Any, None]],
+    ) -> None:
+        """Schedule and retain a refresh for deterministic shutdown."""
+
+        if self._stopping:
+            coro.close()
+            return
         try:
-            self.hass.async_create_task(
-                coro,
-                name=f"{DOMAIN}_schedule_interval_refresh",
-            )
+            task = self.hass.async_create_task(coro, name=name)
         except TypeError:
             coro.close()
-            self.hass.async_create_task(self.async_refresh(reason="interval"))
+            task = self.hass.async_create_task(fallback())
+        if not isinstance(task, asyncio.Future):
+            return
+        self._refresh_tasks.add(task)
+        task.add_done_callback(self._refresh_tasks.discard)
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -480,15 +520,11 @@ class ScheduleSync:
             age = dt_util.utcnow() - self._last_sync
             if age < SYNC_INTERVAL:
                 return
-        coro = self._refresh_if_stale()
-        try:
-            self.hass.async_create_task(
-                coro,
-                name=f"{DOMAIN}_schedule_coordinator_refresh",
-            )
-        except TypeError:
-            coro.close()
-            self.hass.async_create_task(self._refresh_if_stale())
+        self._schedule_refresh_task(
+            self._refresh_if_stale(),
+            f"{DOMAIN}_schedule_coordinator_refresh",
+            fallback=self._refresh_if_stale,
+        )
 
     async def _refresh_if_stale(self) -> None:
         if not self._last_sync:

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -1002,9 +1002,14 @@ class ChargingSwitch(EnphaseBaseEntity, RestoreEntity, SwitchEntity):  # type: i
         self._coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
         if self.hass is None:
             return
-        self.hass.async_create_task(
+        task = self.hass.async_create_task(
             self._coord.async_request_refresh(), name=f"{DOMAIN}_switch_failure_refresh"
         )
+        track_background_task = getattr(
+            self._coord, "track_entry_background_task", None
+        )
+        if callable(track_background_task):
+            track_background_task(task)
 
     def _force_write_state(self) -> None:
         if self.hass is None or not self.entity_id:

--- a/custom_components/enphase_ev/system_events.py
+++ b/custom_components/enphase_ev/system_events.py
@@ -6,7 +6,7 @@ import hashlib
 import logging
 from collections import Counter
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers import issue_registry as ir
@@ -23,6 +23,8 @@ _LOGGER = logging.getLogger(__name__)
 
 SYSTEM_EVENTS_ENDPOINT_FAMILY = "system_events"
 SYSTEM_EVENT_REPAIR_PREFIX = "active_system_event_"
+SYSTEM_EVENT_REPAIR_MISSING_GRACE = timedelta(hours=6)
+SYSTEM_EVENT_REPAIR_CHECKPOINT_INTERVAL = timedelta(hours=1)
 _TERMINAL_STATES = frozenset(
     {"clear", "cleared", "close", "closed", "inactive", "normal", "resolved"}
 )
@@ -235,6 +237,9 @@ class SystemEventsRuntime:
         self._last_success_utc: datetime | None = None
         self._reported_issue_ids: set[str] = set()
         self._active_reported_issue_ids: set[str] = set()
+        self._repair_last_seen_utc: dict[str, datetime] = {}
+        self._repair_checkpoint_utc: dict[str, datetime] = {}
+        self._snapshot_truncated = False
 
     @property
     def active_events(self) -> tuple[SystemEvent, ...]:
@@ -281,20 +286,15 @@ class SystemEventsRuntime:
     def _issue_id(self, event: SystemEvent) -> str:
         return f"{SYSTEM_EVENT_REPAIR_PREFIX}{self._entry_suffix()}_{event.fingerprint}"
 
-    def _existing_issue_ids(self, *, active_only: bool = False) -> set[str]:
-        """Return event issue IDs already persisted by Home Assistant."""
+    def _registry_issue_entries(self) -> dict[str, object] | None:
+        """Return persisted event Repair entries for this config entry."""
 
         registry = ir.async_get(self.coordinator.hass)
         issues = getattr(registry, "issues", {})
         if not isinstance(issues, dict):
-            return set(
-                self._active_reported_issue_ids
-                if active_only
-                else self._reported_issue_ids
-            )
+            return None
         entry_prefix = f"{SYSTEM_EVENT_REPAIR_PREFIX}{self._entry_suffix()}_"
-        existing: set[str] = set()
-        known: set[str] = set()
+        entries: dict[str, object] = {}
         for key, entry in issues.items():
             if (
                 not isinstance(key, tuple)
@@ -304,16 +304,56 @@ class SystemEventsRuntime:
                 or not key[1].startswith(entry_prefix)
             ):
                 continue
-            known.add(key[1])
-            if active_only and getattr(entry, "active", True) is not True:
-                continue
-            existing.add(key[1])
+            entries[key[1]] = entry
+        return entries
+
+    def _existing_issue_ids(self, *, active_only: bool = False) -> set[str]:
+        """Return event issue IDs already persisted by Home Assistant."""
+
+        entries = self._registry_issue_entries()
+        if entries is None:
+            return set(
+                self._active_reported_issue_ids
+                if active_only
+                else self._reported_issue_ids
+            )
+        existing = {
+            issue_id
+            for issue_id, entry in entries.items()
+            if not active_only or getattr(entry, "active", True) is True
+        }
         if active_only:
-            return existing | (self._active_reported_issue_ids - known)
+            return existing | (self._active_reported_issue_ids - entries.keys())
         return existing | self._reported_issue_ids
 
-    def _sync_repairs(self, resolved_fingerprints: frozenset[str]) -> None:
-        """Create high-impact repairs and clear only explicitly resolved rows."""
+    def _restore_repair_last_seen(self) -> None:
+        """Restore persisted Repair checkpoints from issue-registry data."""
+
+        entries = self._registry_issue_entries()
+        if not entries:
+            return
+        for issue_id, entry in entries.items():
+            data = getattr(entry, "data", None)
+            if not isinstance(data, dict):
+                continue
+            raw_last_seen = data.get("last_seen_utc")
+            if not isinstance(raw_last_seen, str):
+                continue
+            last_seen = dt_util.parse_datetime(raw_last_seen)
+            if last_seen is None or last_seen.tzinfo is None:
+                continue
+            last_seen = dt_util.as_utc(last_seen)
+            self._repair_last_seen_utc.setdefault(issue_id, last_seen)
+            self._repair_checkpoint_utc.setdefault(issue_id, last_seen)
+
+    def _sync_repairs(
+        self,
+        resolved_fingerprints: frozenset[str],
+        *,
+        observed_at: datetime,
+        authoritative: bool,
+    ) -> None:
+        """Create Repairs and age missing rows only after a complete snapshot."""
 
         active_high_impact = {
             self._issue_id(event): event for event in self._events if event.high_impact
@@ -323,15 +363,34 @@ class SystemEventsRuntime:
             f"{SYSTEM_EVENT_REPAIR_PREFIX}{self._entry_suffix()}_{fingerprint}"
             for fingerprint in resolved_fingerprints
         }
+        self._restore_repair_last_seen()
         existing = self._existing_issue_ids()
         active_existing = self._existing_issue_ids(active_only=True)
-        delete_issue_ids = (existing & resolved_issue_ids) | (
-            (existing & active_issue_ids) - active_high_impact.keys()
+        for issue_id in active_high_impact:
+            self._repair_last_seen_utc[issue_id] = observed_at
+        missing_issue_ids = existing - active_issue_ids - resolved_issue_ids
+        stale_issue_ids: set[str] = set()
+        if authoritative:
+            for issue_id in missing_issue_ids:
+                last_seen = self._repair_last_seen_utc.setdefault(issue_id, observed_at)
+                if observed_at - last_seen >= SYSTEM_EVENT_REPAIR_MISSING_GRACE:
+                    stale_issue_ids.add(issue_id)
+        delete_issue_ids = (
+            (existing & resolved_issue_ids)
+            | ((existing & active_issue_ids) - active_high_impact.keys())
+            | stale_issue_ids
         )
         for issue_id in delete_issue_ids:
             ir.async_delete_issue(self.coordinator.hass, DOMAIN, issue_id)
+            self._repair_last_seen_utc.pop(issue_id, None)
+            self._repair_checkpoint_utc.pop(issue_id, None)
         for issue_id, event in active_high_impact.items():
-            if issue_id in active_existing:
+            checkpoint = self._repair_checkpoint_utc.get(issue_id)
+            if (
+                issue_id in active_existing
+                and checkpoint is not None
+                and observed_at - checkpoint < SYSTEM_EVENT_REPAIR_CHECKPOINT_INTERVAL
+            ):
                 continue
             ir.async_create_issue(
                 self.coordinator.hass,
@@ -351,8 +410,10 @@ class SystemEventsRuntime:
                     "severity": event.severity,
                     "device_type": event.device_type,
                     "event_date": event.event_date,
+                    "last_seen_utc": observed_at.isoformat(),
                 },
             )
+            self._repair_checkpoint_utc[issue_id] = observed_at
         self._reported_issue_ids = (
             existing | set(active_high_impact)
         ) - delete_issue_ids
@@ -373,9 +434,15 @@ class SystemEventsRuntime:
             payload,
             site_id=str(self.coordinator.site_id),
         )
-        self._last_success_utc = dt_util.utcnow()
+        observed_at = dt_util.utcnow()
+        self._snapshot_truncated = payload.get("_enphase_ev_truncated") is True
+        self._last_success_utc = observed_at
         self.coordinator._note_endpoint_family_success(SYSTEM_EVENTS_ENDPOINT_FAMILY)
-        self._sync_repairs(resolved_fingerprints)
+        self._sync_repairs(
+            resolved_fingerprints,
+            observed_at=observed_at,
+            authoritative=not self._snapshot_truncated,
+        )
         _LOGGER.debug(
             "System event summary refreshed for site [site]: active=%s high_impact=%s",
             self.active_count,
@@ -400,4 +467,5 @@ class SystemEventsRuntime:
             "using_cached_data": bool(
                 self.available and health.consecutive_failures > 0
             ),
+            "truncated": self._snapshot_truncated,
         }

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -47,6 +47,7 @@ FIRMWARE_HISTORY_STORAGE_KEY = f"{DOMAIN}_firmware_version_history"
 FIRMWARE_HISTORY_STORAGE_VERSION = 1
 FIRMWARE_HISTORY_MAX_ENTRIES = 10
 FIRMWARE_HISTORY_SAVE_DELAY = 5
+FIRMWARE_HISTORY_MANAGER_DATA_KEY = f"{DOMAIN}_firmware_version_history_manager"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -71,17 +72,21 @@ class FirmwareVersionHistoryStore:
         )
         self._history: dict[str, list[dict[str, str | None]]] = {}
         self._max_entries = max(1, max_entries)
+        self._load_lock = asyncio.Lock()
+        self._loaded = False
 
     async def async_load(self) -> None:
         """Load stored firmware history."""
         stored = await self._store.async_load()
         if not isinstance(stored, dict):
             self._history = {}
+            self._loaded = True
             return
 
         entries_by_id = stored.get("entries")
         if not isinstance(entries_by_id, dict):
             self._history = {}
+            self._loaded = True
             return
 
         history: dict[str, list[dict[str, str | None]]] = {}
@@ -90,6 +95,17 @@ class FirmwareVersionHistoryStore:
             if clean:
                 history[str(unique_id)] = clean
         self._history = history
+        self._loaded = True
+
+    async def async_ensure_loaded(self) -> None:
+        """Load history once across all concurrently setting-up config entries."""
+
+        if self._loaded:
+            return
+        async with self._load_lock:
+            if not self._loaded:
+                await self.async_load()
+                self._loaded = True
 
     def history_for(self, unique_id: str | None) -> list[dict[str, str | None]]:
         """Return a copy of the stored history for an update entity."""
@@ -178,6 +194,19 @@ class FirmwareVersionHistoryStore:
         return clean[-self._max_entries :]
 
 
+async def async_get_firmware_version_history_store(
+    hass: HomeAssistant,
+) -> FirmwareVersionHistoryStore:
+    """Return the Home Assistant-wide firmware history owner."""
+
+    store = hass.data.get(FIRMWARE_HISTORY_MANAGER_DATA_KEY)
+    if not isinstance(store, FirmwareVersionHistoryStore):
+        store = FirmwareVersionHistoryStore(hass)
+        hass.data[FIRMWARE_HISTORY_MANAGER_DATA_KEY] = store
+    await store.async_ensure_loaded()
+    return store
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EnphaseConfigEntry,
@@ -196,8 +225,7 @@ async def async_setup_entry(
             lambda: coord.inventory_view.type_device_serial_number("envoy"),
         )
     )
-    version_history = FirmwareVersionHistoryStore(hass)
-    await version_history.async_load()
+    version_history = await async_get_firmware_version_history_store(hass)
     ent_reg = er.async_get(hass)
 
     entities: list[UpdateEntity] = []

--- a/custom_components/enphase_ev/weather.py
+++ b/custom_components/enphase_ev/weather.py
@@ -288,7 +288,7 @@ async def async_setup_entry(
         main_coordinator.client,
         locale=locale,
     )
-    entry.async_create_background_task(
+    task = entry.async_create_background_task(
         hass,
         _async_discover_weather(
             coordinator,
@@ -297,3 +297,8 @@ async def async_setup_entry(
         ),
         f"{DOMAIN}_weather_discovery",
     )
+    track_background_task = getattr(
+        main_coordinator, "track_entry_background_task", None
+    )
+    if callable(track_background_task):
+        track_background_task(task)

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -8388,7 +8388,10 @@ async def test_system_dashboard_events_uses_observed_query_and_headers() -> None
     )
     client._json = AsyncMock(return_value={"events": []})
 
-    assert await client.system_dashboard_events() == {"events": []}
+    assert await client.system_dashboard_events() == {
+        "events": [],
+        "_enphase_ev_truncated": False,
+    }
 
     args, kwargs = client._json.await_args
     assert args[0] == "GET"
@@ -8412,6 +8415,61 @@ async def test_system_dashboard_events_uses_observed_query_and_headers() -> None
     assert kwargs["headers"]["Authorization"] == "Bearer BEAR"
     assert kwargs["headers"]["e-auth-token"] == "EAUTH"
     assert kwargs["headers"]["X-CSRF-Token"] == "xsrf"
+
+
+@pytest.mark.asyncio
+async def test_system_dashboard_events_paginates_and_merges_catalogs() -> None:
+    client = _make_client()
+    first_page = {"events": [{"id": str(index)} for index in range(200)]}
+    second_page = {
+        "events": [{"id": "last"}],
+        "event_types": [{"id": 1}],
+        "event_states": [{"id": 2}],
+        "event_severities": [{"id": 3}],
+    }
+    client._json = AsyncMock(side_effect=[first_page, second_page])
+
+    result = await client.system_dashboard_events()
+
+    assert result is not None
+    assert len(result["events"]) == 201
+    assert result["events"][-1] == {"id": "last"}
+    assert result["event_types"] == [{"id": 1}]
+    assert result["event_states"] == [{"id": 2}]
+    assert result["event_severities"] == [{"id": 3}]
+    assert result["_enphase_ev_truncated"] is False
+    assert client._json.await_count == 2
+    first_url = URL(client._json.await_args_list[0].args[1])
+    second_url = URL(client._json.await_args_list[1].args[1])
+    assert first_url.query["page"] == "1"
+    assert second_url.query["page"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_system_dashboard_events_pagination_is_bounded() -> None:
+    client = _make_client()
+    full_page = {"events": [{"id": str(index)} for index in range(200)]}
+    client._json = AsyncMock(return_value=full_page)
+
+    result = await client.system_dashboard_events()
+
+    assert result is not None
+    assert len(result["events"]) == 2_000
+    assert result["_enphase_ev_truncated"] is True
+    assert client._json.await_count == 10
+
+
+@pytest.mark.asyncio
+async def test_system_dashboard_events_rejects_invalid_later_page() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=[
+            {"events": [{"id": str(index)} for index in range(200)]},
+            {"events": "invalid"},
+        ]
+    )
+
+    assert await client.system_dashboard_events() is None
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -1272,6 +1272,17 @@ def test_prune_runtime_caches_removes_stale_serial_state(coordinator_factory):
         "EV2": [{"to_connector_status": "SUSPENDED_EVSE"}],
     }
     coord._desired_charging = {"EV1": True, "EV2": False}  # noqa: SLF001
+    keep_auto_resume = MagicMock()
+    keep_auto_resume.done.return_value = False
+    drop_auto_resume = MagicMock()
+    drop_auto_resume.done.return_value = False
+    completed_auto_resume = MagicMock()
+    completed_auto_resume.done.return_value = True
+    coord._auto_resume_tasks = {  # noqa: SLF001
+        "EV1": keep_auto_resume,
+        "EV2": drop_auto_resume,
+        "EV3": completed_auto_resume,
+    }
     coord._session_history_cache_shim = {  # noqa: SLF001
         ("EV1", "2020-01-02"): (1.0, [{"session_id": "keep"}]),
         ("EV2", "2020-01-02"): (1.0, [{"session_id": "drop-serial"}]),
@@ -1294,6 +1305,11 @@ def test_prune_runtime_caches_removes_stale_serial_state(coordinator_factory):
         "EV1": [{"to_connector_status": "CHARGING"}]
     }
     assert coord._desired_charging == {"EV1": True}  # noqa: SLF001
+    assert coord._auto_resume_tasks == {  # noqa: SLF001
+        "EV1": keep_auto_resume,
+        "EV2": drop_auto_resume,
+    }
+    drop_auto_resume.cancel.assert_called_once_with()
     assert coord._session_history_cache_shim == {  # noqa: SLF001
         ("EV1", "2020-01-02"): (1.0, [{"session_id": "keep"}])
     }
@@ -2088,6 +2104,7 @@ def test_sync_desired_charging_schedules_auto_resume(coordinator_factory, monkey
     now = coord_mod.time.monotonic()
     coord._desired_charging = {sn: True}
     coord._auto_resume_attempts = {}
+    del coord._auto_resume_tasks  # noqa: SLF001
     coord.data = {
         sn: {
             "sn": sn,
@@ -2108,9 +2125,48 @@ def test_sync_desired_charging_schedules_auto_resume(coordinator_factory, monkey
 
     assert len(created) == 1
     coro, name = created[0]
-    assert name == f"enphase_ev_auto_resume_{sn}"
+    assert name.startswith("enphase_ev_auto_resume_")
+    assert sn not in name
     coro.close()
     assert coord._auto_resume_attempts[sn] >= now
+
+
+@pytest.mark.asyncio
+async def test_sync_desired_charging_tracks_and_coalesces_auto_resume(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sn = next(iter(coord.serials))
+    coord._desired_charging = {sn: True}
+    coord._auto_resume_attempts = {}
+    coord.data = {
+        sn: {
+            "sn": sn,
+            "charging": False,
+            "plugged": True,
+            "connector_status": coord_mod.SUSPENDED_EVSE_STATUS,
+        }
+    }
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _auto_resume(_sn, _snapshot) -> None:
+        started.set()
+        await release.wait()
+
+    coord.evse_runtime.async_auto_resume = _auto_resume
+    coord._sync_desired_charging(coord.data)
+    await started.wait()
+    task = coord._auto_resume_tasks[sn]  # noqa: SLF001
+
+    coord._auto_resume_attempts.clear()  # noqa: SLF001
+    coord._sync_desired_charging(coord.data)
+    assert coord._auto_resume_tasks[sn] is task  # noqa: SLF001
+
+    release.set()
+    await task
+    await asyncio.sleep(0)
+    assert coord._auto_resume_tasks == {}  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -156,8 +156,11 @@ async def test_coordinator_init_normalizes_serials_and_options(hass, monkeypatch
     entry.add_to_hass(hass)
 
     captured_tasks: list = []
+    scheduled_task = asyncio.get_running_loop().create_future()
     monkeypatch.setattr(
-        hass, "async_create_task", lambda coro: captured_tasks.append(coro)
+        hass,
+        "async_create_task",
+        lambda coro: (captured_tasks.append(coro), scheduled_task)[1],
     )
     monkeypatch.setattr(
         coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
@@ -184,7 +187,11 @@ async def test_coordinator_init_normalizes_serials_and_options(hass, monkeypatch
     assert coord._session_history_interval_min == DEFAULT_SESSION_HISTORY_INTERVAL_MIN
     assert coord._session_history_cache_ttl == DEFAULT_SESSION_HISTORY_INTERVAL_MIN * 60
     assert captured_tasks, "set_reauth_callback coroutine should be scheduled"
+    assert scheduled_task in coord._entry_background_tasks  # noqa: SLF001
     await captured_tasks[0]
+    scheduled_task.set_result(None)
+    await asyncio.sleep(0)
+    assert scheduled_task not in coord._entry_background_tasks  # noqa: SLF001
 
 
 def test_coordinator_init_defaults_session_history_interval_on_helper_failure(
@@ -1878,14 +1885,69 @@ async def test_cleanup_cancels_fired_backoff_refresh(hass, monkeypatch) -> None:
 
     coord._schedule_backoff_timer(1)  # noqa: SLF001
     captured["callback"](dt_util.utcnow())
-    task = next(iter(coord._backoff_refresh_tasks))  # noqa: SLF001
+    grid_profile_task = asyncio.create_task(asyncio.sleep(60))
+    coord._grid_profile_metadata_task = grid_profile_task  # noqa: SLF001
+    amp_restart_task = asyncio.create_task(asyncio.sleep(60))
+    coord._amp_restart_tasks["EV123"] = amp_restart_task  # noqa: SLF001
+    snapshot_save_task = asyncio.create_task(asyncio.sleep(60))
+    coord.discovery_snapshot._save_task = snapshot_save_task  # noqa: SLF001
+    session_enrichment_task = asyncio.create_task(asyncio.sleep(60))
+    coord.session_history._enrichment_tasks.add(session_enrichment_task)  # noqa: SLF001
+    entry_background_task = asyncio.create_task(asyncio.sleep(60))
+    coord.track_entry_background_task(entry_background_task)
+    auto_resume_task = asyncio.create_task(asyncio.sleep(60))
+    coord._auto_resume_tasks["EV123"] = auto_resume_task  # noqa: SLF001
     await started.wait()
 
-    coord.cleanup_runtime_state()
-    await asyncio.gather(task, return_exceptions=True)
+    await coord.async_cleanup_runtime_state()
 
     assert cancelled.is_set()
+    assert grid_profile_task.cancelled()
+    assert amp_restart_task.cancelled()
+    assert snapshot_save_task.cancelled()
+    assert session_enrichment_task.cancelled()
+    assert entry_background_task.cancelled()
+    assert auto_resume_task.cancelled()
+    assert coord._grid_profile_metadata_task is None  # noqa: SLF001
     assert coord._backoff_refresh_tasks == set()  # noqa: SLF001
+    assert coord._entry_background_tasks == set()  # noqa: SLF001
+    assert coord._auto_resume_tasks == {}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_runtime_cleanup_timeout_is_bounded(
+    coordinator_factory, monkeypatch, caplog
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory()
+    task = asyncio.create_task(asyncio.sleep(60))
+    coord.track_entry_background_task(task)
+
+    async def _pending(tasks, *, timeout):
+        assert timeout == coord_mod.RUNTIME_CLEANUP_TIMEOUT_S
+        return set(), set(tasks)
+
+    monkeypatch.setattr(coord_mod.asyncio, "wait", _pending)
+    with caplog.at_level(logging.WARNING):
+        await coord.async_cleanup_runtime_state()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert "Timed out waiting for 1 Enphase runtime task" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_track_entry_background_task_ignores_invalid_or_completed(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    completed = asyncio.get_running_loop().create_future()
+    completed.set_result(None)
+
+    coord.track_entry_background_task(object())
+    coord.track_entry_background_task(completed)
+
+    assert coord._entry_background_tasks == set()  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -4309,10 +4371,13 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
 
     create_calls: list[object] = []
 
+    save_task = MagicMock()
+    save_task.done.return_value = False
+
     def _capture_create_task(coro, *, name=None):
         create_calls.append(coro)
         coro.close()
-        return None
+        return save_task
 
     object.__setattr__(coord.hass, "async_create_task", _capture_create_task)
     scheduled: list = []
@@ -4347,11 +4412,13 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
     coord._discovery_snapshot_pending = True  # noqa: SLF001
     scheduled[0](datetime.now(tz=timezone.utc))
     assert len(create_calls) == 1
+    save_task.add_done_callback.assert_called_once()
     cancelled: list[bool] = []
     coord._discovery_snapshot_save_cancel = lambda: cancelled.append(True)  # type: ignore[assignment]  # noqa: SLF001
-    coord.discovery_snapshot.cancel_pending_save()
+    assert coord.discovery_snapshot.cancel_pending_save() is save_task
     assert cancelled == [True]
     assert coord._discovery_snapshot_save_cancel is None  # noqa: SLF001
+    save_task.cancel.assert_called_once_with()
 
     coord.energy = None  # type: ignore[assignment]
     coord.discovery_snapshot.sync_site_energy_discovery_state()

--- a/tests/components/enphase_ev/test_gateway_software_update.py
+++ b/tests/components/enphase_ev/test_gateway_software_update.py
@@ -282,6 +282,56 @@ def test_normalize_gateway_software_update_prefers_active_component() -> None:
     assert completed_component["in_progress"] is False
 
 
+def test_normalize_gateway_software_update_partial_percentage_overrides_complete() -> (
+    None
+):
+    partial = normalize_gateway_software_update(
+        {
+            "site": {
+                "site_update_info": {
+                    "Current_Status_str": "Installing update - 50% complete"
+                }
+            },
+            "devices": {"update_info": [[{"name": "A", "progress": 50}]]},
+        }
+    )
+    assert partial is not None
+    assert partial["in_progress"] is True
+    assert partial["update_percentage"] == 50
+
+    failed = normalize_gateway_software_update(
+        {
+            "site": {
+                "site_update_info": {
+                    "Current_Status_str": "Installing update failed at 50%"
+                }
+            },
+            "devices": {"update_info": [[{"name": "A", "progress": 50}]]},
+        }
+    )
+    assert failed is not None
+    assert failed["in_progress"] is False
+    assert failed["update_percentage"] is None
+
+    active_text = normalize_gateway_software_update(
+        {
+            "site": {"site_update_info": {"Current_Status_str": "Installing update"}},
+            "devices": [],
+        }
+    )
+    assert active_text is not None
+    assert active_text["in_progress"] is True
+
+    active_device = normalize_gateway_software_update(
+        {
+            "site": {"site_update_info": {"Current_Status": "unknown"}},
+            "devices": {"update_info": ["Gateway updating"]},
+        }
+    )
+    assert active_device is not None
+    assert active_device["in_progress"] is True
+
+
 @pytest.mark.parametrize(
     "payload",
     [

--- a/tests/components/enphase_ev/test_grid_profile_runtime.py
+++ b/tests/components/enphase_ev/test_grid_profile_runtime.py
@@ -570,45 +570,132 @@ async def test_runtime_rejects_catalog_region_outside_site_country() -> None:
 
 async def test_coordinator_refreshes_grid_profile_metadata_after_first_poll() -> None:
     refresh = AsyncMock()
-    coordinator = SimpleNamespace(
-        grid_profile_runtime=SimpleNamespace(
-            async_refresh=refresh,
-            support_state=SUPPORT_CONFIRMED,
-        )
-    )
-    context = SimpleNamespace(first_refresh=True, phase_timings={})
+    created_tasks: list[asyncio.Task[None]] = []
 
-    await EnphaseCoordinator._async_refresh_grid_profile_metadata(  # noqa: SLF001
-        coordinator, context
-    )
+    class _Coordinator:
+        async_refresh_grid_profile_metadata = (
+            EnphaseCoordinator.async_refresh_grid_profile_metadata
+        )
+        _clear_grid_profile_metadata_task = (
+            EnphaseCoordinator._clear_grid_profile_metadata_task
+        )
+        _schedule_grid_profile_metadata_refresh = (
+            EnphaseCoordinator._schedule_grid_profile_metadata_refresh
+        )
+
+        def __init__(self) -> None:
+            self.site_id = "site"
+            self.grid_profile_runtime = SimpleNamespace(
+                async_refresh=refresh,
+                support_state=SUPPORT_CONFIRMED,
+            )
+            self._grid_profile_metadata_task = None
+            self._grid_profile_metadata_refresh_lock = asyncio.Lock()
+            self.hass = SimpleNamespace(async_create_task=self._create_task)
+
+        def _create_task(self, coro, *, name=None):
+            task = asyncio.create_task(coro, name=name)
+            created_tasks.append(task)
+            return task
+
+    coordinator = _Coordinator()
+    first_refresh = SimpleNamespace(first_refresh=True)
+    steady_refresh = SimpleNamespace(first_refresh=False)
+
+    coordinator._schedule_grid_profile_metadata_refresh(first_refresh)
     refresh.assert_not_awaited()
 
-    context.first_refresh = False
-    await EnphaseCoordinator._async_refresh_grid_profile_metadata(  # noqa: SLF001
-        coordinator, context
-    )
+    coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
+    task = coordinator._grid_profile_metadata_task
+    assert task is not None
+    coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
+    assert len(created_tasks) == 1
+    await task
 
     refresh.assert_awaited_once_with(force=False, load_profiles=False)
-    assert "grid_profile_s" in context.phase_timings
+    assert coordinator._grid_profile_metadata_task is None
 
     refresh.reset_mock()
-    coordinator.grid_profile_runtime.support_state = "unknown"
-    await EnphaseCoordinator._async_refresh_grid_profile_metadata(  # noqa: SLF001
-        coordinator, context
-    )
-    refresh.assert_not_awaited()
-
+    coordinator.grid_profile_runtime.support_state = SUPPORT_UNKNOWN
+    coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
     coordinator.grid_profile_runtime.support_state = SUPPORT_DENIED
-    await EnphaseCoordinator._async_refresh_grid_profile_metadata(  # noqa: SLF001
-        coordinator, context
-    )
+    coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
     refresh.assert_not_awaited()
 
     coordinator.grid_profile_runtime.support_state = SUPPORT_CONFIRMED
     coordinator.grid_profile_runtime.async_refresh = None
-    await EnphaseCoordinator._async_refresh_grid_profile_metadata(  # noqa: SLF001
-        coordinator, context
+    await coordinator.async_refresh_grid_profile_metadata()
+
+
+async def test_coordinator_grid_profile_metadata_refresh_has_deadline() -> None:
+    async def _never_finishes(**_kwargs) -> None:
+        await asyncio.sleep(60)
+
+    coordinator = SimpleNamespace(
+        site_id="site",
+        grid_profile_runtime=SimpleNamespace(async_refresh=_never_finishes),
+        _grid_profile_metadata_refresh_lock=asyncio.Lock(),
     )
+    with patch(
+        "custom_components.enphase_ev.coordinator.GRID_PROFILE_METADATA_REFRESH_DEADLINE_S",
+        0,
+    ):
+        await EnphaseCoordinator.async_refresh_grid_profile_metadata(
+            coordinator, force=True
+        )
+
+
+async def test_coordinator_grid_profile_deadline_includes_lock_wait() -> None:
+    refresh = AsyncMock()
+    lock = asyncio.Lock()
+    await lock.acquire()
+    coordinator = SimpleNamespace(
+        site_id="site",
+        grid_profile_runtime=SimpleNamespace(async_refresh=refresh),
+        _grid_profile_metadata_refresh_lock=lock,
+    )
+    with patch(
+        "custom_components.enphase_ev.coordinator.GRID_PROFILE_METADATA_REFRESH_DEADLINE_S",
+        0,
+    ):
+        await EnphaseCoordinator.async_refresh_grid_profile_metadata(coordinator)
+    lock.release()
+
+    refresh.assert_not_awaited()
+
+
+async def test_coordinator_serializes_startup_and_steady_grid_profile_refreshes() -> (
+    None
+):
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    calls: list[bool] = []
+
+    async def _refresh(*, force: bool, load_profiles: bool) -> None:
+        assert load_profiles is False
+        calls.append(force)
+        if force:
+            first_started.set()
+            await release_first.wait()
+
+    coordinator = SimpleNamespace(
+        site_id="site",
+        grid_profile_runtime=SimpleNamespace(async_refresh=_refresh),
+        _grid_profile_metadata_refresh_lock=asyncio.Lock(),
+    )
+    startup = asyncio.create_task(
+        EnphaseCoordinator.async_refresh_grid_profile_metadata(coordinator, force=True)
+    )
+    await first_started.wait()
+    steady = asyncio.create_task(
+        EnphaseCoordinator.async_refresh_grid_profile_metadata(coordinator)
+    )
+    await asyncio.sleep(0)
+    assert calls == [True]
+
+    release_first.set()
+    await asyncio.gather(startup, steady)
+    assert calls == [True, False]
 
 
 async def test_runtime_apply_rejects_profile_cached_for_another_region() -> None:
@@ -1282,6 +1369,61 @@ async def test_runtime_starts_and_cancels_pending_refresh_task() -> None:
 
     assert runtime._pending_refresh_task is None  # noqa: SLF001
     assert task.cancelled()
+
+
+async def test_runtime_serializes_grid_profile_writes() -> None:
+    client = _FakeGridProfileClient()
+    runtime = GridProfileRuntime(_FakeCoordinator(client))
+    await runtime.async_refresh(force=True)
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    active_writes = 0
+    max_active_writes = 0
+    write_count = 0
+
+    async def _apply(**_kwargs) -> dict[str, object]:
+        nonlocal active_writes, max_active_writes, write_count
+        write_count += 1
+        active_writes += 1
+        max_active_writes = max(max_active_writes, active_writes)
+        if write_count == 1:
+            first_started.set()
+            await release_first.wait()
+        active_writes -= 1
+        return {}
+
+    client.async_apply_grid_profile = _apply  # type: ignore[method-assign]
+    first = asyncio.create_task(runtime.async_apply_grid_profile("agf:common"))
+    await first_started.wait()
+    second = asyncio.create_task(runtime.async_apply_grid_profile("agf:common"))
+    await asyncio.sleep(0)
+
+    assert write_count == 1
+    release_first.set()
+    await asyncio.gather(first, second)
+
+    assert write_count == 2
+    assert max_active_writes == 1
+
+
+async def test_runtime_expires_unconfirmed_pending_profile() -> None:
+    coordinator = _FakeCoordinator(_FakeGridProfileClient())
+    runtime = GridProfileRuntime(coordinator)
+    runtime.support_state = SUPPORT_CONFIRMED
+    runtime.pending_profile_id = "agf:pending"
+    runtime.pending_gateway_serial = "gateway"
+    runtime.pending_started_mono = 1.0
+    runtime._pending_poll_window_s = 0  # noqa: SLF001
+    runtime._pending_refresh_task = asyncio.current_task()  # noqa: SLF001
+
+    await runtime._async_poll_pending_profile("agf:pending")  # noqa: SLF001
+
+    assert runtime.pending_profile_id is None
+    assert runtime.pending_gateway_serial is None
+    assert runtime.pending_started_mono is None
+    assert runtime._pending_refresh_task is None  # noqa: SLF001
+    assert coordinator.listener_updates == 1
 
 
 async def test_runtime_accepts_false_ensemble_envoy_metadata() -> None:

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -649,7 +649,8 @@ async def test_async_setup_entry_uses_background_task_for_schedule_sync_start(
         def __init__(self) -> None:
             self.site_id = site_id
             self.schedule_sync = SimpleNamespace(async_start=AsyncMock())
-            self.grid_profile_runtime = SimpleNamespace(async_refresh=AsyncMock())
+            self.async_refresh_grid_profile_metadata = AsyncMock()
+            self.track_entry_background_task = MagicMock()
 
         async def async_config_entry_first_refresh(self) -> None:
             return None
@@ -669,12 +670,16 @@ async def test_async_setup_entry_uses_background_task_for_schedule_sync_start(
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
 
     background_calls: list[tuple[HomeAssistant, str, bool]] = []
+    background_tasks: list[object] = []
 
     def _capture_background_task(
         hass_arg: HomeAssistant, target, name: str, eager_start: bool = True
-    ) -> None:
+    ) -> object:
         background_calls.append((hass_arg, name, eager_start))
         target.close()
+        task = object()
+        background_tasks.append(task)
+        return task
 
     monkeypatch.setattr(
         config_entry, "async_create_background_task", _capture_background_task
@@ -686,12 +691,12 @@ async def test_async_setup_entry_uses_background_task_for_schedule_sync_start(
         (hass, "enphase_ev_grid_profile_startup_probe", True),
         (hass, "enphase_ev_schedule_sync_start", True),
     ]
-    dummy_coord.grid_profile_runtime.async_refresh.assert_called_once_with(
-        force=True,
-        load_profiles=False,
-    )
-    dummy_coord.grid_profile_runtime.async_refresh.assert_not_awaited()
+    dummy_coord.async_refresh_grid_profile_metadata.assert_called_once_with(force=True)
+    dummy_coord.async_refresh_grid_profile_metadata.assert_not_awaited()
     dummy_coord.schedule_sync.async_start.assert_not_awaited()
+    assert [
+        call(task) for task in background_tasks
+    ] == dummy_coord.track_entry_background_task.call_args_list
     forward.assert_awaited_once()
 
 
@@ -1591,7 +1596,7 @@ async def test_async_unload_entry_stops_schedule_sync(
     schedule_sync = SimpleNamespace(async_stop=AsyncMock())
     coord = SimpleNamespace(
         schedule_sync=schedule_sync,
-        cleanup_runtime_state=MagicMock(),
+        async_cleanup_runtime_state=AsyncMock(),
         async_close=AsyncMock(),
     )
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
@@ -1601,7 +1606,7 @@ async def test_async_unload_entry_stops_schedule_sync(
 
     assert await async_unload_entry(hass, config_entry)
     schedule_sync.async_stop.assert_awaited_once()
-    coord.cleanup_runtime_state.assert_called_once()
+    coord.async_cleanup_runtime_state.assert_awaited_once()
     coord.async_close.assert_awaited_once()
     assert unload.await_count == len(PLATFORMS)
     assert config_entry.runtime_data is None

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -1381,6 +1381,46 @@ async def test_inventory_runtime_bulk_parameter_telemetry(coordinator_factory) -
 
 
 @pytest.mark.asyncio
+async def test_inventory_runtime_optional_batch_is_serial_and_bounded(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory().inventory_runtime
+    active = 0
+    max_active = 0
+    order: list[str] = []
+
+    async def _request(label: str) -> str:
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        order.append(label)
+        await asyncio.sleep(0)
+        active -= 1
+        return label
+
+    results = await runtime._async_run_bounded_optional_batch(  # noqa: SLF001
+        [lambda: _request("first"), lambda: _request("second")]
+    )
+
+    assert results == ["first", "second"]
+    assert order == ["first", "second"]
+    assert max_active == 1
+
+    bounded = await runtime._async_run_bounded_optional_batch(  # noqa: SLF001
+        [lambda: _request("too-late")],
+        deadline_s=0.0,
+    )
+
+    assert isinstance(bounded[0], TimeoutError)
+
+    async def _failed() -> object:
+        raise RuntimeError("failed")
+
+    failed = await runtime._async_run_bounded_optional_batch([_failed])  # noqa: SLF001
+    assert isinstance(failed[0], RuntimeError)
+
+
+@pytest.mark.asyncio
 async def test_inventory_runtime_empty_parameter_rows_clear_cached_value(
     coordinator_factory, monkeypatch
 ) -> None:

--- a/tests/components/enphase_ev/test_schedule_sync.py
+++ b/tests/components/enphase_ev/test_schedule_sync.py
@@ -1997,6 +1997,95 @@ async def test_schedule_sync_stop_cancels_fired_post_patch_refresh(
 
 
 @pytest.mark.asyncio
+async def test_schedule_sync_stop_cancels_all_regular_refresh_tasks(hass) -> None:
+    sync = ScheduleSync(hass, SimpleNamespace(), None)
+    interval_started = asyncio.Event()
+    coordinator_started = asyncio.Event()
+
+    async def _interval_refresh(*, reason, serials=None) -> None:  # noqa: ARG001
+        assert reason == "interval"
+        interval_started.set()
+        await asyncio.Event().wait()
+
+    async def _coordinator_refresh() -> None:
+        coordinator_started.set()
+        await asyncio.Event().wait()
+
+    sync.async_refresh = _interval_refresh
+    sync._refresh_if_stale = _coordinator_refresh
+    sync._handle_interval()
+    sync._handle_coordinator_update()
+    await interval_started.wait()
+    await coordinator_started.wait()
+    tasks = tuple(sync._refresh_tasks)  # noqa: SLF001
+
+    await sync.async_stop()
+
+    assert len(tasks) == 2
+    assert all(task.cancelled() for task in tasks)
+    assert sync._refresh_tasks == set()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_schedule_sync_stop_timeout_is_bounded(hass, monkeypatch, caplog) -> None:
+    sync = ScheduleSync(hass, SimpleNamespace(), None)
+    task = asyncio.create_task(asyncio.sleep(60))
+    sync._refresh_tasks.add(task)  # noqa: SLF001
+
+    async def _pending(tasks, *, timeout):
+        assert timeout == schedule_sync_mod.SCHEDULE_SYNC_STOP_TIMEOUT_S
+        return set(), set(tasks)
+
+    monkeypatch.setattr(schedule_sync_mod.asyncio, "wait", _pending)
+    with caplog.at_level("WARNING"):
+        await sync.async_stop()
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert "Timed out waiting for 1 Enphase schedule task" in caplog.text
+
+
+def test_schedule_sync_does_not_schedule_after_stop(hass) -> None:
+    sync = ScheduleSync(hass, SimpleNamespace(), None)
+    sync._stopping = True  # noqa: SLF001
+    create_task = MagicMock()
+    sync.hass.async_create_task = create_task
+
+    sync._handle_interval()
+
+    create_task.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_sync_start_aborts_if_stop_wins_race(hass) -> None:
+    sync = ScheduleSync(hass, SimpleNamespace(), None)
+    sync._sync_enabled = lambda: True
+
+    async def _remove_helpers() -> None:
+        sync._stopping = True  # noqa: SLF001
+
+    sync._remove_all_helpers = _remove_helpers
+
+    await sync.async_start()
+
+    assert sync._unsub_interval is None
+    assert sync._unsub_coordinator is None
+
+
+def test_schedule_sync_ignores_non_task_factory_result(hass) -> None:
+    sync = ScheduleSync(hass, SimpleNamespace(), None)
+
+    def _discard(coro, *, name=None):  # noqa: ARG001
+        coro.close()
+        return None
+
+    sync.hass.async_create_task = _discard
+
+    sync._handle_interval()
+
+    assert sync._refresh_tasks == set()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_schedule_sync_refresh_skips_when_locked(hass) -> None:
     slot_id = f"{RANDOM_SITE_ID}:{RANDOM_SERIAL}:slot-15"
     payload = {

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -1481,6 +1481,9 @@ async def test_async_turn_on_not_ready_clears_desired(
     coord.set_charging_expectation.reset_mock()
     coord.kick_fast.reset_mock()
     coord.async_request_refresh.reset_mock()
+    coord.track_entry_background_task = MagicMock(
+        wraps=coord.track_entry_background_task
+    )
 
     sw = ChargingSwitch(coord, RANDOM_SERIAL)
     sw.hass = hass
@@ -1495,6 +1498,7 @@ async def test_async_turn_on_not_ready_clears_desired(
     coord.set_charging_expectation.assert_not_called()
     coord.kick_fast.assert_called_once_with(FAST_TOGGLE_POLL_HOLD_S)
     assert coord.async_request_refresh.called
+    coord.track_entry_background_task.assert_called_once()
     await hass.async_block_till_done()
 
 

--- a/tests/components/enphase_ev/test_system_events.py
+++ b/tests/components/enphase_ev/test_system_events.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -11,6 +12,8 @@ from custom_components.enphase_ev.api import OptionalEndpointUnavailable
 from custom_components.enphase_ev.const import DOMAIN
 from custom_components.enphase_ev.system_events import (
     SYSTEM_EVENTS_ENDPOINT_FAMILY,
+    SYSTEM_EVENT_REPAIR_CHECKPOINT_INTERVAL,
+    SYSTEM_EVENT_REPAIR_MISSING_GRACE,
     SYSTEM_EVENT_REPAIR_PREFIX,
     SystemEventsRuntime,
     _catalog_label,
@@ -222,6 +225,7 @@ async def test_runtime_refresh_clears_repairs_only_for_explicit_resolution(
         "severity": "critical",
         "device_type": "IQ Gateway SERI...TE-1",
         "event_date": "2026-07-11T01:02:03Z",
+        "last_seen_utc": runtime._last_success_utc.isoformat(),  # noqa: SLF001
     }
     coordinator._note_endpoint_family_success.assert_called_once_with(
         SYSTEM_EVENTS_ENDPOINT_FAMILY
@@ -316,6 +320,7 @@ async def test_runtime_diagnostics_and_persisted_issue_cleanup(
     assert snapshot["device_type_counts"] == {"IQ Battery": 1}
     assert snapshot["last_success_utc"].endswith("+00:00")
     assert snapshot["using_cached_data"] is True
+    assert snapshot["truncated"] is False
     assert runtime.active_events[0].event_type == "Warning"
 
     monkeypatch.setattr(
@@ -345,3 +350,161 @@ def test_runtime_unavailable_diagnostics(hass) -> None:
     snapshot = runtime.diagnostics()
     assert snapshot["last_success_utc"] is None
     assert snapshot["using_cached_data"] is False
+    assert snapshot["truncated"] is False
+
+
+def test_runtime_ignores_invalid_persisted_last_seen(hass, monkeypatch) -> None:
+    runtime = SystemEventsRuntime(_runtime_coordinator(hass))
+    prefix = f"{SYSTEM_EVENT_REPAIR_PREFIX}{runtime._entry_suffix()}_"  # noqa: SLF001
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_get",
+        lambda _hass: SimpleNamespace(
+            issues={
+                (DOMAIN, f"{prefix}wrong_type"): SimpleNamespace(
+                    data={"last_seen_utc": 123}
+                ),
+                (DOMAIN, f"{prefix}naive"): SimpleNamespace(
+                    data={"last_seen_utc": "2026-07-11T00:00:00"}
+                ),
+            }
+        ),
+    )
+
+    runtime._restore_repair_last_seen()  # noqa: SLF001
+
+    assert runtime._repair_last_seen_utc == {}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_runtime_expires_missing_repair_after_complete_snapshot_grace(
+    hass, monkeypatch
+) -> None:
+    coordinator = _runtime_coordinator(hass, payload=_event_payload())
+    runtime = SystemEventsRuntime(coordinator)
+    created: list[str] = []
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_get",
+        lambda _hass: SimpleNamespace(issues={}),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_create_issue",
+        lambda _hass, _domain, issue_id, **_kwargs: created.append(issue_id),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_delete_issue",
+        lambda _hass, _domain, issue_id: deleted.append(issue_id),
+    )
+    first_seen = datetime(2026, 7, 11, 23, 55, tzinfo=timezone.utc)
+    observed_times = iter(
+        (
+            first_seen,
+            first_seen + SYSTEM_EVENT_REPAIR_MISSING_GRACE - timedelta(seconds=1),
+            first_seen + SYSTEM_EVENT_REPAIR_MISSING_GRACE,
+        )
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.dt_util.utcnow",
+        lambda: next(observed_times),
+    )
+
+    await runtime.async_refresh()
+    coordinator.client.system_dashboard_events.return_value = {"events": []}
+    await runtime.async_refresh()
+    assert deleted == []
+
+    await runtime.async_refresh()
+    assert deleted == created
+
+
+@pytest.mark.asyncio
+async def test_runtime_does_not_expire_repairs_from_truncated_snapshot(
+    hass, monkeypatch
+) -> None:
+    coordinator = _runtime_coordinator(hass, payload=_event_payload())
+    runtime = SystemEventsRuntime(coordinator)
+    deleted: list[str] = []
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_get",
+        lambda _hass: SimpleNamespace(issues={}),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_create_issue",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_delete_issue",
+        lambda _hass, _domain, issue_id: deleted.append(issue_id),
+    )
+    first_seen = datetime(2026, 7, 11, tzinfo=timezone.utc)
+    observed_times = iter(
+        (first_seen, first_seen + SYSTEM_EVENT_REPAIR_MISSING_GRACE * 2)
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.dt_util.utcnow",
+        lambda: next(observed_times),
+    )
+
+    await runtime.async_refresh()
+    coordinator.client.system_dashboard_events.return_value = {
+        "events": [],
+        "_enphase_ev_truncated": True,
+    }
+    await runtime.async_refresh()
+
+    assert deleted == []
+    assert runtime.diagnostics()["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_persists_last_seen_checkpoint_across_reload(
+    hass, monkeypatch
+) -> None:
+    issues: dict[tuple[str, str], object] = {}
+    created: list[str] = []
+    deleted: list[str] = []
+
+    def _create(_hass, domain, issue_id, **kwargs) -> None:
+        created.append(issue_id)
+        issues[(domain, issue_id)] = SimpleNamespace(
+            active=True,
+            data=kwargs["data"],
+        )
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_get",
+        lambda _hass: SimpleNamespace(issues=issues),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_create_issue",
+        _create,
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.ir.async_delete_issue",
+        lambda _hass, _domain, issue_id: deleted.append(issue_id),
+    )
+    first_seen = datetime(2026, 7, 11, 23, 55, tzinfo=timezone.utc)
+    checkpoint = first_seen + SYSTEM_EVENT_REPAIR_CHECKPOINT_INTERVAL
+    observed_times = iter(
+        (
+            first_seen,
+            checkpoint,
+            checkpoint + SYSTEM_EVENT_REPAIR_MISSING_GRACE,
+        )
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.dt_util.utcnow",
+        lambda: next(observed_times),
+    )
+
+    runtime = SystemEventsRuntime(_runtime_coordinator(hass, payload=_event_payload()))
+    await runtime.async_refresh()
+    await runtime.async_refresh()
+    assert len(created) == 2
+    issue_id = created[-1]
+    assert issues[(DOMAIN, issue_id)].data["last_seen_utc"] == checkpoint.isoformat()
+
+    reloaded = SystemEventsRuntime(_runtime_coordinator(hass, payload={"events": []}))
+    await reloaded.async_refresh()
+
+    assert deleted == [issue_id]

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -14,6 +14,7 @@ from custom_components.enphase_ev import PLATFORMS
 from custom_components.enphase_ev.const import DOMAIN
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 from custom_components.enphase_ev.update import (
+    FIRMWARE_HISTORY_MANAGER_DATA_KEY,
     ChargerFirmwareUpdateEntity,
     FirmwareVersionHistoryStore,
     FirmwareUpdateEntity,
@@ -27,6 +28,7 @@ from custom_components.enphase_ev.update import (
     _gateway_installed_version,
     _text,
     _type_available,
+    async_get_firmware_version_history_store,
     async_setup_entry,
 )
 
@@ -632,6 +634,49 @@ async def test_firmware_version_history_store_records_bounded_changes(
 
     store.remove("update-1")
     assert store.history_for("update-1") == []
+
+
+@pytest.mark.asyncio
+async def test_firmware_version_history_store_is_shared_across_entries(
+    hass, monkeypatch
+) -> None:
+    load = AsyncMock()
+    monkeypatch.setattr(FirmwareVersionHistoryStore, "async_load", load)
+
+    first, second = await asyncio.gather(
+        async_get_firmware_version_history_store(hass),
+        async_get_firmware_version_history_store(hass),
+    )
+
+    assert first is second
+    assert hass.data[FIRMWARE_HISTORY_MANAGER_DATA_KEY] is first
+    load.assert_awaited_once_with()
+
+    save_payloads = []
+    monkeypatch.setattr(
+        first._store,  # noqa: SLF001
+        "async_delay_save",
+        lambda data_func, _delay: save_payloads.append(data_func),
+    )
+    first.record_installed_version(
+        unique_id="entry-1-gateway",
+        version="1.0",
+        hass=None,
+        entity_id=None,
+        name=None,
+    )
+    second.record_installed_version(
+        unique_id="entry-2-gateway",
+        version="2.0",
+        hass=None,
+        entity_id=None,
+        name=None,
+    )
+
+    assert set(save_payloads[-1]()["entries"]) == {
+        "entry-1-gateway",
+        "entry-2-gateway",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_weather.py
+++ b/tests/components/enphase_ev/test_weather.py
@@ -125,7 +125,11 @@ async def test_setup_schedules_discovery_and_creates_cloud_weather_after_success
     hass, config_entry, monkeypatch
 ) -> None:
     client = SimpleNamespace(weather=AsyncMock(return_value=_payload()))
-    coordinator = SimpleNamespace(site_id=RANDOM_SITE_ID, client=client)
+    coordinator = SimpleNamespace(
+        site_id=RANDOM_SITE_ID,
+        client=client,
+        track_entry_background_task=MagicMock(),
+    )
     object.__setattr__(config_entry, "options", {OPT_WEATHER_ENABLED: True})
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coordinator)
     hass.config.language = "en-AU"
@@ -152,6 +156,7 @@ async def test_setup_schedules_discovery_and_creates_cloud_weather_after_success
     client.weather.assert_not_awaited()
     assert len(scheduled) == 1
     assert scheduled[0][1] == "enphase_ev_weather_discovery"
+    coordinator.track_entry_background_task.assert_called_once()
 
     await scheduled[0][0]
 


### PR DESCRIPTION
## Summary

- Isolate optional Grid Profile metadata work from core refreshes, serialize profile writes, and bound queue plus request time.
- Bound and serialize optional inventory/event requests, preserve accurate firmware progress, and expose event truncation safely.
- Make config-entry shutdown deterministic by tracking startup, schedule, discovery, weather, switch recovery, session, and EVSE auto-resume tasks.
- Share firmware history across config entries and persist conservative system-event Repair expiry checkpoints.

This hardens performance, stability, and reliability after the large set of changes accumulated since the previous release.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/api.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/discovery_snapshot.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/gateway_software_update.py custom_components/enphase_ev/grid_profile_runtime.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/schedule_sync.py custom_components/enphase_ev/switch.py custom_components/enphase_ev/system_events.py custom_components/enphase_ev/update.py custom_components/enphase_ev/weather.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_gateway_software_update.py tests/components/enphase_ev/test_grid_profile_runtime.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_schedule_sync.py tests/components/enphase_ev/test_switch_module.py tests/components/enphase_ev/test_system_events.py tests/components/enphase_ev/test_update_module.py tests/components/enphase_ev/test_weather.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/discovery_snapshot.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/gateway_software_update.py,custom_components/enphase_ev/grid_profile_runtime.py,custom_components/enphase_ev/inventory_runtime.py,custom_components/enphase_ev/schedule_sync.py,custom_components/enphase_ev/switch.py,custom_components/enphase_ev/system_events.py,custom_components/enphase_ev/update.py,custom_components/enphase_ev/weather.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/config_flow.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
mkdir -p .ha-config
docker compose -f devtools/docker/docker-compose.yml up -d ha-runtime
curl http://127.0.0.1:8123/
docker compose -f devtools/docker/docker-compose.yml logs --since 2m ha-runtime
docker compose -f devtools/docker/docker-compose.yml stop ha-runtime
```

Results: 3,806 repository tests passed, 3,674 integration tests passed, and all 13 touched Python modules reported 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation changes are not required because setup, options, and supported features are unchanged.
- [x] Translations are unchanged and the service translation suite passes.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Home Assistant 2026.4.1 runtime smoke test reached HTTP 200 with the configured Enphase entry present.
- Runtime logs contained no Enphase errors, exceptions, or tracebacks.
- Account-authorized charger controls were not exercised from the unauthenticated smoke-test session.
