### PR TITLE
Stabilize manual EV charger preferred mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ All notable changes to this project will be documented in this file.
 - Prevented Home Assistant startup from waiting indefinitely on Enphase warmup
   and gateway firmware progress loops by registering long-running work as true
   background tasks.
+- Kept IQ EV Charger `preferred_mode` stable in Manual mode by separating the
+  numeric runtime mode from the scheduler preference and retaining fresh
+  battery-profile preference data between profile refreshes. (#774)
 - Serialized installer Grid Profile writes, expire unconfirmed pending state after
   the follow-up window, and move steady metadata refreshes off the coordinator's
   critical path.

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -2527,10 +2527,12 @@ class BatteryRuntime:
         self._apply_battery_capability_blocks(data)
         devices: list[dict[str, object]] = []
         profile_evse_device: dict[str, object] | None = None
+        profile_devices_authoritative = False
         raw_devices = data.get("devices")
         if isinstance(raw_devices, dict):
             iq_evse = raw_devices.get("iqEvse")
             if isinstance(iq_evse, list):
+                profile_devices_authoritative = True
                 for item in iq_evse:
                     if not isinstance(item, dict):
                         continue
@@ -2595,10 +2597,12 @@ class BatteryRuntime:
         self.sync_storm_guard_pending(storm_state)
         if evse_storm_enabled is not None:
             state._storm_evse_enabled = evse_storm_enabled
-        if devices:
+        if profile_devices_authoritative:
             state._battery_profile_devices = devices
+            state._battery_profile_devices_last_success_mono = time.monotonic()
         elif profile is not None:
             state._battery_profile_devices = []
+            state._battery_profile_devices_last_success_mono = time.monotonic()
         if profile_evse_device is not None:
             state._battery_profile_evse_device = profile_evse_device
         self.sync_backend_battery_profile_pending(data.get("isBatteryChangePending"))

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -3723,7 +3723,7 @@ class EnphaseCoordinator(
                 continue
             self._ensure_serial_tracked(sn)
             records.append((sn, obj))
-            if not self._has_embedded_charge_mode(obj):
+            if not self._has_embedded_charge_mode_preference(obj):
                 charge_mode_candidates.append(sn)
 
         if (
@@ -4760,6 +4760,26 @@ class EnphaseCoordinator(
         for key in ("mode", "chargeMode", "chargingMode", "charge_mode"):
             val = obj.get(key)
             if val is not None:
+                return True
+        sch = obj.get("sch_d")
+        if isinstance(sch, dict):
+            if sch.get("mode") or sch.get("status"):
+                return True
+            info = sch.get("info")
+            if isinstance(info, list):
+                for entry in info:
+                    if isinstance(entry, dict) and (
+                        entry.get("type") or entry.get("mode") or entry.get("status")
+                    ):
+                        return True
+        return False
+
+    def _has_embedded_charge_mode_preference(self, obj: dict[str, object]) -> bool:
+        """Check whether status embeds a charge-mode preference."""
+        if not isinstance(obj, dict):
+            return False
+        for key in ("chargeMode", "chargingMode", "charge_mode"):
+            if obj.get(key) is not None:
                 return True
         sch = obj.get("sch_d")
         if isinstance(sch, dict):

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -31,6 +31,7 @@ from .const import (
     OPT_FAST_POLL_INTERVAL,
     OPT_FAST_WHILE_STREAMING,
     OPT_SLOW_POLL_INTERVAL,
+    STORM_GUARD_CACHE_TTL,
 )
 from .log_redaction import redact_identifier, redact_text
 from .request_metrics import request_metrics_scope
@@ -1924,11 +1925,14 @@ class EvseRuntime:
             serials = self.normalize_serials(getattr(coord, "serials", ()))
             if len(serials) != 1 or sn_str not in serials:
                 return None
-        cache_until = getattr(coord, "_storm_guard_cache_until", None)
-        if cache_until is None:
+        last_success = getattr(
+            coord, "_battery_profile_devices_last_success_mono", None
+        )
+        if last_success is None:
             return None
         try:
-            if time.monotonic() >= float(cache_until):
+            age = time.monotonic() - float(last_success)
+            if age < 0 or age >= STORM_GUARD_CACHE_TTL:
                 return None
         except Exception:
             return None

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -399,6 +399,7 @@ class BatteryState:
     _battery_profile_evse_device: PayloadMap | None = None
     _battery_use_battery_for_self_consumption: bool | None = None
     _battery_profile_devices: PayloadRecords = field(default_factory=list)
+    _battery_profile_devices_last_success_mono: float | None = None
     _battery_pending_profile: str | None = None
     _battery_pending_reserve: int | None = None
     _battery_pending_sub_type: str | None = None

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -334,6 +334,7 @@ Observed property values from the web capture:
 - `connectors[].connectorId=1`, `connectors[].connectorStatusType="AVAILABLE"`, `connectors[].connectorStatusInfo=""`, `connectors[].connectorStatusReason=""`, `connectors[].safeLimitState=1`, `connectors[].dlbActive=false`
 - The `api/v2` status alias was observed with `data.<charger_sn>.connected=true`, `pluggedIn=false`, `charging=false`, and `lst_rpt_at=<epoch_ms>`, matching the web-app charger card state "Not Plugged-in" and `0 kW`.
 - During an active charging capture, the original status endpoint returned `connected=true`, `pluggedIn=true`, `charging=true`, `faulted=false`, `mode=0`, `offGrid="ON_GRID"`, and `connectors[].connectorStatusType="CHARGING"` with `safeLimitState=0`.
+- The numeric status `mode` is the charger’s effective runtime mode; it is not a substitute for the stored scheduler preference returned by the charging-mode preference endpoint.
 - The `api/v2` status alias during the same active charging capture still only exposed the keyed charger booleans/timestamp shape (`connected`, `pluggedIn`, `charging`, `lst_rpt_at`); it did not include the instantaneous charger voltage/current/power rendered by the web UI.
 
 ### 2.2 Extended Summary (Metadata)

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -1526,6 +1526,15 @@ def test_battery_runtime_parse_profile_payload_branches_and_helpers(
     assert coord.battery_profile_evse_device is not None
     assert coord.battery_profile_evse_device["uuid"] == "evse-1"
     assert coord.battery_profile_evse_device["device_name"] == "IQ EV Charger"
+    profile_devices_success = (
+        coord._battery_profile_devices_last_success_mono
+    )  # noqa: SLF001
+    assert isinstance(profile_devices_success, float)
+
+    coord.battery_runtime.parse_battery_profile_payload({"unexpected": True})
+    assert (  # noqa: SLF001
+        coord._battery_profile_devices_last_success_mono == profile_devices_success
+    )
 
     coord.battery_runtime.parse_battery_profile_payload(
         {"profile": "backup_only", "batteryBackupPercentage": 80}
@@ -1533,6 +1542,15 @@ def test_battery_runtime_parse_profile_payload_branches_and_helpers(
     assert coord.battery_effective_backup_percentage == 100
     assert coord._battery_profile_devices == []  # noqa: SLF001
     assert coord.battery_profile_devices_payload() is None
+    assert (  # noqa: SLF001
+        coord._battery_profile_devices_last_success_mono >= profile_devices_success
+    )
+
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "stale", "chargeMode": "MANUAL", "enable": True}
+    ]
+    coord.battery_runtime.parse_battery_profile_payload({"devices": {"iqEvse": []}})
+    assert coord._battery_profile_devices == []  # noqa: SLF001
 
     coord._battery_profile_devices = [  # noqa: SLF001
         {"chargeMode": "MANUAL", "enable": True},

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -2663,10 +2663,7 @@ async def test_async_update_data_uses_status_mode_for_effective_charge_mode(
     coord._has_successful_refresh = True  # noqa: SLF001
     coord._scheduler_available = False  # noqa: SLF001
     coord._scheduler_backoff_active = lambda: False  # type: ignore[assignment]  # noqa: SLF001
-    coord._charge_mode_cache["EV1"] = (
-        "GREEN_CHARGING",
-        coord_mod.time.monotonic(),
-    )
+    coord.client.charge_mode = AsyncMock(return_value="GREEN_CHARGING")
     coord.client.status = AsyncMock(
         return_value={
             "evChargerData": [
@@ -2680,7 +2677,7 @@ async def test_async_update_data_uses_status_mode_for_effective_charge_mode(
                             "connectorStatusReason": "INSUFFICIENT_SOLAR",
                         }
                     ],
-                    "sch_d": {"status": 1, "info": [{"type": "greencharging"}]},
+                    "sch_d": {"status": 0, "info": [{"type": 0}]},
                     "session_d": {},
                     "charging": False,
                     "pluggedIn": True,
@@ -2725,8 +2722,10 @@ async def test_async_update_data_uses_status_mode_for_effective_charge_mode(
     result = await coord._async_update_data()  # noqa: SLF001
 
     assert result["EV1"]["charge_mode_pref"] == "GREEN_CHARGING"
+    assert result["EV1"]["charge_mode_pref_source"] == "scheduler_endpoint"
     assert result["EV1"]["charge_mode"] == "MANUAL_CHARGING"
     assert result["EV1"]["charge_mode_source"] == "explicit_status"
+    coord.client.charge_mode.assert_awaited_once_with("EV1")
 
 
 @pytest.mark.asyncio
@@ -2811,7 +2810,7 @@ async def test_async_update_data_drops_expired_cached_charge_preference_when_sta
 
 
 @pytest.mark.asyncio
-async def test_async_update_data_uses_battery_profile_charge_mode_when_scheduler_pref_missing(
+async def test_async_update_data_keeps_manual_battery_profile_mode_after_refresh_cache_expires(
     coordinator_factory,
 ):
     coord = coordinator_factory(
@@ -2831,23 +2830,28 @@ async def test_async_update_data_uses_battery_profile_charge_mode_when_scheduler
         "GREEN_CHARGING",
         coord_mod.time.monotonic() - CHARGE_MODE_CACHE_TTL - 1,
     )
-    coord._storm_guard_cache_until = coord_mod.time.monotonic() + 300  # noqa: SLF001
+    coord._storm_guard_cache_until = 0.0  # noqa: SLF001
+    coord._battery_profile_devices_last_success_mono = (  # noqa: SLF001
+        coord_mod.time.monotonic()
+    )
     coord._battery_profile_devices = [  # noqa: SLF001
-        {"uuid": "evse-1", "chargeMode": "GREEN", "enable": True}
+        {"uuid": "evse-1", "chargeMode": "MANUAL", "enable": True}
     ]
+    coord.client.charge_mode = AsyncMock(return_value=None)
     coord.client.status = AsyncMock(
         return_value={
             "evChargerData": [
                 {
                     "sn": "EV1",
                     "name": "Garage EV",
+                    "mode": 0,
                     "connectors": [
                         {
                             "connectorStatusType": coord_mod.SUSPENDED_EVSE_STATUS,
                             "connectorStatusReason": "INSUFFICIENT_SOLAR",
                         }
                     ],
-                    "sch_d": {"status": 1, "info": [{"type": "CUSTOM"}]},
+                    "sch_d": {"status": 0, "info": [{"type": 0}]},
                     "session_d": {},
                     "charging": False,
                 }
@@ -2890,8 +2894,11 @@ async def test_async_update_data_uses_battery_profile_charge_mode_when_scheduler
 
     result = await coord._async_update_data()  # noqa: SLF001
 
-    assert result["EV1"]["charge_mode_pref"] == "GREEN_CHARGING"
-    assert result["EV1"]["charge_mode"] == "GREEN_CHARGING"
+    assert result["EV1"]["charge_mode_pref"] == "MANUAL_CHARGING"
+    assert result["EV1"]["charge_mode_pref_source"] == "battery_profile_fallback"
+    assert result["EV1"]["charge_mode"] == "MANUAL_CHARGING"
+    assert result["EV1"]["charge_mode_source"] == "explicit_status"
+    coord.client.charge_mode.assert_awaited_once_with("EV1")
 
 
 @pytest.mark.asyncio
@@ -3241,6 +3248,13 @@ def test_has_embedded_charge_mode_detects_nested():
     }
     assert coord._has_embedded_charge_mode(payload) is True
     assert coord._has_embedded_charge_mode({"foo": "bar"}) is False
+    assert coord._has_embedded_charge_mode({"mode": 0}) is True
+    assert coord._has_embedded_charge_mode_preference({"mode": 0}) is False
+    assert coord._has_embedded_charge_mode_preference(payload) is True
+    assert (
+        coord._has_embedded_charge_mode_preference({"chargeMode": "MANUAL_CHARGING"})
+        is True
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -1551,6 +1551,7 @@ async def test_async_resolve_charge_modes_skips_empty_serials(coordinator_factor
 def test_has_embedded_charge_mode_for_non_dict(coordinator_factory):
     coord = coordinator_factory()
     assert coord._has_embedded_charge_mode([]) is False
+    assert coord._has_embedded_charge_mode_preference([]) is False
 
 
 def test_persist_tokens_handles_missing_entry(coordinator_factory):

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, call
@@ -118,23 +119,34 @@ async def test_evse_runtime_green_battery_write_marks_scheduler_unavailable(
 
 
 def test_evse_runtime_battery_profile_charge_mode_preference_paths(
-    coordinator_factory,
+    coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory(serials=["EV1"])
     runtime = coord.evse_runtime
+    clock = {"now": 1000.0}
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.evse_runtime.time.monotonic",
+        lambda: clock["now"],
+    )
 
     assert runtime.battery_profile_charge_mode_preference("EV1") is None
 
-    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    coord._battery_profile_devices_last_success_mono = 1000.0  # noqa: SLF001
     coord._battery_profile_devices = [  # noqa: SLF001
         {"uuid": "evse-1", "chargeMode": "GREEN", "enable": True}
     ]
     assert runtime.battery_profile_charge_mode_preference("EV1") == "GREEN_CHARGING"
 
-    coord._storm_guard_cache_until = 0.0  # noqa: SLF001
+    clock["now"] = 1299.0
+    assert runtime.battery_profile_charge_mode_preference("EV1") == "GREEN_CHARGING"
+
+    clock["now"] = 1300.0
     assert runtime.battery_profile_charge_mode_preference("EV1") is None
 
-    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    clock["now"] = 999.0
+    assert runtime.battery_profile_charge_mode_preference("EV1") is None
+
+    clock["now"] = 1000.0
     coord._battery_profile_devices = ["bad"]  # noqa: SLF001
     assert runtime.battery_profile_charge_mode_preference("EV1") is None
 
@@ -166,7 +178,7 @@ def test_evse_runtime_battery_profile_charge_mode_preference_error_paths() -> No
         SimpleNamespace(
             _configured_serials=set(),
             serials={"EV1", "EV2"},
-            _storm_guard_cache_until=10.0**12,
+            _battery_profile_devices_last_success_mono=time.monotonic(),
             _battery_profile_devices=[{"chargeMode": "GREEN"}],
         )
     )
@@ -176,7 +188,7 @@ def test_evse_runtime_battery_profile_charge_mode_preference_error_paths() -> No
         SimpleNamespace(
             _configured_serials={"EV1"},
             serials={"EV1"},
-            _storm_guard_cache_until="bad",
+            _battery_profile_devices_last_success_mono="bad",
             _battery_profile_devices=[{"chargeMode": "GREEN"}],
         )
     )
@@ -185,7 +197,7 @@ def test_evse_runtime_battery_profile_charge_mode_preference_error_paths() -> No
     class _BrokenDevices:
         _configured_serials = {"EV1"}
         serials = {"EV1"}
-        _storm_guard_cache_until = 10.0**12
+        _battery_profile_devices_last_success_mono = time.monotonic()
 
         @property
         def _battery_profile_devices(self):

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -402,6 +402,7 @@ async def test_ac_battery_target_state_of_charge_select_rejects_invalid_option(
 
 
 def test_charge_mode_select_current_option_paths(coordinator_factory):
+    from custom_components.enphase_ev.const import STORM_GUARD_CACHE_TTL
     from custom_components.enphase_ev.select import ChargeModeSelect
 
     coord = coordinator_factory()
@@ -427,7 +428,9 @@ def test_charge_mode_select_current_option_paths(coordinator_factory):
     coord._charge_mode_cache.clear()  # noqa: SLF001
     assert sel.current_option == "Green"
 
-    coord._battery_profile_devices_last_success_mono = 0.0  # noqa: SLF001
+    coord._battery_profile_devices_last_success_mono = (  # noqa: SLF001
+        time.monotonic() - STORM_GUARD_CACHE_TTL
+    )
     coord._charge_mode_cache.clear()  # noqa: SLF001
     assert sel.current_option is None
 

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -419,14 +420,14 @@ def test_charge_mode_select_current_option_paths(coordinator_factory):
     assert sel.current_option == "Scheduled"
 
     coord.data[RANDOM_SERIAL]["charge_mode"] = ""
-    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    coord._battery_profile_devices_last_success_mono = time.monotonic()  # noqa: SLF001
     coord._battery_profile_devices = [  # noqa: SLF001
         {"uuid": "evse-1", "chargeMode": "GREEN", "enable": True}
     ]
     coord._charge_mode_cache.clear()  # noqa: SLF001
     assert sel.current_option == "Green"
 
-    coord._storm_guard_cache_until = 0.0  # noqa: SLF001
+    coord._battery_profile_devices_last_success_mono = 0.0  # noqa: SLF001
     coord._charge_mode_cache.clear()  # noqa: SLF001
     assert sel.current_option is None
 
@@ -471,7 +472,7 @@ async def test_charge_mode_select_sets_smart_mode_for_single_evse_profile_contex
     from custom_components.enphase_ev.select import ChargeModeSelect
 
     coord = coordinator_factory()
-    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    coord._battery_profile_devices_last_success_mono = time.monotonic()  # noqa: SLF001
     coord._battery_profile_devices = [  # noqa: SLF001
         {"uuid": RANDOM_SERIAL, "chargeMode": "SMART", "enable": False}
     ]
@@ -494,7 +495,7 @@ async def test_charge_mode_select_maps_legacy_green_alias_to_smart_mode(
     from custom_components.enphase_ev.select import ChargeModeSelect
 
     coord = coordinator_factory()
-    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    coord._battery_profile_devices_last_success_mono = time.monotonic()  # noqa: SLF001
     coord._battery_profile_devices = [  # noqa: SLF001
         {"uuid": RANDOM_SERIAL, "chargeMode": "SMART", "enable": False}
     ]
@@ -520,7 +521,7 @@ async def test_charge_mode_select_maps_localized_green_alias_to_smart_mode(
     coord = coordinator_factory()
     coord.hass.config.language = "de"
     await async_prime_label_translations(coord.hass)
-    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    coord._battery_profile_devices_last_success_mono = time.monotonic()  # noqa: SLF001
     coord._battery_profile_devices = [  # noqa: SLF001
         {"uuid": RANDOM_SERIAL, "chargeMode": "SMART", "enable": False}
     ]


### PR DESCRIPTION
## Summary

- Separate the IQ EV Charger numeric runtime mode from its stored scheduler preference so `mode: 0` no longer suppresses preference lookups.
- Keep authoritative BatteryConfig EVSE preferences valid for a bounded 300-second window independent of the shorter Storm Guard refresh cache deadline.
- Add regression coverage for Manual-mode stability, scheduler/effective-mode separation, freshness boundaries, malformed data, and empty profile-device snapshots.

Fixes #774.

## Related Issues

- Related state-stability history: #424

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_select_charge_mode.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:delegated ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/state_models.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/config_flow.py"
```

- Full repository suite: 3,806 passed.
- Integration suite under coverage: 3,674 passed.
- Targeted coverage: 100% for `coordinator.py`, `evse_runtime.py`, `battery_runtime.py`, and `state_models.py`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid; no translation keys changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- No diagnostics payload is included; the issue logs and source path were sufficient to reproduce the failure.
- Numeric status `mode` remains authoritative for effective mode only. Scheduler preference and fresh BatteryConfig fallback data drive `preferred_mode`.
- The BatteryConfig/Storm Guard endpoint cadence is unchanged; this does not add per-poll BatteryConfig traffic.
