### PR TITLE
Preserve EV charger entities during transient empty status responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug fixes
 - Removed a previously created Enphase site weather entity automatically when
   Enable weather is turned off.
+- Preserved IQ EV Charger entities and their last good state through isolated
+  empty status responses, requiring repeated absence and inventory confirmation
+  before removing the entities from Home Assistant.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -229,6 +229,7 @@ SESSION_HISTORY_IDLE_HARD_TTL_GRACE_S = 300.0
 SESSION_HISTORY_RECENT_STOP_WINDOW_S = 600.0
 GRID_PROFILE_METADATA_REFRESH_DEADLINE_S = 15.0
 RUNTIME_CLEANUP_TIMEOUT_S = 10.0
+EVSE_EMPTY_STATUS_CONFIRMATIONS = 3
 BATTERY_GRID_MODE_PERMISSIONS = {
     "importexport": (True, True),
     "importonly": (True, False),
@@ -554,6 +555,7 @@ class EnphaseCoordinator(
     _last_error: str | None
     _backoff_until: float | None
     _status_charger_data_serials: list[str] | None
+    _empty_status_charger_data_count: int
     last_success_utc: datetime | None
     last_failure_utc: datetime | None
     last_failure_status: int | None
@@ -3015,6 +3017,7 @@ class EnphaseCoordinator(
         phase_timings = context.phase_timings
         self._status_charger_data_authoritative = False
         self._status_charger_data_serials = None
+        self._empty_status_charger_data_count = 0
         self._backoff_until = None
         self._clear_backoff_timer()
         self._clear_auth_repair_issues_on_success()
@@ -3546,12 +3549,15 @@ class EnphaseCoordinator(
         status_refresh_succeeded = False
         status_charger_data_authoritative = False
         status_charger_data_serials: list[str] | None = None
+        status_empty_observed = False
+        status_empty_preserved = False
+        preserve_normalized_status = False
         try:
             status_start = time.monotonic()
             data = await self.client.status()
             phase_timings["status_s"] = round(time.monotonic() - status_start, 3)
             if isinstance(data, dict):
-                self._status_payload_cache = dict(data)
+                fresh_status_payload = dict(data)
                 raw_charger_data = data.get("evChargerData")
                 if isinstance(raw_charger_data, list):
                     status_charger_data_serials = []
@@ -3565,13 +3571,64 @@ class EnphaseCoordinator(
                             status_charger_data_authoritative = False
                             break
                         status_charger_data_serials.append(serial)
-            self._mark_payload_endpoint_success(
-                "status",
-                success_mono=time.monotonic(),
-                success_utc=dt_util.utcnow(),
-            )
+                    if (
+                        status_charger_data_authoritative
+                        and not status_charger_data_serials
+                    ):
+                        status_empty_observed = True
+                        self._empty_status_charger_data_count += 1
+                        inventory_serials = self._inventory_evse_serials()
+                        status_empty_preserved = (
+                            self._empty_status_charger_data_count
+                            < EVSE_EMPTY_STATUS_CONFIRMATIONS
+                            or inventory_serials is None
+                            or bool(inventory_serials)
+                        )
+                        if status_empty_preserved:
+                            status_charger_data_authoritative = False
+                            status_charger_data_serials = None
+                            cached_status = self._status_payload_cache
+                            cached_charger_data = (
+                                cached_status.get("evChargerData")
+                                if isinstance(cached_status, dict)
+                                else None
+                            )
+                            if isinstance(cached_charger_data, list) and bool(
+                                cached_charger_data
+                            ):
+                                data = dict(cached_status)
+                                self.payload_using_stale = True
+                            elif fallback_data:
+                                preserve_normalized_status = True
+                                self.payload_using_stale = True
+                            else:
+                                self.payload_using_stale = False
+                            context.status_used_stale = self.payload_using_stale
+                if not status_empty_preserved:
+                    self._status_payload_cache = fresh_status_payload
+            if status_empty_preserved:
+                confirmation_count = min(
+                    self._empty_status_charger_data_count,
+                    EVSE_EMPTY_STATUS_CONFIRMATIONS,
+                )
+                self._note_payload_endpoint_failure(
+                    "status",
+                    error=(
+                        "Empty EVSE status response awaiting confirmation "
+                        f"({confirmation_count}/"
+                        f"{EVSE_EMPTY_STATUS_CONFIRMATIONS})"
+                    ),
+                    using_stale=self.payload_using_stale,
+                )
+            else:
+                self._mark_payload_endpoint_success(
+                    "status",
+                    success_mono=time.monotonic(),
+                    success_utc=dt_util.utcnow(),
+                )
             self.last_failure_endpoint = None
-            self.payload_using_stale = False
+            if not status_empty_preserved:
+                self.payload_using_stale = False
             self.payload_failure_kind = None
             self._unauth_errors = 0
             self._clear_auth_repair_issues_on_success()
@@ -3805,6 +3862,8 @@ class EnphaseCoordinator(
                     retry_after=backoff,
                 )
         finally:
+            if not status_empty_observed:
+                self._empty_status_charger_data_count = 0
             self._status_charger_data_authoritative = (
                 status_charger_data_authoritative
                 and not bool(getattr(self, "payload_using_stale", False))
@@ -3823,7 +3882,15 @@ class EnphaseCoordinator(
 
         prev_data = self.data if isinstance(self.data, dict) else {}
         self._has_successful_refresh = True
-        out: dict[str, dict[str, object]] = {}
+        out: dict[str, dict[str, object]] = (
+            {
+                serial: dict(snapshot)
+                for serial, snapshot in fallback_data.items()
+                if isinstance(snapshot, dict)
+            }
+            if preserve_normalized_status
+            else {}
+        )
         raw_charger_data = data.get("evChargerData")
         arr = (
             [charger for charger in raw_charger_data if isinstance(charger, dict)]
@@ -7504,15 +7571,24 @@ class EnphaseCoordinator(
                 source = self.data if isinstance(self.data, dict) else {}
                 status_serials = [str(sn) for sn in source if sn]
             return status_serials
+        if 0 < self._empty_status_charger_data_count < EVSE_EMPTY_STATUS_CONFIRMATIONS:
+            return None
+        return self._inventory_evse_serials()
+
+    def _inventory_evse_serials(self) -> list[str] | None:
+        """Return EVSE serials from the device inventory when it is conclusive."""
+
+        if not bool(getattr(self, "_devices_inventory_ready", False)):
+            return None
         try:
             bucket = self.inventory_view.type_bucket("iqevse")
         except Exception:  # noqa: BLE001
-            return status_serials
+            return None
         if not isinstance(bucket, dict):
-            return status_serials
+            return None
         members = bucket.get("devices")
         if not isinstance(members, list):
-            return status_serials
+            return None
         serials: list[str] = []
         for member in members:
             if not isinstance(member, dict):
@@ -7531,14 +7607,14 @@ class EnphaseCoordinator(
         if serials:
             return [serial for serial in dict.fromkeys(serials) if serial]
         if "count" not in bucket:
-            return status_serials
+            return None
         try:
             count = int(str(bucket.get("count")))
         except (TypeError, ValueError):
-            return status_serials
+            return None
         if count == 0:
-            return status_serials or []
-        return status_serials
+            return []
+        return None
 
     def iter_battery_serials(self) -> list[str]:
         """Return active battery identities in a stable order."""

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -3593,8 +3593,10 @@ class EnphaseCoordinator(
                                 if isinstance(cached_status, dict)
                                 else None
                             )
-                            if isinstance(cached_charger_data, list) and bool(
-                                cached_charger_data
+                            if (
+                                isinstance(cached_status, dict)
+                                and isinstance(cached_charger_data, list)
+                                and bool(cached_charger_data)
                             ):
                                 data = dict(cached_status)
                                 self.payload_using_stale = True

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -170,6 +170,7 @@ class RefreshHealthState:
     _has_successful_refresh: bool = False
     _status_charger_data_authoritative: bool = False
     _status_charger_data_serials: list[str] | None = None
+    _empty_status_charger_data_count: int = 0
     _session_history_cache_shim: dict[
         tuple[str, str], tuple[float, list[dict[str, object]]]
     ] = field(default_factory=dict)

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -444,7 +444,7 @@ async def test_async_update_data_handles_system_dashboard_refresh_error(
 
     result = await coord._async_update_data()
 
-    assert result == {}
+    assert set(result) == {SERIAL_ONE}
     refresh_dashboard.assert_not_awaited()
     assert "system_dashboard_s" not in coord.phase_timings
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1686,7 +1686,8 @@ async def test_update_keeps_status_when_configured_evse_serials_are_pruned(
 
     assert result == {}
     coord.client.status.assert_awaited_once()
-    assert coord._status_charger_data_authoritative is True  # noqa: SLF001
+    assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+    assert coord._empty_status_charger_data_count == 1  # noqa: SLF001
     assert coord.iter_serials() == []
 
 
@@ -3792,7 +3793,7 @@ async def test_refresh_malformed_nested_status_row_keeps_cleanup_authority(
 
 
 @pytest.mark.asyncio
-async def test_first_refresh_empty_evchargerdata_is_cleanup_authoritative(
+async def test_first_refresh_empty_evchargerdata_waits_for_confirmation(
     hass, monkeypatch
 ) -> None:
     coord = _make_coordinator(hass, monkeypatch)
@@ -3812,14 +3813,15 @@ async def test_first_refresh_empty_evchargerdata_is_cleanup_authoritative(
     coord.data = data
 
     assert data == {}
-    assert coord._status_charger_data_authoritative is True  # noqa: SLF001
-    assert coord._status_charger_data_serials == []  # noqa: SLF001
-    assert coord._active_inventory_evse_serials() == []  # noqa: SLF001
-    assert coord.iter_serials() == []
+    assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+    assert coord._status_charger_data_serials is None  # noqa: SLF001
+    assert coord._empty_status_charger_data_count == 1  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() is None  # noqa: SLF001
+    assert coord.iter_serials() == ["RESTORED"]
 
 
 @pytest.mark.asyncio
-async def test_empty_evchargerdata_keeps_status_refresh_after_serials_pruned(
+async def test_empty_evchargerdata_waits_for_inventory_to_confirm_removal(
     hass, monkeypatch
 ) -> None:
     coord = _make_coordinator(hass, monkeypatch)
@@ -3835,24 +3837,175 @@ async def test_empty_evchargerdata_keeps_status_refresh_after_serials_pruned(
     coord._type_device_order = ["iqevse"]  # noqa: SLF001
     coord.client.status = AsyncMock(return_value={"evChargerData": [], "ts": 0})
 
+    for _ in range(3):
+        data = await coord._async_update_data()  # noqa: SLF001
+        coord.data = data
+
+    assert data == {}
+    assert coord._empty_status_charger_data_count == 3  # noqa: SLF001
+    assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() == ["RESTORED"]  # noqa: SLF001
+    assert coord.iter_serials() == ["RESTORED"]
+
+    coord._type_device_buckets = {"iqevse": {"count": 0, "devices": []}}  # noqa: SLF001
     data = await coord._async_update_data()  # noqa: SLF001
     coord.data = data
 
     assert data == {}
-    assert coord.serials == set()
-    assert coord.iter_serials() == []
-
-    coord.client.status.reset_mock()
-
-    data = await coord._async_update_data()  # noqa: SLF001
-    coord.data = data
-
-    assert data == {}
-    coord.client.status.assert_awaited_once()
+    assert coord.client.status.await_count == 4
     assert coord._status_charger_data_authoritative is True  # noqa: SLF001
     assert coord._status_charger_data_serials == []  # noqa: SLF001
     assert coord._active_inventory_evse_serials() == []  # noqa: SLF001
     assert coord.iter_serials() == []
+
+
+@pytest.mark.asyncio
+async def test_empty_evchargerdata_waits_when_inventory_is_already_empty(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.discovery_snapshot.apply({"serial_order": ["RESTORED"]})
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[method-assign]
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._type_device_buckets = {"iqevse": {"count": 0, "devices": []}}  # noqa: SLF001
+    coord._type_device_order = ["iqevse"]  # noqa: SLF001
+    coord._inventory_evse_serials = Mock(return_value=[])  # type: ignore[method-assign]  # noqa: SLF001
+    coord.client.status = AsyncMock(return_value={"evChargerData": [], "ts": 0})
+
+    for expected_count in range(1, 3):
+        data = await coord._async_update_data()  # noqa: SLF001
+        coord.data = data
+
+        assert coord._empty_status_charger_data_count == expected_count  # noqa: SLF001
+        assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+        assert coord._active_inventory_evse_serials() is None  # noqa: SLF001
+        assert coord.iter_serials() == ["RESTORED"]
+
+    data = await coord._async_update_data()  # noqa: SLF001
+    coord.data = data
+
+    assert data == {}
+    assert coord._empty_status_charger_data_count == 3  # noqa: SLF001
+    assert coord._status_charger_data_authoritative is True  # noqa: SLF001
+    assert coord._status_charger_data_serials == []  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() == []  # noqa: SLF001
+    assert coord.iter_serials() == []
+
+
+@pytest.mark.asyncio
+async def test_empty_evchargerdata_waits_when_inventory_has_different_serial(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.discovery_snapshot.apply({"serial_order": ["RESTORED"]})
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[method-assign]
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._inventory_evse_serials = Mock(return_value=["OTHER"])  # type: ignore[method-assign]  # noqa: SLF001
+    coord.client.status = AsyncMock(return_value={"evChargerData": [], "ts": 0})
+
+    for expected_count in range(1, 3):
+        data = await coord._async_update_data()  # noqa: SLF001
+        coord.data = data
+
+        assert coord._empty_status_charger_data_count == expected_count  # noqa: SLF001
+        assert coord._active_inventory_evse_serials() is None  # noqa: SLF001
+        assert coord.iter_serials() == ["RESTORED"]
+
+    data = await coord._async_update_data()  # noqa: SLF001
+    coord.data = data
+
+    assert coord._empty_status_charger_data_count == 3  # noqa: SLF001
+    assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() == ["OTHER"]  # noqa: SLF001
+    assert coord.iter_serials() == ["OTHER"]
+
+
+@pytest.mark.asyncio
+async def test_empty_evchargerdata_preserves_status_without_conclusive_inventory(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.discovery_snapshot.apply({"serial_order": ["RESTORED"]})
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[method-assign]
+    coord._devices_inventory_ready = False  # noqa: SLF001
+    coord.client.status = AsyncMock(return_value={"evChargerData": [], "ts": 0})
+
+    for _ in range(3):
+        data = await coord._async_update_data()  # noqa: SLF001
+        coord.data = data
+
+    assert data == {}
+    assert coord._empty_status_charger_data_count == 3  # noqa: SLF001
+    assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+    assert coord._status_charger_data_serials is None  # noqa: SLF001
+    assert coord._active_inventory_evse_serials() is None  # noqa: SLF001
+    assert coord.iter_serials() == ["RESTORED"]
+
+
+@pytest.mark.asyncio
+async def test_transient_empty_evchargerdata_preserves_last_good_status(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    good_status = {
+        "evChargerData": [{"sn": "ACTIVE", "connectors": [{}]}],
+        "ts": 1,
+    }
+    coord.data = {"ACTIVE": {"sn": "ACTIVE", "charging": False}}
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._status_payload_cache = dict(good_status)  # noqa: SLF001
+    coord.client.status = AsyncMock(
+        side_effect=[
+            {"evChargerData": [], "ts": 2},
+            good_status,
+        ]
+    )
+
+    preserved = await coord._async_update_data()  # noqa: SLF001
+    coord.data = preserved
+
+    from custom_components.enphase_ev.switch import ChargingSwitch
+
+    assert set(preserved) == {"ACTIVE"}
+    assert "ACTIVE" in coord.iter_serials()
+    assert ChargingSwitch(coord, "ACTIVE").available is True
+    assert coord.payload_using_stale is True
+    assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+    assert coord._empty_status_charger_data_count == 1  # noqa: SLF001
+    assert coord._status_payload_cache == good_status  # noqa: SLF001
+    status_health = coord._payload_health_state("status")  # noqa: SLF001
+    assert status_health["using_stale"] is True
+    assert status_health["failures"] == 1
+
+    recovered = await coord._async_update_data()  # noqa: SLF001
+    coord.data = recovered
+
+    assert set(recovered) == {"ACTIVE"}
+    assert coord.payload_using_stale is False
+    assert coord._status_charger_data_authoritative is True  # noqa: SLF001
+    assert coord._status_charger_data_serials == ["ACTIVE"]  # noqa: SLF001
+    assert coord._empty_status_charger_data_count == 0  # noqa: SLF001
+    assert status_health["using_stale"] is False
+    assert status_health["failures"] == 0
+
+
+@pytest.mark.asyncio
+async def test_transient_empty_evchargerdata_preserves_normalized_fallback(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.data = {"ACTIVE": {"sn": "ACTIVE", "charging": False}}
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._status_payload_cache = None  # noqa: SLF001
+    coord.client.status = AsyncMock(return_value={"evChargerData": [], "ts": 2})
+
+    preserved = await coord._async_update_data()  # noqa: SLF001
+
+    assert set(preserved) == {"ACTIVE"}
+    assert preserved["ACTIVE"]["charging"] is False
+    assert coord.payload_using_stale is True
+    assert coord._status_charger_data_authoritative is False  # noqa: SLF001
+    assert coord._status_payload_cache is None  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve IQ EV Charger entities and their last known state through isolated empty status payloads
- require three consecutive empty responses plus conclusive inventory before allowing entity cleanup
- keep registry cleanup non-authoritative while empty-status confirmation is pending

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/state_models.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
git diff --check
```

Results: strict mypy passed for all 74 integration modules, 3,725 integration tests passed, all 3,857 repository tests passed, and the touched coordinator modules report 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed. No setup or option documentation changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. No translation files changed; translation coverage passed in the integration and full suites.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate). Pending PR creation.
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The fix treats isolated empty `evChargerData` responses as incomplete status payloads. Cached raw status or normalized coordinator data remains active until repeated status absence and authoritative inventory both confirm removal.
