### PR TITLE
Add system event history calendar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
   per-microinverter Lifetime Energy sensors and all installer-level Power sensors.
   Existing defaults are preserved: Lifetime Energy is enabled and Power is
   disabled until opted in.
+- Added a site-level `System Event History` calendar on the Enphase Cloud device,
+  backed by the localized homeowner event feed with bounded cursor pagination,
+  short-lived range caching, and identifier-safe summaries.
 
 ### 🐛 Bug fixes
 - Removed a previously created Enphase site weather entity automatically when
@@ -21,7 +24,8 @@ All notable changes to this project will be documented in this file.
   before removing the entities from Home Assistant.
 
 ### 🔧 Improvements
-- None
+- Excluded explicitly informational rows from Active System Events while
+  preserving its existing standing-alarm and high-impact Problem threshold.
 
 ### 🔄 Other changes
 - None

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Read-only System Dashboard event and standing-alarm monitoring, including a
   diagnostic Problem sensor with bounded sanitized event context and optional,
   default-off Repair notifications sourced from authoritative standing alarms
+- A site-level System Event History calendar on the Enphase Cloud device, with
+  localized descriptions, bounded on-demand pagination, and identifier redaction
 - Detailed diagnostic and inventory entities remain available but are disabled by default when they are mainly useful for troubleshooting
 - Restored discovery data creates known entities early during startup; live power
   acquisition starts alongside the minimal setup refresh and is attempted within

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -699,8 +699,17 @@ def _request_label(method: object, url: object) -> str:
 
     if url_obj.path:
         path = url_obj.path
-    if url_obj.query_string:
-        path = f"{path}?{url_obj.query_string}" if path else f"?{url_obj.query_string}"
+    query_string = url_obj.query_string
+    query = getattr(url_obj, "query", None)
+    cursor_query = {
+        str(key): "[redacted]"
+        for key in query or ()
+        if str(key).strip().casefold() in {"cursor", "next"}
+    }
+    if cursor_query:
+        query_string = url_obj.update_query(cursor_query).query_string
+    if query_string:
+        path = f"{path}?{query_string}" if path else f"?{query_string}"
     if path:
         return f"{method_text} {path}"
     return method_text
@@ -2451,6 +2460,15 @@ class EnphaseEVClient:
         headers = dict(self._h)
         headers["Accept"] = "*/*"
         headers["Referer"] = self._site_web_referer("history")
+        return headers
+
+    def _homeowner_events_headers(self) -> dict[str, str]:
+        """Return browser-style headers for the homeowner event-history feed."""
+
+        headers = self._history_headers()
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        headers["X-Requested-With"] = "XMLHttpRequest"
         return headers
 
     def _today_headers(self) -> dict[str, str]:
@@ -7741,6 +7759,52 @@ class EnphaseEVClient:
             page == _SYSTEM_EVENTS_MAX_PAGES and last_page_full
         )
         return merged
+
+    async def homeowner_events_page(
+        self,
+        *,
+        next_cursor: str = "start",
+        page_size: int = 200,
+        locale: str = "en",
+    ) -> JsonDict | None:
+        """Return one cursor-paginated homeowner event-history page.
+
+        GET /service/events-platform-service/v1.0/<site_id>/events/homeowner
+        """
+
+        url = str(
+            URL(
+                f"{BASE_URL}/service/events-platform-service/v1.0/"
+                f"{self._site}/events/homeowner"
+            ).update_query(
+                {
+                    "next": str(next_cursor or "start"),
+                    "page_size": str(max(1, min(int(page_size), 200))),
+                    "locale": str(locale or "en"),
+                }
+            )
+        )
+        try:
+            data = await self._json(
+                "GET",
+                url,
+                headers=self._homeowner_events_headers(),
+            )
+        except Exception as err:  # noqa: BLE001
+            if self._system_dashboard_is_optional_error(err) or isinstance(
+                err, InvalidPayloadError
+            ):
+                return None
+            raise
+        if not isinstance(data, dict) or not isinstance(data.get("events"), list):
+            return None
+        cursor = data.get("next")
+        if cursor is not None and (
+            isinstance(cursor, (dict, list, tuple, set, bool))
+            or not str(cursor).strip()
+        ):
+            return None
+        return data
 
     async def system_dashboard_standing_alarms(self) -> JsonDict | None:
         """Return current System Dashboard standing alarms.

--- a/custom_components/enphase_ev/calendar.py
+++ b/custom_components/enphase_ev/calendar.py
@@ -6,6 +6,7 @@ from typing import TypeVar, cast
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant, callback as ha_callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -18,6 +19,10 @@ from .runtime_helpers import (
     inventory_type_device_info as _type_device_info,
 )
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
+from .system_events import (
+    SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY,
+    SystemEventHistoryEntry,
+)
 
 PARALLEL_UPDATES = 0
 
@@ -38,25 +43,133 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coord: EnphaseCoordinator = get_runtime_data(entry).coordinator
-    site_entity_added = False
+    backup_history_entity_added = False
+    system_event_history_entity_added = False
+    ent_reg = er.async_get(hass)
+
+    def _site_calendar_unique_id(key: str) -> str:
+        return f"{DOMAIN}_site_{coord.site_id}_{key}"
 
     @callback
     def _async_sync_site_entities() -> None:
-        nonlocal site_entity_added
-        if site_entity_added:
-            return
-        if not _site_has_battery(coord, strict=True) or not _type_available(
-            coord, "encharge"
+        nonlocal backup_history_entity_added, system_event_history_entity_added
+        if (
+            not backup_history_entity_added
+            and _site_has_battery(coord, strict=True)
+            and _type_available(coord, "encharge")
         ):
-            return
-        async_add_entities(
-            [BackupHistoryCalendarEntity(coord)], update_before_add=False
+            async_add_entities(
+                [BackupHistoryCalendarEntity(coord)], update_before_add=False
+            )
+            backup_history_entity_added = True
+
+        history_entity_id = ent_reg.async_get_entity_id(
+            "calendar",
+            DOMAIN,
+            _site_calendar_unique_id("system_event_history"),
         )
-        site_entity_added = True
+        endpoint_health = coord._endpoint_family_state(
+            SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+        )
+        endpoint_suppressed = endpoint_health.support_state == "suppressed"
+        if not endpoint_suppressed and (
+            coord.system_events_runtime.history_available
+            or history_entity_id is not None
+        ):
+            if not system_event_history_entity_added:
+                async_add_entities(
+                    [SystemEventHistoryCalendarEntity(coord)],
+                    update_before_add=False,
+                )
+                system_event_history_entity_added = True
+        elif bool(getattr(coord, "_devices_inventory_ready", False)):
+            if history_entity_id is not None:
+                ent_reg.async_remove(history_entity_id)
+            system_event_history_entity_added = False
 
     unsubscribe = coord.async_add_listener(_async_sync_site_entities)
     entry.async_on_unload(unsubscribe)
     _async_sync_site_entities()
+
+
+class SystemEventHistoryCalendarEntity(
+    CoordinatorEntity,  # type: ignore[misc]
+    CalendarEntity,  # type: ignore[misc]
+):
+    """Expose sanitized Enphase homeowner event history as a calendar."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "system_event_history"
+
+    def __init__(self, coord: EnphaseCoordinator) -> None:
+        super().__init__(coord)
+        self._coord = coord
+        self._attr_unique_id = f"{DOMAIN}_site_{coord.site_id}_system_event_history"
+
+    @property
+    def available(self) -> bool:
+        endpoint_health = self._coord._endpoint_family_state(
+            SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+        )
+        return bool(
+            self._coord.system_events_runtime.history_available
+            and endpoint_health.support_state != "suppressed"
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = _type_device_info(self._coord, "cloud")
+        if info is not None:
+            return info
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"type:{self._coord.site_id}:cloud")},
+            manufacturer="Enphase",
+        )
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        return None
+
+    def _to_calendar_event(self, item: SystemEventHistoryEntry) -> CalendarEvent:
+        summary = (
+            item.summary.strip() if item.summary and item.summary.strip() else None
+        )
+        if summary is None:
+            try:
+                name = self.name
+            except Exception:  # noqa: BLE001 - platform may not be attached in tests
+                name = None
+            if isinstance(name, str) and name.strip():
+                summary = name.strip()
+            else:
+                entity_id = getattr(self, "entity_id", None)
+                if isinstance(entity_id, str) and entity_id.strip():
+                    summary = entity_id.strip()
+        return CalendarEvent(
+            summary=summary or self._attr_unique_id,
+            start=item.start,
+            end=item.end,
+            description=item.description,
+        )
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        _ = hass
+        if start_date.tzinfo is None:
+            start_date = start_date.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+        if end_date.tzinfo is None:
+            end_date = end_date.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+        if end_date <= start_date:
+            return []
+        events = await self._coord.system_events_runtime.async_history_events(
+            start_date,
+            end_date,
+        )
+        return [self._to_calendar_event(item) for item in events]
 
 
 class BackupHistoryCalendarEntity(

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1042,6 +1042,15 @@ class EnphaseCoordinator(
                 suppress_after_failures=3,
                 support_state_on_success=True,
             ),
+            "system_event_history": EndpointFamilyPolicy(
+                success_ttl_s=900.0,
+                stale_after_s=86400.0,
+                failure_backoff_schedule_s=(900.0, 1800.0, 3600.0, 7200.0),
+                max_backoff_s=7200.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
             "grid_control_check": EndpointFamilyPolicy(
                 success_ttl_s=300.0,
                 stale_after_s=GRID_CONTROL_CHECK_STALE_AFTER_S,

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -563,6 +563,18 @@ async def async_get_config_entry_diagnostics(
         except DIAGNOSTIC_CAPTURE_ERRORS:
             system_events = {}
 
+    system_event_history: dict[str, Any] = {}
+    system_event_history_diagnostics = getattr(
+        system_events_runtime,
+        "history_diagnostics",
+        None,
+    )
+    if callable(system_event_history_diagnostics):
+        try:
+            system_event_history = system_event_history_diagnostics()
+        except DIAGNOSTIC_CAPTURE_ERRORS:
+            system_event_history = {}
+
     grid_profile: dict[str, Any] = {}
     grid_profile_runtime = getattr(coord, "grid_profile_runtime", None)
     grid_profile_diagnostics = getattr(grid_profile_runtime, "diagnostics", None)
@@ -604,6 +616,7 @@ async def async_get_config_entry_diagnostics(
         "payload_health": payload_health,
         "system_dashboard": system_dashboard,
         "system_events": system_events,
+        "system_event_history": system_event_history,
         "heatpump_runtime": heatpump_runtime,
         "current_power": current_power,
         "scheduler": scheduler,

--- a/custom_components/enphase_ev/log_redaction.py
+++ b/custom_components/enphase_ev/log_redaction.py
@@ -74,6 +74,8 @@ def _key_kind(key: object) -> str:
     if compact in {"entityid"}:
         # Entity IDs are user-visible Home Assistant names, not Enphase secrets.
         return "text"
+    if compact in {"cursor", "next"}:
+        return "redact"
     if any(
         token in compact
         for token in ("token", "auth", "cookie", "email", "user", "pass", "secret")

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -29,6 +29,7 @@ REFRESH_TASK_ENDPOINT_FAMILIES: dict[str, str] = {
     "hems_devices_s": "inventory_topology",
     "system_dashboard_s": "inventory_topology",
     "system_events_s": "system_events",
+    "system_event_history_s": "system_event_history",
     "inverters_s": "inverter_inventory",
     "current_power_s": "current_power",
 }
@@ -214,6 +215,12 @@ WARMUP_STATE_STAGE = RefreshStage(
             "system events",
             "system_events_runtime",
             "async_refresh",
+        ),
+        object_method_task(
+            "system_event_history_s",
+            "system event history",
+            "system_events_runtime",
+            "async_refresh_history",
         ),
         method_task(
             "battery_backup_history_s",
@@ -852,6 +859,16 @@ def build_followup_plan(owner: object, *, force_full: bool = False) -> RefreshPl
                 "system events",
                 "system_events_runtime",
                 "async_refresh",
+            )
+        )
+    history_refresh_due = getattr(system_events, "history_refresh_due", None)
+    if callable(history_refresh_due) and history_refresh_due():
+        parallel.append(
+            object_method_task(
+                "system_event_history_s",
+                "system event history",
+                "system_events_runtime",
+                "async_refresh_history",
             )
         )
     if battery.battery_status_refresh_due():

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -2334,6 +2334,9 @@
     "calendar": {
       "backup_history": {
         "name": "Backup History"
+      },
+      "system_event_history": {
+        "name": "System Event History"
       }
     },
     "select": {

--- a/custom_components/enphase_ev/system_events.py
+++ b/custom_components/enphase_ev/system_events.py
@@ -2,18 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
-from collections import Counter
+import re
+import time
+from collections import Counter, OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.util import dt as dt_util
 
-from .api import OptionalEndpointUnavailable
+from .api import EnphaseLoginWallUnauthorized, OptionalEndpointUnavailable
 from .const import (
     DEFAULT_SYSTEM_EVENT_REPAIR_ISSUES,
     DOMAIN,
@@ -27,15 +30,26 @@ if TYPE_CHECKING:  # pragma: no cover
 _LOGGER = logging.getLogger(__name__)
 
 SYSTEM_EVENTS_ENDPOINT_FAMILY = "system_events"
+SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY = "system_event_history"
 SYSTEM_EVENT_REPAIR_PREFIX = "active_system_event_"
 SYSTEM_EVENT_REPAIR_MISSING_GRACE = timedelta(hours=6)
 SYSTEM_EVENT_REPAIR_CHECKPOINT_INTERVAL = timedelta(hours=1)
 ACTIVE_EVENTS_ATTRIBUTE_LIMIT = 20
+SYSTEM_EVENT_HISTORY_PAGE_SIZE = 200
+SYSTEM_EVENT_HISTORY_ROW_LIMIT = 2_000
+SYSTEM_EVENT_HISTORY_MAX_PAGES = 100
+SYSTEM_EVENT_HISTORY_CACHE_TTL = 900.0
+SYSTEM_EVENT_HISTORY_CACHE_MAX_RANGES = 4
+SYSTEM_EVENT_HISTORY_INSTANT_DURATION = timedelta(minutes=1)
 _TERMINAL_STATES = frozenset(
     {"clear", "cleared", "close", "closed", "inactive", "normal", "resolved"}
 )
 _HIGH_IMPACT_SEVERITIES = frozenset(
     {"critical", "emergency", "error", "fatal", "severe"}
+)
+_INFORMATIONAL_LABELS = frozenset({"info", "informational"})
+_HISTORY_SERIAL_RE = re.compile(
+    r"(?i)(?:sno\.?|serial(?:\s+number)?)\s*[:#=-]?\s*\(?([A-Z0-9-]{6,})"
 )
 
 
@@ -139,6 +153,28 @@ def _event_is_active(row: dict[str, object], state: str) -> bool:
     return _normalized(state) not in _TERMINAL_STATES
 
 
+def _event_is_informational(
+    row: dict[str, object],
+    *,
+    severity: str,
+    event_type: str,
+    state: str,
+) -> bool:
+    """Return whether explicit event metadata classifies a row as informational."""
+
+    return any(
+        _normalized(value) in _INFORMATIONAL_LABELS
+        for value in (
+            severity,
+            event_type,
+            state,
+            row.get("status"),
+            row.get("event_severity"),
+            row.get("severity"),
+        )
+    )
+
+
 def _event_fingerprint(row: dict[str, object]) -> str:
     """Return a stable, non-reversible event key for issue IDs."""
 
@@ -175,6 +211,154 @@ class StandingAlarm:
     severity: str
     device_type: str
     first_set: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class SystemEventHistoryEntry:
+    """Sanitized normalized homeowner event-history row."""
+
+    fingerprint: str
+    summary: str | None
+    description: str | None
+    start: datetime
+    end: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class _HistoryRangeCacheEntry:
+    """Short-lived sanitized result for one calendar range."""
+
+    expires_mono: float
+    events: tuple[SystemEventHistoryEntry, ...]
+    truncated: bool
+
+
+def _history_epoch(value: object) -> datetime | None:
+    """Return an aware UTC datetime for a seconds-or-milliseconds epoch."""
+
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        timestamp = int(float(str(value).strip()))
+        if timestamp > 10**12:
+            timestamp //= 1000
+        return datetime.fromtimestamp(timestamp, tz=UTC)
+    except (OverflowError, TypeError, ValueError):
+        return None
+
+
+def _history_identifiers(row: dict[str, object]) -> tuple[str, ...]:
+    """Return identifier candidates used only while sanitizing a history row."""
+
+    identifiers: list[str] = []
+    serial = _text(row.get("serial_num"))
+    if serial:
+        identifiers.append(serial)
+    for key in ("description", "type", "recommended_action"):
+        text = _text(row.get(key))
+        if text:
+            identifiers.extend(
+                match.group(1) for match in _HISTORY_SERIAL_RE.finditer(text)
+            )
+    impacted = row.get("devices_impacted")
+    if isinstance(impacted, list):
+        for item in impacted:
+            text = _text(item)
+            if not text:
+                continue
+            identifiers.extend(
+                match.group(1) for match in _HISTORY_SERIAL_RE.finditer(text)
+            )
+    return tuple(dict.fromkeys(identifiers))
+
+
+def _history_fingerprint(row: dict[str, object]) -> str:
+    """Return a stable non-reversible history-row key."""
+
+    stable_id = _text(row.get("id"))
+    if stable_id:
+        source = f"id:{stable_id}"
+    else:
+        source = "|".join(
+            _text(row.get(key)) or ""
+            for key in ("event_key", "event_date", "event_start_date", "serial_num")
+        )
+    return hashlib.sha256(source.encode()).hexdigest()[:16]
+
+
+def _history_event_key_label(value: object) -> str | None:
+    """Return a compact human-readable fallback for an event key."""
+
+    text = _text(value)
+    if not text:
+        return None
+    return " ".join(text.replace("_", " ").replace("-", " ").split()).capitalize()
+
+
+def parse_homeowner_event_history(
+    payload: object,
+    *,
+    site_id: str,
+) -> tuple[SystemEventHistoryEntry, ...] | None:
+    """Parse and sanitize one homeowner event-history payload."""
+
+    if not isinstance(payload, dict):
+        return None
+    rows = payload.get("events")
+    if not isinstance(rows, list):
+        return None
+    events: dict[str, SystemEventHistoryEntry] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        start = _history_epoch(row.get("event_start_date")) or _history_epoch(
+            row.get("event_date")
+        )
+        if start is None:
+            continue
+        clear = _history_epoch(row.get("event_clear_date"))
+        end = (
+            clear
+            if clear is not None and clear > start
+            else (start + SYSTEM_EVENT_HISTORY_INSTANT_DURATION)
+        )
+        identifiers = _history_identifiers(row)
+        description = redact_text(
+            _text(row.get("description")) or "",
+            site_ids=(site_id,),
+            identifiers=identifiers,
+            max_length=512,
+        )
+        event_type = redact_text(
+            _text(row.get("type")) or "",
+            site_ids=(site_id,),
+            identifiers=identifiers,
+            max_length=120,
+        )
+        event_key = redact_text(
+            _history_event_key_label(row.get("event_key")) or "",
+            site_ids=(site_id,),
+            identifiers=identifiers,
+            max_length=120,
+        )
+        recommended_action = redact_text(
+            _text(row.get("recommended_action")) or "",
+            site_ids=(site_id,),
+            identifiers=identifiers,
+            max_length=512,
+        )
+        fingerprint = _history_fingerprint(row)
+        events.setdefault(
+            fingerprint,
+            SystemEventHistoryEntry(
+                fingerprint=fingerprint,
+                summary=description or event_type or event_key or None,
+                description=recommended_action or None,
+                start=start,
+                end=end,
+            ),
+        )
+    return tuple(sorted(events.values(), key=lambda event: event.start))
 
 
 def parse_active_system_events(
@@ -293,6 +477,13 @@ def _parse_system_event_snapshot(
             severities=severities,
         )
         event_type = _catalog_label(row.get("event_type"), event_types) or "unknown"
+        if _event_is_informational(
+            row,
+            severity=severity,
+            event_type=event_type,
+            state=state,
+        ):
+            continue
         event_type = redact_text(
             event_type,
             site_ids=(site_id,),
@@ -333,6 +524,14 @@ class SystemEventsRuntime:
         self._repair_last_seen_utc: dict[str, datetime] = {}
         self._repair_checkpoint_utc: dict[str, datetime] = {}
         self._snapshot_truncated = False
+        self._history_last_success_utc: datetime | None = None
+        self._history_probe_events: tuple[SystemEventHistoryEntry, ...] = ()
+        self._history_range_cache: OrderedDict[
+            tuple[str, str, str], _HistoryRangeCacheEntry
+        ] = OrderedDict()
+        self._history_lock = asyncio.Lock()
+        self._history_using_cached_data = False
+        self._history_truncated = False
 
     @property
     def active_events(self) -> tuple[SystemEvent, ...]:
@@ -345,6 +544,12 @@ class SystemEventsRuntime:
         """Return whether at least one valid response has been received."""
 
         return self._last_success_utc is not None
+
+    @property
+    def history_available(self) -> bool:
+        """Return whether the homeowner event-history endpoint has succeeded."""
+
+        return self._history_last_success_utc is not None
 
     @property
     def active_count(self) -> int:
@@ -403,6 +608,248 @@ class SystemEventsRuntime:
         return self.coordinator._endpoint_family_should_run(
             SYSTEM_EVENTS_ENDPOINT_FAMILY
         )
+
+    def history_refresh_due(self) -> bool:
+        """Return whether the optional history endpoint may be probed now."""
+
+        return self.coordinator._endpoint_family_should_run(
+            SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+        )
+
+    def _history_locale(self) -> str:
+        """Return the Home Assistant locale used for Enphase event descriptions."""
+
+        config = getattr(getattr(self.coordinator, "hass", None), "config", None)
+        locale = _text(getattr(config, "language", None))
+        return locale or "en"
+
+    def _history_cache_key(
+        self,
+        start: datetime,
+        end: datetime,
+        locale: str,
+    ) -> tuple[str, str, str]:
+        return (
+            dt_util.as_utc(start).isoformat(),
+            dt_util.as_utc(end).isoformat(),
+            locale,
+        )
+
+    def _history_cached_range(
+        self,
+        key: tuple[str, str, str],
+        *,
+        allow_expired: bool = False,
+    ) -> _HistoryRangeCacheEntry | None:
+        entry = self._history_range_cache.get(key)
+        if entry is None:
+            return None
+        if not allow_expired and time.monotonic() >= entry.expires_mono:
+            return None
+        self._history_range_cache.move_to_end(key)
+        return entry
+
+    def _store_history_range(
+        self,
+        key: tuple[str, str, str],
+        events: tuple[SystemEventHistoryEntry, ...],
+        *,
+        truncated: bool,
+    ) -> None:
+        self._history_range_cache[key] = _HistoryRangeCacheEntry(
+            expires_mono=time.monotonic() + SYSTEM_EVENT_HISTORY_CACHE_TTL,
+            events=events,
+            truncated=truncated,
+        )
+        self._history_range_cache.move_to_end(key)
+        while len(self._history_range_cache) > SYSTEM_EVENT_HISTORY_CACHE_MAX_RANGES:
+            self._history_range_cache.popitem(last=False)
+
+    async def async_refresh_history(self) -> None:
+        """Probe the homeowner history endpoint without blocking core setup."""
+
+        if not self.history_refresh_due():
+            return
+        fetcher = getattr(self.coordinator.client, "homeowner_events_page", None)
+        if not callable(fetcher):
+            return
+        try:
+            payload = await fetcher(
+                next_cursor="start",
+                page_size=SYSTEM_EVENT_HISTORY_PAGE_SIZE,
+                locale=self._history_locale(),
+            )
+        except EnphaseLoginWallUnauthorized:
+            raise
+        except Exception as err:  # noqa: BLE001
+            self.coordinator._note_endpoint_family_failure(
+                SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY,
+                err,
+            )
+            return
+        parsed = parse_homeowner_event_history(
+            payload,
+            site_id=str(self.coordinator.site_id),
+        )
+        if parsed is None:
+            self.coordinator._note_endpoint_family_failure(
+                SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY,
+                OptionalEndpointUnavailable("System event history unavailable"),
+            )
+            return
+        self._history_probe_events = parsed
+        self._history_last_success_utc = dt_util.utcnow()
+        self._history_using_cached_data = False
+        self.coordinator._note_endpoint_family_success(
+            SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+        )
+
+    async def async_history_events(
+        self,
+        start: datetime,
+        end: datetime,
+    ) -> tuple[SystemEventHistoryEntry, ...]:
+        """Return sanitized homeowner events overlapping a calendar range."""
+
+        locale = self._history_locale()
+        key = self._history_cache_key(start, end, locale)
+        cached = self._history_cached_range(key)
+        if cached is not None:
+            self._history_using_cached_data = False
+            self._history_truncated = cached.truncated
+            return cached.events
+
+        async with self._history_lock:
+            cached = self._history_cached_range(key)
+            if cached is not None:
+                self._history_using_cached_data = False
+                self._history_truncated = cached.truncated
+                return cached.events
+
+            health = self.coordinator._endpoint_family_state(
+                SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+            )
+            if (
+                health.consecutive_failures > 0
+                and self.coordinator._endpoint_family_wait_active(
+                    SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+                )
+            ):
+                stale = (
+                    self._history_cached_range(key, allow_expired=True)
+                    if self.coordinator._endpoint_family_can_use_stale(
+                        SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+                    )
+                    else None
+                )
+                self._history_using_cached_data = stale is not None
+                self._history_truncated = (
+                    stale.truncated if stale is not None else False
+                )
+                return stale.events if stale is not None else ()
+
+            fetcher = getattr(self.coordinator.client, "homeowner_events_page", None)
+            if not callable(fetcher):
+                return ()
+            cursor = "start"
+            seen_cursors: set[str] = set()
+            rows_seen = 0
+            pages_seen = 0
+            events: dict[str, SystemEventHistoryEntry] = {}
+            truncated = False
+            try:
+                while rows_seen < SYSTEM_EVENT_HISTORY_ROW_LIMIT:
+                    pages_seen += 1
+                    if pages_seen > SYSTEM_EVENT_HISTORY_MAX_PAGES:
+                        truncated = True
+                        break
+                    payload = await fetcher(
+                        next_cursor=cursor,
+                        page_size=SYSTEM_EVENT_HISTORY_PAGE_SIZE,
+                        locale=locale,
+                    )
+                    if not isinstance(payload, dict):
+                        raise OptionalEndpointUnavailable(
+                            "System event history unavailable"
+                        )
+                    rows = payload.get("events")
+                    if not isinstance(rows, list):
+                        raise OptionalEndpointUnavailable(
+                            "System event history unavailable"
+                        )
+                    remaining = SYSTEM_EVENT_HISTORY_ROW_LIMIT - rows_seen
+                    bounded_rows = rows[:remaining]
+                    bounded_payload = dict(payload)
+                    bounded_payload["events"] = bounded_rows
+                    parsed = parse_homeowner_event_history(
+                        bounded_payload,
+                        site_id=str(self.coordinator.site_id),
+                    )
+                    if parsed is None:  # pragma: no cover - shape validated above
+                        raise OptionalEndpointUnavailable(
+                            "System event history unavailable"
+                        )
+                    page_truncated = len(rows) > len(bounded_rows)
+                    if page_truncated:
+                        truncated = True
+                    rows_seen += len(bounded_rows)
+                    for event in parsed:
+                        events.setdefault(event.fingerprint, event)
+                    oldest = min((event.start for event in parsed), default=None)
+                    next_value = payload.get("next")
+                    next_cursor = _text(next_value)
+                    if oldest is not None and oldest < start:
+                        break
+                    if page_truncated:
+                        break
+                    if not next_cursor:
+                        break
+                    if next_cursor in seen_cursors or next_cursor == cursor:
+                        truncated = True
+                        break
+                    if rows_seen >= SYSTEM_EVENT_HISTORY_ROW_LIMIT:
+                        truncated = True
+                        break
+                    seen_cursors.add(cursor)
+                    cursor = next_cursor
+            except EnphaseLoginWallUnauthorized:
+                raise
+            except Exception as err:  # noqa: BLE001
+                self.coordinator._note_endpoint_family_failure(
+                    SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY,
+                    err,
+                )
+                stale = (
+                    self._history_cached_range(key, allow_expired=True)
+                    if self.coordinator._endpoint_family_can_use_stale(
+                        SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+                    )
+                    else None
+                )
+                self._history_using_cached_data = stale is not None
+                self._history_truncated = (
+                    stale.truncated if stale is not None else False
+                )
+                return stale.events if stale is not None else ()
+
+            overlapping = tuple(
+                sorted(
+                    (
+                        event
+                        for event in events.values()
+                        if event.end > start and event.start < end
+                    ),
+                    key=lambda event: event.start,
+                )
+            )
+            self._store_history_range(key, overlapping, truncated=truncated)
+            self._history_last_success_utc = dt_util.utcnow()
+            self._history_using_cached_data = False
+            self._history_truncated = truncated
+            self.coordinator._note_endpoint_family_success(
+                SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+            )
+            return overlapping
 
     def _entry_suffix(self) -> str:
         entry_id = getattr(
@@ -651,4 +1098,25 @@ class SystemEventsRuntime:
             ),
             "truncated": self._snapshot_truncated,
             "repairs_enabled": self.repairs_enabled,
+        }
+
+    def history_diagnostics(self) -> dict[str, object]:
+        """Return identifier-free homeowner event-history diagnostics."""
+
+        cached_fingerprints = {
+            event.fingerprint
+            for entry in self._history_range_cache.values()
+            for event in entry.events
+        }
+        return {
+            "available": self.history_available,
+            "cached_range_count": len(self._history_range_cache),
+            "cached_event_count": len(cached_fingerprints),
+            "last_success_utc": (
+                self._history_last_success_utc.isoformat()
+                if self._history_last_success_utc
+                else None
+            ),
+            "using_cached_data": self._history_using_cached_data,
+            "truncated": self._history_truncated,
         }

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "История на резервното захранване"
+      },
+      "system_event_history": {
+        "name": "История на системните събития"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Historie záložního napájení"
+      },
+      "system_event_history": {
+        "name": "Historie systémových událostí"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Historik for backupdrift"
+      },
+      "system_event_history": {
+        "name": "Historik over systemhændelser"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Verlauf der Ersatzstromversorgung"
+      },
+      "system_event_history": {
+        "name": "Systemereignisverlauf"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Ιστορικό εφεδρικής τροφοδοσίας"
+      },
+      "system_event_history": {
+        "name": "Ιστορικό συμβάντων συστήματος"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -2334,6 +2334,9 @@
     "calendar": {
       "backup_history": {
         "name": "Backup History"
+      },
+      "system_event_history": {
+        "name": "System Event History"
       }
     },
     "select": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -2334,6 +2334,9 @@
     "calendar": {
       "backup_history": {
         "name": "Backup History"
+      },
+      "system_event_history": {
+        "name": "System Event History"
       }
     },
     "select": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -2334,6 +2334,9 @@
     "calendar": {
       "backup_history": {
         "name": "Backup History"
+      },
+      "system_event_history": {
+        "name": "System Event History"
       }
     },
     "select": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -2334,6 +2334,9 @@
     "calendar": {
       "backup_history": {
         "name": "Backup History"
+      },
+      "system_event_history": {
+        "name": "System Event History"
       }
     },
     "select": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -2334,6 +2334,9 @@
     "calendar": {
       "backup_history": {
         "name": "Backup History"
+      },
+      "system_event_history": {
+        "name": "System Event History"
       }
     },
     "select": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -2334,6 +2334,9 @@
     "calendar": {
       "backup_history": {
         "name": "Backup History"
+      },
+      "system_event_history": {
+        "name": "System Event History"
       }
     },
     "select": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Historial de respaldo"
+      },
+      "system_event_history": {
+        "name": "Historial de eventos del sistema"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Varutoite ajalugu"
+      },
+      "system_event_history": {
+        "name": "Süsteemisündmuste ajalugu"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Varmennushistoria"
+      },
+      "system_event_history": {
+        "name": "Järjestelmätapahtumien historia"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Historique de secours"
+      },
+      "system_event_history": {
+        "name": "Historique des événements système"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Tartalékellátás előzményei"
+      },
+      "system_event_history": {
+        "name": "Rendszeresemények előzményei"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Cronologia backup"
+      },
+      "system_event_history": {
+        "name": "Cronologia eventi di sistema"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Atsarginio maitinimo istorija"
+      },
+      "system_event_history": {
+        "name": "Sistemos įvykių istorija"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Rezerves barošanas vēsture"
+      },
+      "system_event_history": {
+        "name": "Sistēmas notikumu vēsture"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Historikk for reservekraft"
+      },
+      "system_event_history": {
+        "name": "Historikk for systemhendelser"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Back-upgeschiedenis"
+      },
+      "system_event_history": {
+        "name": "Geschiedenis van systeemgebeurtenissen"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Historia zasilania rezerwowego"
+      },
+      "system_event_history": {
+        "name": "Historia zdarzeń systemowych"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Histórico de backup"
+      },
+      "system_event_history": {
+        "name": "Histórico de eventos do sistema"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Istoric alimentare de rezervă"
+      },
+      "system_event_history": {
+        "name": "Istoricul evenimentelor de sistem"
       }
     },
     "update": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -2395,6 +2395,9 @@
     "calendar": {
       "backup_history": {
         "name": "Historik för reservkraft"
+      },
+      "system_event_history": {
+        "name": "Historik över systemhändelser"
       }
     },
     "update": {

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -153,7 +153,7 @@ Status labels:
 | PLC FFT MQTT bootstrap | `GET` | `/service/system_dashboard/api_internal/dashboard/fft_scan?serial_number=<gateway_sn>&mode=<mode>` | dashboard-read headers; response contains short-lived AWS IoT credentials | Browser capture only |
 | Generator/live MQTT bootstrap | `GET` | `/admin/aws_sigv4/livestream?serial_num=<gateway_sn>` | authenticated session cookies; response contains short-lived AWS IoT credentials | Browser capture only |
 | Site lifetime energy | `GET` | `/pv/systems/<site_id>/lifetime_energy` | `e-auth-token` + cookies | Runtime |
-| Homeowner events | `GET` | `/service/events-platform-service/v1.0/<site_id>/events/homeowner` | `e-auth-token` + cookies | Not implemented |
+| Homeowner events | `GET` | `/service/events-platform-service/v1.0/<site_id>/events/homeowner` | `e-auth-token` + cookies | Runtime |
 | Battery backup history | `GET` | `/app-api/<site_id>/battery_backup_history.json` | `e-auth-token` + cookies | Runtime |
 | Grid eligibility | `GET` | `/app-api/<site_id>/grid_control_check.json` | `e-auth-token` + cookies | Runtime |
 | Dry contact settings | `GET` | `/pv/settings/<site_id>/dry_contacts` | `e-auth-token` + cookies | Runtime |
@@ -3513,9 +3513,13 @@ Inference:
 - The event-history feed provides stable SG Ready transition keys even when the human-readable descriptions are localized, so it is useful for documenting `MODE_2` versus `MODE_3` semantics without relying on translated text.
 
 Implementation note:
-- The integration does not fetch this homeowner feed for entities. It uses the
-  cleaner System Dashboard event table described below and keeps the HEMS
-  per-device event JSON routes in `2.20` for diagnostics.
+- The integration exposes this feed through the site-level `System Event History`
+  calendar on the Enphase Cloud device. Calendar range requests paginate from the
+  newest row until the requested start date or a 2,000-row safety bound is reached.
+  Raw IDs, serials, impacted-device lists, message parameters, CSV links, and
+  continuation cursors are discarded after descriptions and recommended actions
+  are sanitized. The separate System Dashboard table below remains authoritative
+  for Active System Events and standing-alarm monitoring.
 
 ### 2.10.1 System Dashboard Active Events
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -101,6 +101,8 @@ Runtime managers keep endpoint-family behavior out of the main coordinator:
 - `inventory_runtime.py` handles topology, type buckets, HEMS inventory, and system-dashboard payloads.
 - `heatpump_runtime.py` handles HEMS heat-pump runtime state, daily consumption, and diagnostics snapshots.
 - `current_power_runtime.py`, `evse_feature_flags_runtime.py`, `auth_refresh_runtime.py`, and `ac_battery_runtime.py` handle smaller endpoint families.
+- `system_events.py` independently manages active System Dashboard events and the
+  bounded, on-demand homeowner event-history cache used by the Cloud calendar.
 
 These managers should own cache lifetimes, stale data decisions, and endpoint-specific parsing for their family. The coordinator should expose their normalized state through properties and helper methods.
 

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -1086,6 +1086,12 @@ def test_request_label_formats_path_and_query() -> None:
         api._request_label("get", "https://example.test/path?foo=1")
         == "GET /path?foo=1"
     )
+    label = api._request_label(
+        "get",
+        "https://example.test/path?next=private:cursor:795:-1&foo=1",
+    )
+    assert label == "GET /path?next=[redacted]&foo=1"
+    assert "private:cursor:795:-1" not in label
 
 
 def test_request_label_handles_bad_method_and_raw_url_fallback(monkeypatch) -> None:
@@ -8528,6 +8534,90 @@ async def test_system_dashboard_events_rejects_invalid_shapes_and_unexpected_err
     client._json = AsyncMock(side_effect=RuntimeError("boom"))
     with pytest.raises(RuntimeError, match="boom"):
         await client.system_dashboard_events()
+
+
+@pytest.mark.asyncio
+async def test_homeowner_events_page_uses_cursor_locale_and_history_headers() -> None:
+    client = _make_client()
+    client.update_credentials(
+        cookie="enlighten_manager_token_production=BEAR; XSRF-TOKEN=xsrf",
+        eauth="EAUTH",
+    )
+    client._json = AsyncMock(return_value={"events": [], "next": "private cursor"})
+
+    result = await client.homeowner_events_page(
+        next_cursor="private cursor",
+        page_size=500,
+        locale="en-AU",
+    )
+
+    assert result == {"events": [], "next": "private cursor"}
+    args, kwargs = client._json.await_args
+    assert args[0] == "GET"
+    url = URL(args[1])
+    assert url.path.endswith(
+        "/service/events-platform-service/v1.0/SITE/events/homeowner"
+    )
+    assert dict(url.query) == {
+        "next": "private cursor",
+        "page_size": "200",
+        "locale": "en-AU",
+    }
+    assert kwargs["headers"]["Accept"] == "application/json"
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert kwargs["headers"]["X-Requested-With"] == "XMLHttpRequest"
+    assert kwargs["headers"]["e-auth-token"] == "EAUTH"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    (
+        [],
+        {},
+        {"events": "invalid"},
+        {"events": [], "next": {}},
+        {"events": [], "next": ""},
+    ),
+)
+async def test_homeowner_events_page_rejects_invalid_shapes(payload) -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value=payload)
+
+    assert await client.homeowner_events_page() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error",
+    (
+        api.Unauthorized(),
+        _make_cre(403),
+        _make_cre(404),
+        api.InvalidPayloadError("invalid", status=200),
+    ),
+)
+async def test_homeowner_events_page_optional_errors_return_none(error) -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=error)
+
+    assert await client.homeowner_events_page() is None
+
+
+@pytest.mark.asyncio
+async def test_homeowner_events_page_preserves_login_wall_failure() -> None:
+    client = _make_client()
+    error = api.EnphaseLoginWallUnauthorized(
+        endpoint="/service/events-platform-service/v1.0/SITE/events/homeowner",
+        request_label="GET homeowner events",
+        status=401,
+        content_type="text/html",
+        body_preview_redacted="login",
+    )
+    client._json = AsyncMock(side_effect=error)
+
+    with pytest.raises(api.EnphaseLoginWallUnauthorized):
+        await client.homeowner_events_page()
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_calendar_module.py
+++ b/tests/components/enphase_ev/test_calendar_module.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
 from custom_components.enphase_ev import DOMAIN
 from custom_components.enphase_ev.calendar import (
     BackupHistoryCalendarEntity,
+    SystemEventHistoryCalendarEntity,
     async_setup_entry,
 )
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
+from custom_components.enphase_ev.system_events import SystemEventHistoryEntry
 
 
 def test_site_has_battery_helper_defaults_and_strict() -> None:
@@ -140,6 +143,209 @@ async def test_async_setup_entry_skips_backup_history_calendar_without_battery(
     await async_setup_entry(hass, config_entry, _capture)
 
     assert not any(isinstance(ent, BackupHistoryCalendarEntity) for ent in added)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_system_event_history_after_first_success(
+    hass, config_entry, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = False  # noqa: SLF001
+    coord.system_events_runtime._history_last_success_utc = datetime.now(
+        timezone.utc
+    )  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    added: list[object] = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    assert (
+        len(
+            [
+                entity
+                for entity in added
+                if isinstance(entity, SystemEventHistoryCalendarEntity)
+            ]
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_system_event_history_calendar_retains_registry_then_suppresses(
+    hass, config_entry, coordinator_factory
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    coord = coordinator_factory()
+    coord._battery_has_encharge = False  # noqa: SLF001
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord.system_events_runtime._history_last_success_utc = datetime.now(
+        timezone.utc
+    )  # noqa: SLF001
+    callbacks: list = []
+    coord.async_add_listener = lambda callback: (  # type: ignore[method-assign]
+        callbacks.append(callback) or (lambda: None)
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    ent_reg = er.async_get(hass)
+    existing = ent_reg.async_get_or_create(
+        "calendar",
+        DOMAIN,
+        f"{DOMAIN}_site_{coord.site_id}_system_event_history",
+        config_entry=config_entry,
+    )
+    added: list[object] = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    assert ent_reg.async_get(existing.entity_id) is not None
+    history_entity = next(
+        entity
+        for entity in added
+        if isinstance(entity, SystemEventHistoryCalendarEntity)
+    )
+    assert history_entity.available is True
+    coord._endpoint_family_state("system_event_history").support_state = "suppressed"
+    callbacks[0]()
+    assert ent_reg.async_get(existing.entity_id) is None
+    assert history_entity.available is False
+
+
+def test_system_event_history_calendar_metadata_and_availability(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    entity = SystemEventHistoryCalendarEntity(coord)
+
+    assert entity.translation_key == "system_event_history"
+    assert entity.unique_id == f"{DOMAIN}_site_{coord.site_id}_system_event_history"
+    assert entity.available is False
+    assert entity.event is None
+    assert entity.device_info["identifiers"] == {
+        (DOMAIN, f"type:{coord.site_id}:cloud")
+    }
+
+    coord.system_events_runtime._history_last_success_utc = datetime.now(
+        timezone.utc
+    )  # noqa: SLF001
+    assert entity.available is True
+
+    coord._endpoint_family_state("system_event_history").support_state = "suppressed"
+    assert entity.available is False
+
+
+def test_system_event_history_calendar_device_info_fallback(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import calendar as calendar_mod
+
+    coord = coordinator_factory()
+    monkeypatch.setattr(calendar_mod, "_type_device_info", lambda *_args: None)
+
+    assert SystemEventHistoryCalendarEntity(coord).device_info == {
+        "identifiers": {(DOMAIN, f"type:{coord.site_id}:cloud")},
+        "manufacturer": "Enphase",
+    }
+
+
+@pytest.mark.asyncio
+async def test_system_event_history_calendar_get_events_and_naive_range(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    entry = SystemEventHistoryEntry(
+        fingerprint="safe",
+        summary="Charging started",
+        description="No action is required.",
+        start=datetime(2026, 2, 1, 8, 0, tzinfo=timezone.utc),
+        end=datetime(2026, 2, 1, 8, 1, tzinfo=timezone.utc),
+    )
+    coord.system_events_runtime.async_history_events = AsyncMock(return_value=(entry,))
+    entity = SystemEventHistoryCalendarEntity(coord)
+
+    events = await entity.async_get_events(
+        None,
+        datetime(2026, 2, 1, 0, 0),
+        datetime(2026, 2, 2, 0, 0),
+    )
+
+    assert len(events) == 1
+    assert events[0].summary == "Charging started"
+    assert events[0].description == "No action is required."
+    assert events[0].start == entry.start
+    assert events[0].end == entry.end
+    coord.system_events_runtime.async_history_events.assert_awaited_once()
+
+    assert (
+        await entity.async_get_events(
+            None,
+            datetime(2026, 2, 2, tzinfo=timezone.utc),
+            datetime(2026, 2, 1, tzinfo=timezone.utc),
+        )
+        == []
+    )
+
+
+def test_system_event_history_calendar_summary_fallbacks(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    entity = SystemEventHistoryCalendarEntity(coord)
+    entry = SystemEventHistoryEntry(
+        fingerprint="safe",
+        summary=None,
+        description=None,
+        start=datetime(2026, 2, 1, 8, 0, tzinfo=timezone.utc),
+        end=datetime(2026, 2, 1, 8, 1, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        SystemEventHistoryCalendarEntity,
+        "name",
+        property(lambda self: " System Event History "),
+    )
+    assert (
+        entity._to_calendar_event(entry).summary == "System Event History"
+    )  # noqa: SLF001
+
+    monkeypatch.setattr(
+        SystemEventHistoryCalendarEntity,
+        "name",
+        property(lambda self: "   "),
+    )
+    monkeypatch.setattr(
+        SystemEventHistoryCalendarEntity,
+        "entity_id",
+        property(lambda self: " calendar.system_event_history "),
+        raising=False,
+    )
+    assert (  # noqa: SLF001
+        entity._to_calendar_event(entry).summary == "calendar.system_event_history"
+    )
+
+    def _raise_name(_self):
+        raise RuntimeError
+
+    monkeypatch.setattr(
+        SystemEventHistoryCalendarEntity,
+        "name",
+        property(_raise_name),
+    )
+    monkeypatch.setattr(
+        SystemEventHistoryCalendarEntity,
+        "entity_id",
+        property(lambda self: None),
+        raising=False,
+    )
+    assert entity._to_calendar_event(entry).summary == entity.unique_id  # noqa: SLF001
 
 
 def test_backup_history_calendar_available_gating(coordinator_factory) -> None:

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -300,6 +300,8 @@ class _RefreshOwner:
         self.system_events_runtime = SimpleNamespace(
             refresh_due=lambda: True,
             async_refresh=lambda: self._record("system_events"),
+            history_refresh_due=lambda: False,
+            async_refresh_history=lambda: self._record("system_event_history"),
         )
         self.battery_runtime = SimpleNamespace(
             async_refresh_grid_control_check=self._async_refresh_grid_control_check,
@@ -525,6 +527,8 @@ def test_refresh_plans_bind_dynamic_followup_and_warmup_calls() -> None:
     assert bound_warmup.stages[0].parallel_calls[0][2]() == "warmup-summary"
     assert bound_warmup.stages[1].parallel_calls[0][0] == "system_events_s"
     assert bound_warmup.stages[1].parallel_calls[0][2]() == "system_events"
+    assert bound_warmup.stages[1].parallel_calls[1][0] == "system_event_history_s"
+    assert bound_warmup.stages[1].parallel_calls[1][2]() == "system_event_history"
     assert "tariff_s" in [call[0] for call in bound_warmup.stages[1].parallel_calls]
     assert bound_warmup.stages[2].ordered_calls[0][2]() == "heatpump-runtime"
     assert bound_warmup.stages[3].parallel_calls[0][2]() == "warmup-site-energy"
@@ -557,6 +561,7 @@ def test_warmup_plan_filters_unselected_devices_and_disabled_features() -> None:
 
     assert "evse_summary_s" in keys
     assert "system_events_s" in keys
+    assert "system_event_history_s" in keys
     assert "tariff_s" in keys
     assert "devices_inventory_s" in keys
     assert "evse_timeseries_s" in keys
@@ -724,6 +729,38 @@ def test_dynamic_followup_plan_includes_due_evse_feature_flags() -> None:
     assert len(plan.stages) == 1
     assert [task.timing_key for task in plan.stages[0].parallel_tasks] == [
         "evse_feature_flags_s",
+    ]
+
+
+def test_dynamic_followup_plan_includes_due_system_event_history() -> None:
+    owner = _RefreshOwner()
+    owner.system_events_runtime.history_refresh_due = lambda: True
+    for method_name in (
+        "battery_site_settings_refresh_due",
+        "battery_backup_history_refresh_due",
+        "battery_settings_refresh_due",
+        "battery_schedules_refresh_due",
+        "storm_guard_refresh_due",
+        "storm_alert_refresh_due",
+        "grid_control_check_refresh_due",
+        "grid_mode_status_refresh_due",
+        "grid_outage_context_refresh_due",
+        "dry_contact_settings_refresh_due",
+        "battery_status_refresh_due",
+        "ac_battery_devices_refresh_due",
+    ):
+        setattr(owner.battery_runtime, method_name, lambda: False)
+    owner.inventory_runtime.devices_inventory_refresh_due = lambda: False
+    owner.inventory_runtime.hems_devices_refresh_due = lambda: False
+    owner.current_power_runtime.refresh_due = lambda: False
+    owner.evse_feature_flags_runtime.refresh_due = lambda: False
+    owner.system_events_runtime.refresh_due = lambda: False
+    owner.tariff_runtime.refresh_due = lambda: False
+
+    plan = build_followup_plan(owner)
+
+    assert [task.timing_key for task in plan.stages[0].parallel_tasks] == [
+        "system_event_history_s"
     ]
 
 

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -768,7 +768,13 @@ async def test_config_entry_diagnostics_includes_coordinator(
             "active_count": 1,
             "high_impact_count": 1,
             "device_type_counts": {"IQ Gateway": 1},
-        }
+        },
+        history_diagnostics=lambda: {
+            "available": True,
+            "cached_range_count": 1,
+            "cached_event_count": 3,
+            "truncated": False,
+        },
     )
     coord.current_power_runtime = SimpleNamespace(
         diagnostics=lambda: {
@@ -1053,6 +1059,12 @@ async def test_config_entry_diagnostics_includes_coordinator(
         "high_impact_count": 1,
         "device_type_counts": {"IQ Gateway": 1},
     }
+    assert diag["coordinator"]["system_event_history"] == {
+        "available": True,
+        "cached_range_count": 1,
+        "cached_event_count": 3,
+        "truncated": False,
+    }
 
 
 @pytest.mark.asyncio
@@ -1068,6 +1080,22 @@ async def test_config_entry_diagnostics_handles_system_events_capture_error(
     diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
 
     assert diag["coordinator"]["system_events"] == {}
+
+
+@pytest.mark.asyncio
+async def test_config_entry_diagnostics_handles_system_event_history_capture_error(
+    hass, config_entry
+) -> None:
+    coord = DummyCoordinator()
+    coord.system_events_runtime = SimpleNamespace(
+        diagnostics=lambda: {},
+        history_diagnostics=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
+
+    assert diag["coordinator"]["system_event_history"] == {}
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_log_redaction.py
+++ b/tests/components/enphase_ev/test_log_redaction.py
@@ -20,7 +20,8 @@ def test_identifier_helpers_redact_values() -> None:
 def test_redact_text_scrubs_common_sensitive_values() -> None:
     text = (
         "site_id=12345&source=evse serialNumber=SERIAL-12345678 uid=DEVICE-UID-9999 "
-        "email=user@example.com ip=10.0.0.2 mac=AA:BB:CC:DD:EE:FF plain 12345"
+        "email=user@example.com ip=10.0.0.2 mac=AA:BB:CC:DD:EE:FF "
+        "next=private:cursor:795:-1 plain 12345"
     )
 
     redacted = redact_text(
@@ -35,10 +36,12 @@ def test_redact_text_scrubs_common_sensitive_values() -> None:
     assert "user@example.com" not in redacted
     assert "10.0.0.2" not in redacted
     assert "AA:BB:CC:DD:EE:FF" not in redacted
+    assert "private:cursor:795:-1" not in redacted
     assert "site_id=[site]" in redacted
     assert "source=evse" in redacted
     assert "serialNumber=SERI...5678" in redacted
     assert "uid=DEVI...9999" in redacted
+    assert "next=[redacted]" in redacted
     assert redacted.count("[redacted]") >= 3
 
 

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -872,6 +872,7 @@ def test_battery_settings_entity_strings_exist_for_all_locales() -> None:
         "entity.time.charge_from_grid_start_time.name",
         "entity.time.charge_from_grid_end_time.name",
         "entity.calendar.backup_history.name",
+        "entity.calendar.system_event_history.name",
     ]
     for locale in translations_dir.glob("*.json"):
         data = json.loads(locale.read_text(encoding="utf-8"))

--- a/tests/components/enphase_ev/test_system_events.py
+++ b/tests/components/enphase_ev/test_system_events.py
@@ -2,16 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.enphase_ev.api import OptionalEndpointUnavailable
+from custom_components.enphase_ev.api import (
+    EnphaseLoginWallUnauthorized,
+    OptionalEndpointUnavailable,
+)
 from custom_components.enphase_ev.const import DOMAIN, OPT_SYSTEM_EVENT_REPAIR_ISSUES
 from custom_components.enphase_ev.system_events import (
     ACTIVE_EVENTS_ATTRIBUTE_LIMIT,
+    SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY,
     SYSTEM_EVENTS_ENDPOINT_FAMILY,
     SYSTEM_EVENT_REPAIR_CHECKPOINT_INTERVAL,
     SYSTEM_EVENT_REPAIR_MISSING_GRACE,
@@ -20,11 +25,14 @@ from custom_components.enphase_ev.system_events import (
     _catalog_label,
     _event_fingerprint,
     _event_is_active,
+    _event_is_informational,
+    _history_epoch,
     _lookup_catalog,
     _normalized,
     _text,
     _timestamp,
     parse_active_system_events,
+    parse_homeowner_event_history,
     parse_standing_alarms,
 )
 
@@ -169,6 +177,170 @@ def test_event_parser_handles_malformed_and_direct_severity_shapes() -> None:
     assert state_severity[0].high_impact is True
 
 
+def test_event_parser_excludes_explicit_informational_rows() -> None:
+    payload = {
+        "events": [
+            {
+                "id": "severity-info",
+                "event_type": "Routine update",
+                "event_state": "open",
+                "event_severity": 1,
+            },
+            {
+                "id": "type-info",
+                "event_type": "Informational",
+                "event_state": "open",
+            },
+            {
+                "id": "state-info",
+                "event_type": "Routine update",
+                "event_state": "Info",
+                "severity": "critical",
+            },
+            {
+                "id": "warning",
+                "event_type": "Warning",
+                "event_state": "open",
+                "severity": "warning",
+            },
+            {
+                "id": "critical",
+                "event_type": "Critical fault",
+                "event_state": "open",
+                "severity": "critical",
+            },
+        ],
+        "event_severities": [{"id": 1, "name": "Info"}],
+    }
+
+    events = parse_active_system_events(payload, site_id="1")
+
+    assert [event.event_type for event in events] == ["Warning", "Critical fault"]
+    assert [event.high_impact for event in events] == [False, True]
+    assert _event_is_informational(
+        {}, severity="informational", event_type="fault", state="open"
+    )
+    assert not _event_is_informational(
+        {}, severity="warning", event_type="Information unavailable", state="open"
+    )
+
+
+def test_homeowner_history_parser_normalizes_redacts_and_preserves_all_classes() -> (
+    None
+):
+    payload = {
+        "events": [
+            {
+                "id": "info-event",
+                "status": "Info",
+                "type": "IQ EV Charger",
+                "description": (
+                    "Charging started on IQ EV Charger "
+                    "(SNo. EV1234567890) at site 1234567."
+                ),
+                "event_start_date": 1770000100,
+                "event_clear_date": 1770000100,
+                "serial_num": "EV1234567890",
+                "devices_impacted": ["IQ EV Charger (SNo. EV1234567890)"],
+                "event_key": "evse_start_charging",
+                "recommended_action": "Check EV1234567890 if charging stops.",
+                "message_params": "private mode details",
+            },
+            {
+                "id": "warning-event",
+                "status": "Warning",
+                "type": "IQ Gateway",
+                "event_date": 1770000000,
+                "event_clear_date": 1770000060,
+                "event_key": "gateway_warning",
+            },
+            {
+                "id": "warning-event",
+                "event_date": 1770000000,
+                "description": "duplicate",
+            },
+            {"id": "invalid"},
+            "invalid-row",
+        ]
+    }
+
+    events = parse_homeowner_event_history(payload, site_id="1234567")
+
+    assert events is not None
+    assert len(events) == 2
+    assert [event.summary for event in events] == [
+        "IQ Gateway",
+        "Charging started on IQ EV Charger (SNo. EV12...7890) at site [site].",
+    ]
+    assert events[0].end - events[0].start == timedelta(minutes=1)
+    assert events[1].end - events[1].start == timedelta(minutes=1)
+    assert events[1].description == "Check EV12...7890 if charging stops."
+    assert "EV1234567890" not in repr(events)
+    assert "private mode details" not in repr(events)
+    assert parse_homeowner_event_history(None, site_id="1") is None
+    assert parse_homeowner_event_history({"events": {}}, site_id="1") is None
+    assert _history_epoch(True) is None
+    assert _history_epoch("not-a-time") is None
+    assert _history_epoch(1770000000000) == datetime.fromtimestamp(
+        1770000000, tz=timezone.utc
+    )
+
+    fallback = parse_homeowner_event_history(
+        {
+            "events": [
+                {
+                    "event_key": "fallback_event_key",
+                    "event_date": 1770000000,
+                    "serial_num": "SERIAL-1",
+                    "devices_impacted": [None, "IQ Device without serial"],
+                }
+            ]
+        },
+        site_id="1",
+    )
+    assert fallback is not None
+    assert fallback[0].summary == "Fallback event key"
+
+    no_summary = parse_homeowner_event_history(
+        {"events": [{"event_date": 1770000000}]},
+        site_id="1",
+    )
+    assert no_summary is not None
+    assert no_summary[0].summary is None
+
+    incomplete_metadata = parse_homeowner_event_history(
+        {
+            "events": [
+                {
+                    "event_date": 1770000000,
+                    "description": "Device (SNo. EV1234567890) reported an event.",
+                },
+                {
+                    "event_date": 1770000060,
+                    "type": "Serial: TYPE1234567890",
+                },
+                {
+                    "event_date": 1770000120,
+                    "recommended_action": (
+                        "Inspect serial number ACTION1234567890 before continuing."
+                    ),
+                },
+            ]
+        },
+        site_id="1",
+    )
+    assert incomplete_metadata is not None
+    assert len(incomplete_metadata) == 3
+    assert all(
+        identifier not in repr(incomplete_metadata)
+        for identifier in (
+            "EV1234567890",
+            "TYPE1234567890",
+            "ACTION1234567890",
+        )
+    )
+
+
 def test_standing_alarm_parser_normalizes_redacts_and_deduplicates() -> None:
     alarms = parse_standing_alarms(_standing_alarm_payload(), site_id="1234567")
 
@@ -225,6 +397,7 @@ def _runtime_coordinator(
     *,
     payload: object = None,
     alarm_payload: object = _DEFAULT_ALARMS,
+    history_payload: object | None = None,
     due: bool = True,
     entry_id: str | None = "Entry-ID",
     repairs_enabled: bool = True,
@@ -246,13 +419,383 @@ def _runtime_coordinator(
         client=SimpleNamespace(
             system_dashboard_events=AsyncMock(return_value=payload),
             system_dashboard_standing_alarms=AsyncMock(return_value=alarm_payload),
+            homeowner_events_page=AsyncMock(return_value=history_payload),
         ),
-        _endpoint_family_should_run=lambda family: (
-            family == SYSTEM_EVENTS_ENDPOINT_FAMILY and due
-        ),
+        _endpoint_family_should_run=lambda family: due,
+        _endpoint_family_wait_active=lambda family: False,
+        _endpoint_family_can_use_stale=lambda family: True,
         _endpoint_family_state=lambda family: health,
+        _note_endpoint_family_failure=MagicMock(),
         _note_endpoint_family_success=MagicMock(),
     )
+
+
+@pytest.mark.asyncio
+async def test_runtime_probes_homeowner_history_and_reports_safe_diagnostics(
+    hass,
+) -> None:
+    coordinator = _runtime_coordinator(
+        hass,
+        history_payload={
+            "events": [
+                {
+                    "id": "private-id",
+                    "event_date": 1770000000,
+                    "description": "Routine event",
+                }
+            ],
+            "next": "private-cursor",
+        },
+    )
+    runtime = SystemEventsRuntime(coordinator)
+
+    await runtime.async_refresh_history()
+
+    assert runtime.history_available is True
+    assert runtime.history_refresh_due() is True
+    coordinator.client.homeowner_events_page.assert_awaited_once_with(
+        next_cursor="start",
+        page_size=200,
+        locale=hass.config.language,
+    )
+    coordinator._note_endpoint_family_success.assert_called_once_with(
+        SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+    )
+    diagnostics = runtime.history_diagnostics()
+    assert diagnostics == {
+        "available": True,
+        "cached_range_count": 0,
+        "cached_event_count": 0,
+        "last_success_utc": runtime._history_last_success_utc.isoformat(),  # noqa: SLF001
+        "using_cached_data": False,
+        "truncated": False,
+    }
+    assert "private" not in repr(diagnostics)
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_probe_handles_skip_and_optional_failures(hass) -> None:
+    coordinator = _runtime_coordinator(hass, due=False)
+    runtime = SystemEventsRuntime(coordinator)
+    await runtime.async_refresh_history()
+    coordinator.client.homeowner_events_page.assert_not_awaited()
+
+    coordinator._endpoint_family_should_run = lambda family: True
+    coordinator.client.homeowner_events_page = None
+    await runtime.async_refresh_history()
+
+    coordinator.client.homeowner_events_page = AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+    await runtime.async_refresh_history()
+    coordinator._note_endpoint_family_failure.assert_called_once()
+
+    coordinator.client.homeowner_events_page = AsyncMock(return_value=None)
+    await runtime.async_refresh_history()
+    assert coordinator._note_endpoint_family_failure.call_count == 2
+
+    coordinator.client.homeowner_events_page = AsyncMock(
+        side_effect=EnphaseLoginWallUnauthorized(
+            endpoint="/events/homeowner",
+            request_label="GET homeowner events",
+        )
+    )
+    with pytest.raises(EnphaseLoginWallUnauthorized):
+        await runtime.async_refresh_history()
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_paginates_filters_and_caches_range(hass) -> None:
+    coordinator = _runtime_coordinator(hass)
+    coordinator.client.homeowner_events_page = AsyncMock(
+        side_effect=[
+            {
+                "events": [
+                    {
+                        "id": "newer",
+                        "event_date": 1770000300,
+                        "description": "Newer informational event",
+                    },
+                    {
+                        "id": "in-range",
+                        "event_date": 1770000200,
+                        "description": "In range warning event",
+                    },
+                ],
+                "next": "private-next-cursor",
+            },
+            {
+                "events": [
+                    {
+                        "id": "older",
+                        "event_date": 1770000000,
+                        "description": "Older event",
+                    }
+                ],
+                "next": None,
+            },
+        ]
+    )
+    runtime = SystemEventsRuntime(coordinator)
+    start = datetime.fromtimestamp(1770000100, tz=timezone.utc)
+    end = datetime.fromtimestamp(1770000400, tz=timezone.utc)
+
+    events = await runtime.async_history_events(start, end)
+    cached_events = await runtime.async_history_events(start, end)
+
+    assert [event.summary for event in events] == [
+        "In range warning event",
+        "Newer informational event",
+    ]
+    assert cached_events == events
+    assert coordinator.client.homeowner_events_page.await_count == 2
+    assert (
+        coordinator.client.homeowner_events_page.await_args_list[1].kwargs[
+            "next_cursor"
+        ]
+        == "private-next-cursor"
+    )
+    diagnostics = runtime.history_diagnostics()
+    assert diagnostics["cached_range_count"] == 1
+    assert diagnostics["cached_event_count"] == 2
+    assert diagnostics["truncated"] is False
+    assert "private-next-cursor" not in repr(
+        runtime._history_range_cache
+    )  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_marks_repeated_cursor_and_row_cap_truncated(
+    hass, monkeypatch
+) -> None:
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.SYSTEM_EVENT_HISTORY_ROW_LIMIT",
+        2,
+    )
+    coordinator = _runtime_coordinator(hass)
+    coordinator.client.homeowner_events_page = AsyncMock(
+        return_value={
+            "events": [
+                {"id": "1", "event_date": 1770000200},
+                {"id": "2", "event_date": 1770000100},
+            ],
+            "next": "more-private-data",
+        }
+    )
+    runtime = SystemEventsRuntime(coordinator)
+
+    events = await runtime.async_history_events(
+        datetime.fromtimestamp(1769990000, tz=timezone.utc),
+        datetime.fromtimestamp(1770010000, tz=timezone.utc),
+    )
+
+    assert len(events) == 2
+    assert runtime.history_diagnostics()["truncated"] is True
+    assert "more-private-data" not in repr(runtime.history_diagnostics())
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_bounds_oversized_page(hass, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.SYSTEM_EVENT_HISTORY_ROW_LIMIT",
+        2,
+    )
+    coordinator = _runtime_coordinator(hass)
+    coordinator.client.homeowner_events_page = AsyncMock(
+        return_value={
+            "events": [
+                {"id": "1", "event_date": 1770000200},
+                {"id": "2", "event_date": 1770000100},
+                {"id": "3", "event_date": 1770000000},
+            ]
+        }
+    )
+    runtime = SystemEventsRuntime(coordinator)
+
+    events = await runtime.async_history_events(
+        datetime.fromtimestamp(1769990000, tz=timezone.utc),
+        datetime.fromtimestamp(1770010000, tz=timezone.utc),
+    )
+
+    assert len(events) == 2
+    assert runtime.history_diagnostics()["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_rejects_non_list_rows(hass) -> None:
+    coordinator = _runtime_coordinator(hass, history_payload={"events": {}})
+    runtime = SystemEventsRuntime(coordinator)
+
+    assert (
+        await runtime.async_history_events(
+            datetime.fromtimestamp(1769990000, tz=timezone.utc),
+            datetime.fromtimestamp(1770010000, tz=timezone.utc),
+        )
+        == ()
+    )
+    coordinator._note_endpoint_family_failure.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_marks_page_cap_and_repeated_cursor_truncated(
+    hass, monkeypatch
+) -> None:
+    coordinator = _runtime_coordinator(hass)
+    runtime = SystemEventsRuntime(coordinator)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.SYSTEM_EVENT_HISTORY_MAX_PAGES",
+        0,
+    )
+    await runtime.async_history_events(
+        datetime.fromtimestamp(1769990000, tz=timezone.utc),
+        datetime.fromtimestamp(1770010000, tz=timezone.utc),
+    )
+    assert runtime.history_diagnostics()["truncated"] is True
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.SYSTEM_EVENT_HISTORY_MAX_PAGES",
+        100,
+    )
+    runtime._history_range_cache.clear()  # noqa: SLF001
+    coordinator.client.homeowner_events_page = AsyncMock(
+        return_value={
+            "events": [{"id": "1", "event_date": 1770000200}],
+            "next": "start",
+        }
+    )
+    await runtime.async_history_events(
+        datetime.fromtimestamp(1770000000, tz=timezone.utc),
+        datetime.fromtimestamp(1770010000, tz=timezone.utc),
+    )
+    assert runtime.history_diagnostics()["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_cache_eviction_inner_hit_cooldown_and_missing_fetcher(
+    hass, monkeypatch
+) -> None:
+    coordinator = _runtime_coordinator(hass)
+    runtime = SystemEventsRuntime(coordinator)
+    now = 1000.0
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.time.monotonic", lambda: now
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.SYSTEM_EVENT_HISTORY_CACHE_MAX_RANGES",
+        1,
+    )
+    first_start = datetime.fromtimestamp(1770000000, tz=timezone.utc)
+    first_end = datetime.fromtimestamp(1770000200, tz=timezone.utc)
+    first_key = runtime._history_cache_key(first_start, first_end, "en")  # noqa: SLF001
+    runtime._store_history_range(first_key, (), truncated=False)  # noqa: SLF001
+    second_key = runtime._history_cache_key(  # noqa: SLF001
+        first_start + timedelta(days=1),
+        first_end + timedelta(days=1),
+        "en",
+    )
+    runtime._store_history_range(second_key, (), truncated=False)  # noqa: SLF001
+    assert list(runtime._history_range_cache) == [second_key]  # noqa: SLF001
+
+    runtime._history_range_cache.clear()  # noqa: SLF001
+
+    class _PopulateCacheLock:
+        async def __aenter__(self):
+            runtime._store_history_range(first_key, (), truncated=True)  # noqa: SLF001
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    runtime._history_lock = _PopulateCacheLock()  # type: ignore[assignment]  # noqa: SLF001
+    assert await runtime.async_history_events(first_start, first_end) == ()
+    assert runtime.history_diagnostics()["truncated"] is True
+
+    runtime._history_lock = asyncio.Lock()  # noqa: SLF001
+    now += 901
+    coordinator._endpoint_family_state(
+        SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+    ).consecutive_failures = 1
+    coordinator._endpoint_family_wait_active = lambda family: True
+    runtime._history_truncated = False  # noqa: SLF001
+    assert await runtime.async_history_events(first_start, first_end) == ()
+    assert runtime.history_diagnostics()["using_cached_data"] is True
+    assert runtime.history_diagnostics()["truncated"] is True
+
+    coordinator._endpoint_family_can_use_stale = lambda family: False
+    runtime._history_last_success_utc = datetime.now(timezone.utc)  # noqa: SLF001
+    runtime._history_truncated = True  # noqa: SLF001
+    assert await runtime.async_history_events(first_start, first_end) == ()
+    assert runtime.history_diagnostics()["using_cached_data"] is False
+    assert runtime.history_diagnostics()["truncated"] is False
+
+    runtime._history_range_cache.clear()  # noqa: SLF001
+    coordinator._endpoint_family_state(
+        SYSTEM_EVENT_HISTORY_ENDPOINT_FAMILY
+    ).consecutive_failures = 0
+    coordinator.client.homeowner_events_page = None
+    assert await runtime.async_history_events(first_start, first_end) == ()
+
+    coordinator.client.homeowner_events_page = AsyncMock(return_value=None)
+    assert await runtime.async_history_events(first_start, first_end) == ()
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_returns_expired_cache_after_failure(
+    hass, monkeypatch
+) -> None:
+    coordinator = _runtime_coordinator(hass)
+    coordinator.client.homeowner_events_page = AsyncMock(
+        return_value={
+            "events": [
+                {
+                    "id": "cached",
+                    "event_date": 1770000100,
+                    "description": "Cached event",
+                }
+            ]
+        }
+    )
+    runtime = SystemEventsRuntime(coordinator)
+    start = datetime.fromtimestamp(1770000000, tz=timezone.utc)
+    end = datetime.fromtimestamp(1770000200, tz=timezone.utc)
+    now = 1000.0
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.system_events.time.monotonic", lambda: now
+    )
+    expected = await runtime.async_history_events(start, end)
+    key = runtime._history_cache_key(start, end, "en")  # noqa: SLF001
+    runtime._store_history_range(key, expected, truncated=True)  # noqa: SLF001
+    runtime._history_truncated = False  # noqa: SLF001
+    now += 901.0
+    coordinator.client.homeowner_events_page.side_effect = RuntimeError("boom")
+
+    actual = await runtime.async_history_events(start, end)
+
+    assert actual == expected
+    assert runtime.history_diagnostics()["using_cached_data"] is True
+    assert runtime.history_diagnostics()["truncated"] is True
+    coordinator._note_endpoint_family_failure.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_runtime_history_preserves_login_wall_failure(hass) -> None:
+    coordinator = _runtime_coordinator(hass)
+    coordinator.client.homeowner_events_page = AsyncMock(
+        side_effect=EnphaseLoginWallUnauthorized(
+            endpoint="/events/homeowner",
+            request_label="GET homeowner events",
+            status=200,
+            content_type="text/html",
+        )
+    )
+    runtime = SystemEventsRuntime(coordinator)
+
+    with pytest.raises(EnphaseLoginWallUnauthorized):
+        await runtime.async_history_events(
+            datetime.fromtimestamp(1770000000, tz=timezone.utc),
+            datetime.fromtimestamp(1770000200, tz=timezone.utc),
+        )
+
+    coordinator._note_endpoint_family_failure.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Add a site-level System Event History calendar backed by the localized Enphase homeowner event feed.
- Paginate, sanitize, deduplicate, range-filter, and briefly cache history rows without retaining raw identifiers or continuation cursors.
- Exclude explicitly informational rows from Active System Events while preserving standing alarms and high-impact Problem behavior.
- Add endpoint-family backoff, safe diagnostics, localized entity names, documentation, and regression coverage.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/calendar.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/diagnostics.py custom_components/enphase_ev/log_redaction.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/system_events.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_calendar_module.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_log_redaction.py tests/components/enphase_ev/test_service_translations.py tests/components/enphase_ev/test_system_events.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/calendar.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/diagnostics.py,custom_components/enphase_ev/log_redaction.py,custom_components/enphase_ev/refresh_plan.py,custom_components/enphase_ev/system_events.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/config_flow.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Results:

- Integration tests: 3,756 passed.
- Full test suite: 3,888 passed.
- Targeted coverage: 100% across all seven touched Python modules.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- History diagnostics expose only availability, sanitized cache counts, last success, cached-data state, and truncation state.
- Raw event IDs, serials, impacted-device lists, message parameters, CSV links, and continuation cursors are not exposed through calendar state or diagnostics.
- No configuration-entry migration or user-facing option is required.
