### PR TITLE
Prevent background tasks from blocking Home Assistant startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ All notable changes to this project will be documented in this file.
 - Added installer-only, cloud-based Grid Profile Control with country-scoped region and profile selection, explicit apply confirmation, current profile monitoring, and follow-up cloud status refreshes.
 
 ### 🐛 Bug fixes
+- Prevented Home Assistant startup from waiting indefinitely on Enphase warmup
+  and gateway firmware progress loops by registering long-running work as true
+  background tasks.
 - Serialized installer Grid Profile writes, expire unconfirmed pending state after
   the follow-up window, and move steady metadata refreshes off the coordinator's
   critical path.

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1666,10 +1666,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     def _schedule_background_task(coro: Coroutine[Any, Any, Any], name: str) -> None:
         entry_create_background = getattr(entry, "async_create_background_task", None)
         hass_create_background = getattr(hass, "async_create_background_task", None)
-        if callable(entry_create_background):
-            task = entry_create_background(hass, coro, name)
-        elif callable(hass_create_background):
+        if callable(hass_create_background):
             task = hass_create_background(coro, name)
+        elif callable(entry_create_background):
+            task = entry_create_background(hass, coro, name)
         else:
             task = hass.async_create_task(coro, name=name)
         track_background_task = getattr(coord, "track_entry_background_task", None)

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -335,12 +335,12 @@ class RefreshRunner:
         if coordinator._warmup_task is not None and not coordinator._warmup_task.done():
             return
         try:
-            coordinator._warmup_task = coordinator.hass.async_create_task(
+            coordinator._warmup_task = coordinator.hass.async_create_background_task(
                 self.async_startup_warmup_runner(),
                 name=f"{DOMAIN}_warmup_site",
             )
         except TypeError:
-            coordinator._warmup_task = coordinator.hass.async_create_task(
+            coordinator._warmup_task = coordinator.hass.async_create_background_task(
                 self.async_startup_warmup_runner()
             )
 

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -498,7 +498,7 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
             and not self._progress_refresh_task.done()
         ):
             return
-        self._progress_refresh_task = self.hass.async_create_task(
+        self._progress_refresh_task = self.hass.async_create_background_task(
             self._async_refresh_progress_loop(),
             name=f"{DOMAIN}_gateway_software_update_progress",
         )

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -4560,7 +4560,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
             raise TypeError("no name support")
         return "task"
 
-    object.__setattr__(coord.hass, "async_create_task", _create_task)
+    object.__setattr__(coord.hass, "async_create_background_task", _create_task)
     await coord.async_start_startup_warmup()
     assert create_calls == []
 

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -669,27 +669,23 @@ async def test_async_setup_entry_uses_background_task_for_schedule_sync_start(
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
 
-    background_calls: list[tuple[HomeAssistant, str, bool]] = []
+    background_calls: list[tuple[str, bool]] = []
     background_tasks: list[object] = []
 
-    def _capture_background_task(
-        hass_arg: HomeAssistant, target, name: str, eager_start: bool = True
-    ) -> object:
-        background_calls.append((hass_arg, name, eager_start))
+    def _capture_background_task(target, name: str, eager_start: bool = True) -> object:
+        background_calls.append((name, eager_start))
         target.close()
         task = object()
         background_tasks.append(task)
         return task
 
-    monkeypatch.setattr(
-        config_entry, "async_create_background_task", _capture_background_task
-    )
+    monkeypatch.setattr(hass, "async_create_background_task", _capture_background_task)
 
     assert await async_setup_entry(hass, config_entry)
 
     assert background_calls == [
-        (hass, "enphase_ev_grid_profile_startup_probe", True),
-        (hass, "enphase_ev_schedule_sync_start", True),
+        ("enphase_ev_grid_profile_startup_probe", True),
+        ("enphase_ev_schedule_sync_start", True),
     ]
     dummy_coord.async_refresh_grid_profile_metadata.assert_called_once_with(force=True)
     dummy_coord.async_refresh_grid_profile_metadata.assert_not_awaited()
@@ -785,21 +781,17 @@ async def test_async_setup_entry_uses_background_task_for_startup_warmup(
     forward = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
 
-    background_calls: list[tuple[HomeAssistant, str, bool]] = []
+    background_calls: list[tuple[str, bool]] = []
 
-    def _capture_background_task(
-        hass_arg: HomeAssistant, target, name: str, eager_start: bool = True
-    ) -> None:
-        background_calls.append((hass_arg, name, eager_start))
+    def _capture_background_task(target, name: str, eager_start: bool = True) -> None:
+        background_calls.append((name, eager_start))
         target.close()
 
-    monkeypatch.setattr(
-        config_entry, "async_create_background_task", _capture_background_task
-    )
+    monkeypatch.setattr(hass, "async_create_background_task", _capture_background_task)
 
     assert await async_setup_entry(hass, config_entry)
 
-    assert background_calls == [(hass, "enphase_ev_startup_warmup", True)]
+    assert background_calls == [("enphase_ev_startup_warmup", True)]
     dummy_coord.refresh_runner.async_start_startup_warmup.assert_not_awaited()
     forward.assert_awaited_once()
 
@@ -1176,7 +1168,7 @@ def test_remove_legacy_site_device_handles_guard_paths(
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_schedule_sync_falls_back_to_hass_background_task(
+async def test_async_setup_entry_schedule_sync_falls_back_to_entry_background_task(
     hass: HomeAssistant, config_entry, monkeypatch
 ) -> None:
     site_id = config_entry.data[CONF_SITE_ID]
@@ -1201,22 +1193,24 @@ async def test_async_setup_entry_schedule_sync_falls_back_to_hass_background_tas
         lambda hass_, entry_data, config_entry=None, **kwargs: dummy_coord,
     )
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock())
-    monkeypatch.setattr(config_entry, "async_create_background_task", None)
+    monkeypatch.setattr(hass, "async_create_background_task", None)
 
-    calls: list[tuple[str, bool]] = []
+    calls: list[tuple[HomeAssistant, str, bool]] = []
 
-    def _capture_hass_background_task(target, name: str, eager_start: bool = True):
-        calls.append((name, eager_start))
+    def _capture_entry_background_task(
+        hass_arg: HomeAssistant, target, name: str, eager_start: bool = True
+    ):
+        calls.append((hass_arg, name, eager_start))
         target.close()
         return None
 
     monkeypatch.setattr(
-        hass, "async_create_background_task", _capture_hass_background_task
+        config_entry, "async_create_background_task", _capture_entry_background_task
     )
 
     assert await async_setup_entry(hass, config_entry)
 
-    assert calls == [("enphase_ev_schedule_sync_start", True)]
+    assert calls == [(hass, "enphase_ev_schedule_sync_start", True)]
     dummy_coord.schedule_sync.async_start.assert_not_awaited()
 
 


### PR DESCRIPTION
## Summary

Prevent Enphase startup warmup and gateway firmware progress loops from being
tracked as finite Home Assistant startup work. Long-running tasks now use Home
Assistant's background-task API, allowing Home Assistant to transition to
`RUNNING` and render the dashboard normally.

Add regression coverage for the preferred Home Assistant background-task path,
the config-entry compatibility fallback, and the legacy unnamed-task fallback.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/refresh_runner.py custom_components/enphase_ev/update.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_coordinator_behavior.py && ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/config_flow.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Targeted coverage was collected in memory-safe alphabetical pytest batches with
the shared `COVERAGE_FILE=/workspace/.coverage.codex`, followed by:

```bash
python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/update.py,custom_components/enphase_ev/refresh_runner.py --fail-under=100
```

Result: 1,756 statements, 0 missed, 100% coverage. The integration suite passed
3,674 tests and the repository-wide suite passed 3,806 tests.

Manual validation used the official Home Assistant 2026.7.2 runtime. Before the
fix, startup remained `NOT_RUNNING` while waiting on the Enphase warmup and
firmware progress tasks. After the fix, the dashboard rendered without a startup
loader and the Enphase entry loaded 4 devices and 149 entities.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation does not require changes because no options or supported behavior changed.
- [x] Translations are unchanged and the service translation test passes.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Home Assistant startup diagnostics reported the indefinite tasks by name:
`enphase_ev_warmup_site` and `enphase_ev_gateway_software_update_progress`.
Both are lifecycle-managed and cancelled during config-entry unload; this change
only corrects their startup classification.
