### PR TITLE
Remove weather entity when disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Removed a previously created Enphase site weather entity automatically when
+  Enable weather is turned off.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/weather.py
+++ b/custom_components/enphase_ev/weather.py
@@ -14,6 +14,7 @@ import aiohttp
 from homeassistant.components.weather import WeatherEntity
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -278,10 +279,18 @@ async def async_setup_entry(
 ) -> None:
     """Create weather only after an enabled endpoint probe succeeds."""
 
-    if not bool(entry.options.get(OPT_WEATHER_ENABLED, False)):
-        return
     main_coordinator = get_runtime_data(entry).coordinator
     site_id = str(main_coordinator.site_id)
+    if not bool(entry.options.get(OPT_WEATHER_ENABLED, False)):
+        ent_reg = er.async_get(hass)
+        entity_id = ent_reg.async_get_entity_id(
+            "weather",
+            DOMAIN,
+            f"{DOMAIN}_site_{site_id}_weather",
+        )
+        if entity_id is not None:
+            ent_reg.async_remove(entity_id)
+        return
     locale = str(getattr(hass.config, "language", "en") or "en")
     coordinator = EnphaseWeatherCoordinator(
         hass,

--- a/tests/components/enphase_ev/test_weather.py
+++ b/tests/components/enphase_ev/test_weather.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 from homeassistant.const import UnitOfTemperature
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.enphase_ev.const import OPT_WEATHER_ENABLED
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
@@ -113,11 +114,19 @@ async def test_setup_skips_weather_when_option_disabled(hass, config_entry) -> N
     coordinator = SimpleNamespace(site_id=RANDOM_SITE_ID, client=client)
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coordinator)
     added: list[EnphaseSiteWeather] = []
+    ent_reg = er.async_get(hass)
+    stale_weather = ent_reg.async_get_or_create(
+        "weather",
+        "enphase_ev",
+        f"enphase_ev_site_{RANDOM_SITE_ID}_weather",
+        config_entry=config_entry,
+    )
 
     await async_setup_entry(hass, config_entry, added.extend)
 
     assert added == []
     client.weather.assert_not_awaited()
+    assert ent_reg.async_get(stale_weather.entity_id) is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- remove the previously registered Enphase site weather entity when Enable weather is turned off
- add regression coverage for disabling weather after the entity has been created
- document the user-facing fix in the changelog

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check . && black custom_components/enphase_ev/weather.py tests/components/enphase_ev/test_weather.py && python -m pre_commit run --all-files && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/weather.py --fail-under=100 && pytest tests/components/enphase_ev -q && pytest"
```

- Integration suite: 3,719 passed
- Full repository suite: 3,851 passed
- Targeted `weather.py` coverage: 100%

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed. No documentation update was needed because the existing weather option documentation remains accurate.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. No translation strings changed, and the full suite includes translation validation.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots are required for this registry-cleanup fix.
