### PR TITLE
Refactor coordinator state ownership and lifecycle

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1610,10 +1610,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
         evse_schedule_editor=evse_schedule_editor,
     )
     _record_phase("coordinator_init_s", coordinator_started)
-    coord._setup_started_mono = setup_started
-    coord._setup_phase_timings = setup_timings
     setup_milestones: dict[str, float] = {}
-    coord._setup_milestones = setup_milestones
+    begin_setup_tracking = getattr(coord, "begin_setup_tracking", None)
+    if callable(begin_setup_tracking):
+        begin_setup_tracking(setup_started, setup_timings, setup_milestones)
+    else:
+        # Compatibility for lightweight coordinators supplied by downstream tests.
+        coord._setup_started_mono = setup_started
+        coord._setup_phase_timings = setup_timings
+        coord._setup_milestones = setup_milestones
 
     async def _prime_labels() -> None:
         started = _time.monotonic()
@@ -1635,40 +1640,51 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     version_task = asyncio.create_task(
         _prime_version(), name=f"{DOMAIN}_startup_version"
     )
-    discovery_snapshot = getattr(coord, "discovery_snapshot", None)
-    restore_discovery_state = getattr(discovery_snapshot, "async_restore_state", None)
     try:
-        snapshot_started = _time.monotonic()
-        if callable(restore_discovery_state):
-            await restore_discovery_state()
-        _record_phase("snapshot_restore_s", snapshot_started)
+        bootstrap_first_refresh = getattr(coord, "async_bootstrap_first_refresh", None)
+        if callable(bootstrap_first_refresh):
+            await bootstrap_first_refresh()
+        else:
+            # Compatibility for lightweight coordinators supplied by downstream tests.
+            discovery_snapshot = getattr(coord, "discovery_snapshot", None)
+            restore_discovery_state = getattr(
+                discovery_snapshot, "async_restore_state", None
+            )
+            snapshot_started = _time.monotonic()
+            if callable(restore_discovery_state):
+                await restore_discovery_state()
+            _record_phase("snapshot_restore_s", snapshot_started)
 
-        refresh_runner = getattr(coord, "refresh_runner", None)
-        start_power = getattr(refresh_runner, "async_start_startup_power", None)
-        if callable(start_power):
-            await start_power()
+            refresh_runner = getattr(coord, "refresh_runner", None)
+            start_power = getattr(refresh_runner, "async_start_startup_power", None)
+            if callable(start_power):
+                await start_power()
 
-        first_refresh_started = _time.monotonic()
-        coord._minimal_setup_refresh_active = True
-        try:
+            first_refresh_started = _time.monotonic()
             await coord.async_config_entry_first_refresh()
-        finally:
-            coord._minimal_setup_refresh_active = False
             _record_phase("first_refresh_s", first_refresh_started)
-        setup_milestones["core_ready"] = round(_time.monotonic() - setup_started, 3)
+        mark_setup_milestone = getattr(coord, "mark_setup_milestone", None)
+        if callable(mark_setup_milestone):
+            mark_setup_milestone("core_ready")
+        else:
+            setup_milestones["core_ready"] = round(_time.monotonic() - setup_started, 3)
         await asyncio.gather(label_task, version_task)
     except BaseException:
         for task in (label_task, version_task):
             if not task.done():
                 task.cancel()
         await asyncio.gather(label_task, version_task, return_exceptions=True)
-        startup_power_task = getattr(coord, "_startup_power_task", None)
-        if (
-            isinstance(startup_power_task, asyncio.Future)
-            and not startup_power_task.done()
-        ):
-            startup_power_task.cancel()
-            await asyncio.gather(startup_power_task, return_exceptions=True)
+        cancel_startup_power = getattr(coord, "async_cancel_startup_power", None)
+        if callable(cancel_startup_power):
+            await cancel_startup_power()
+        else:  # pragma: no cover - lightweight downstream coordinator compatibility
+            startup_power_task = getattr(coord, "_startup_power_task", None)
+            if (
+                isinstance(startup_power_task, asyncio.Future)
+                and not startup_power_task.done()
+            ):
+                startup_power_task.cancel()
+                await asyncio.gather(startup_power_task, return_exceptions=True)
         raise
 
     editor_sync_started = _time.monotonic()
@@ -1740,13 +1756,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     platform_started = _time.monotonic()
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     _record_phase("platform_forward_s", platform_started)
-    setup_milestones["entities_forwarded"] = round(_time.monotonic() - setup_started, 3)
+    mark_setup_milestone = getattr(coord, "mark_setup_milestone", None)
+    if callable(mark_setup_milestone):
+        mark_setup_milestone("entities_forwarded")
+    else:
+        setup_milestones["entities_forwarded"] = round(
+            _time.monotonic() - setup_started, 3
+        )
     # Start background work only after entities have been forwarded so restored
     # topology can create entities first and warmup can fill in live state later.
     # Schedule warmup first so the bounded startup power stage gets priority over
     # other optional background work competing for the shared read limiter.
-    refresh_runner = getattr(coord, "refresh_runner", None)
-    startup_warmup = getattr(refresh_runner, "async_start_startup_warmup", None)
+    startup_warmup = getattr(coord, "async_start_startup_warmup", None)
+    if not callable(startup_warmup):
+        refresh_runner = getattr(coord, "refresh_runner", None)
+        startup_warmup = getattr(refresh_runner, "async_start_startup_warmup", None)
     if callable(startup_warmup):
         _schedule_background_task(
             startup_warmup(),
@@ -1769,9 +1793,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
             f"{DOMAIN}_schedule_sync_start",
         )
 
-    setup_timings["total_s"] = round(_time.monotonic() - setup_started, 3)
-    coord._setup_phase_timings = dict(setup_timings)
-    setup_milestones["setup_complete"] = setup_timings["total_s"]
+    total_setup_seconds = _time.monotonic() - setup_started
+    finish_setup_tracking = getattr(coord, "finish_setup_tracking", None)
+    if callable(finish_setup_tracking):
+        finish_setup_tracking(total_setup_seconds)
+    else:
+        setup_timings["total_s"] = round(total_setup_seconds, 3)
+        coord._setup_phase_timings = dict(setup_timings)
+        setup_milestones["setup_complete"] = setup_timings["total_s"]
     return True
 
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -116,7 +116,7 @@ from .const import (
 )
 from .battery_runtime import BatteryRuntime
 from .coordinator_diagnostics import CoordinatorDiagnostics
-from .current_power_runtime import CurrentPowerRuntime
+from .current_power_runtime import CurrentPowerRuntime, CurrentPowerSample
 from .discovery_snapshot import DiscoverySnapshotManager
 from .device_types import (
     normalize_type_key,
@@ -124,7 +124,10 @@ from .device_types import (
 )
 from .energy import EnergyManager
 from .evse_timeseries import EVSETimeseriesManager
-from .evse_feature_flags_runtime import EvseFeatureFlagsRuntime
+from .evse_feature_flags_runtime import (
+    EvseFeatureFlagsRuntime,
+    EvseFeatureFlagsSnapshot,
+)
 from .evse_runtime import (
     AMP_RESTART_DELAY_S,
     FAST_TOGGLE_POLL_HOLD_S,
@@ -139,6 +142,11 @@ from .grid_profile_runtime import SUPPORT_DENIED, SUPPORT_UNKNOWN, GridProfileRu
 from .heatpump_runtime import HeatpumpRuntime
 from .inventory_runtime import CoordinatorTopologySnapshot, InventoryRuntime
 from .inventory_view import InventoryView
+from .integration_snapshot import (
+    CoordinatorData,
+    IntegrationSnapshot,
+    freeze_charger_data,
+)
 from .labels import (
     battery_grid_mode_label,
     battery_profile_label as translated_battery_profile_label,
@@ -578,6 +586,154 @@ class EnphaseCoordinator(
     _storm_evse_enabled: bool | None
     _storm_alert_active: bool | None
 
+    @property
+    def integration_snapshot(self) -> IntegrationSnapshot | None:
+        """Return the last immutable aggregate state published to listeners."""
+
+        return self._integration_snapshot
+
+    @property
+    def current_power_snapshot(self) -> CurrentPowerSample:
+        """Return the current-power runtime's immutable snapshot."""
+
+        return cast(CurrentPowerSample, self.current_power_runtime.snapshot)
+
+    @property
+    def evse_feature_flags_snapshot(self) -> EvseFeatureFlagsSnapshot:
+        """Return the EVSE feature-flag runtime's immutable snapshot."""
+
+        return cast(EvseFeatureFlagsSnapshot, self.evse_feature_flags_runtime.snapshot)
+
+    def _current_power_value(self, field: str) -> object:
+        runtime = self.__dict__.get("current_power_runtime")
+        if isinstance(runtime, CurrentPowerRuntime):
+            return getattr(runtime.snapshot, field)
+        return self.__dict__.get(f"_legacy_current_power_{field}")
+
+    def _set_current_power_value(self, field: str, value: object) -> None:
+        runtime = self.__dict__.get("current_power_runtime")
+        if isinstance(runtime, CurrentPowerRuntime):
+            runtime.replace_snapshot(**{field: value})
+            return
+        self.__dict__[f"_legacy_current_power_{field}"] = value
+
+    @property
+    def _current_power_consumption_w(self) -> float | None:
+        return cast(float | None, self._current_power_value("w"))
+
+    @_current_power_consumption_w.setter
+    def _current_power_consumption_w(self, value: float | None) -> None:
+        self._set_current_power_value("w", value)
+
+    @property
+    def _current_power_consumption_sample_utc(self) -> datetime | None:
+        return cast(datetime | None, self._current_power_value("sample_utc"))
+
+    @_current_power_consumption_sample_utc.setter
+    def _current_power_consumption_sample_utc(self, value: datetime | None) -> None:
+        self._set_current_power_value("sample_utc", value)
+
+    @property
+    def _current_power_consumption_reported_units(self) -> str | None:
+        return cast(str | None, self._current_power_value("reported_units"))
+
+    @_current_power_consumption_reported_units.setter
+    def _current_power_consumption_reported_units(self, value: str | None) -> None:
+        self._set_current_power_value("reported_units", value)
+
+    @property
+    def _current_power_consumption_reported_precision(self) -> int | None:
+        return cast(int | None, self._current_power_value("reported_precision"))
+
+    @_current_power_consumption_reported_precision.setter
+    def _current_power_consumption_reported_precision(self, value: int | None) -> None:
+        self._set_current_power_value("reported_precision", value)
+
+    @property
+    def _current_power_consumption_source(self) -> str | None:
+        return cast(str | None, self._current_power_value("source"))
+
+    @_current_power_consumption_source.setter
+    def _current_power_consumption_source(self, value: str | None) -> None:
+        self._set_current_power_value("source", value)
+
+    def _feature_flags_runtime(self) -> EvseFeatureFlagsRuntime | None:
+        runtime = self.__dict__.get("evse_feature_flags_runtime")
+        return runtime if isinstance(runtime, EvseFeatureFlagsRuntime) else None
+
+    @property
+    def _evse_feature_flags_cache_until(self) -> float | None:
+        runtime = self._feature_flags_runtime()
+        if runtime is not None:
+            return runtime.cache_until_mono
+        return cast(
+            float | None,
+            self.__dict__.get("_legacy_evse_feature_flags_cache_until"),
+        )
+
+    @_evse_feature_flags_cache_until.setter
+    def _evse_feature_flags_cache_until(self, value: float | None) -> None:
+        runtime = self._feature_flags_runtime()
+        if runtime is not None:
+            runtime.cache_until_mono = value
+            return
+        self.__dict__["_legacy_evse_feature_flags_cache_until"] = value
+
+    @property
+    def _evse_feature_flags_payload(self) -> dict[str, object] | None:
+        runtime = self._feature_flags_runtime()
+        if runtime is not None:
+            payload = runtime.snapshot.payload
+            return dict(payload) if payload is not None else None
+        return cast(
+            dict[str, object] | None,
+            self.__dict__.get("_legacy_evse_feature_flags_payload"),
+        )
+
+    @_evse_feature_flags_payload.setter
+    def _evse_feature_flags_payload(self, value: dict[str, object] | None) -> None:
+        runtime = self._feature_flags_runtime()
+        if runtime is not None:
+            runtime.replace_payload(value)
+            return
+        self.__dict__["_legacy_evse_feature_flags_payload"] = value
+
+    @property
+    def _evse_site_feature_flags(self) -> dict[str, object]:
+        runtime = self._feature_flags_runtime()
+        if runtime is not None:
+            return dict(runtime.snapshot.site_feature_flags)
+        value = self.__dict__.get("_legacy_evse_site_feature_flags", {})
+        return value if isinstance(value, dict) else {}
+
+    @_evse_site_feature_flags.setter
+    def _evse_site_feature_flags(self, value: dict[str, object]) -> None:
+        runtime = self._feature_flags_runtime()
+        if runtime is not None:
+            runtime.replace_site_feature_flags(value)
+            return
+        self.__dict__["_legacy_evse_site_feature_flags"] = value
+
+    @property
+    def _evse_feature_flags_by_serial(self) -> dict[str, object]:
+        runtime = self._feature_flags_runtime()
+        if runtime is not None:
+            snapshot = runtime.snapshot
+            return {
+                str(key): dict(value)
+                for key, value in snapshot.charger_feature_flags_by_serial.items()
+            }
+        value = self.__dict__.get("_legacy_evse_feature_flags_by_serial", {})
+        return value if isinstance(value, dict) else {}
+
+    @_evse_feature_flags_by_serial.setter
+    def _evse_feature_flags_by_serial(self, value: dict[str, object]) -> None:
+        runtime = self._feature_flags_runtime()
+        if runtime is not None:
+            runtime.replace_charger_feature_flags(value)
+            return
+        self.__dict__["_legacy_evse_feature_flags_by_serial"] = value
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -587,6 +743,9 @@ class EnphaseCoordinator(
         cookie_header_session: aiohttp.ClientSession | None = None,
     ) -> None:
         self.hass = hass
+        self._integration_snapshot: IntegrationSnapshot | None = None
+        self._publication_revision = 0
+        self._runtime_publication_revisions: dict[str, int] = {}
         self.config_entry = config_entry
         self._grid_toggle_enabled = bool(
             config_entry and config_entry.options.get(OPT_GRID_TOGGLE_ENABLED, False)
@@ -920,6 +1079,66 @@ class EnphaseCoordinator(
             return
         super().__setattr__(name, value)
 
+    def _build_integration_snapshot(
+        self, data: Mapping[str, Mapping[str, object]]
+    ) -> IntegrationSnapshot:
+        """Build and retain the aggregate state used for update equality."""
+
+        current_power_runtime = self.__dict__.get("current_power_runtime")
+        current_power = (
+            current_power_runtime.snapshot
+            if isinstance(current_power_runtime, CurrentPowerRuntime)
+            else CurrentPowerSample()
+        )
+        feature_flags_runtime = self.__dict__.get("evse_feature_flags_runtime")
+        feature_flags = (
+            feature_flags_runtime.snapshot
+            if isinstance(feature_flags_runtime, EvseFeatureFlagsRuntime)
+            else EvseFeatureFlagsSnapshot(
+                payload=None,
+                site_feature_flags={},
+                charger_feature_flags_by_serial={},
+                charger_serial_count=0,
+            )
+        )
+        candidate = IntegrationSnapshot(
+            chargers=freeze_charger_data(data),
+            evse_feature_flags=feature_flags,
+            current_power=current_power,
+            runtime_revisions=tuple(
+                sorted(self._runtime_publication_revisions.items())
+            ),
+            revision=self._publication_revision,
+        )
+        previous = self._integration_snapshot
+        if previous is None or candidate != previous:
+            self._publication_revision += 1
+            candidate = IntegrationSnapshot(
+                chargers=candidate.chargers,
+                evse_feature_flags=candidate.evse_feature_flags,
+                current_power=candidate.current_power,
+                runtime_revisions=candidate.runtime_revisions,
+                revision=self._publication_revision,
+            )
+        self._integration_snapshot = candidate
+        return candidate
+
+    def async_set_updated_data(self, data: dict[str, dict[str, object]]) -> None:
+        """Publish normalized data using aggregate integration equality."""
+
+        snapshot = self._build_integration_snapshot(data)
+        super().async_set_updated_data(CoordinatorData(data, snapshot))
+
+    def publish_runtime_state_update(self, source: str) -> None:
+        """Publish a manager-owned state transition with unchanged charger data."""
+
+        source_key = str(source).strip() or "runtime"
+        self._runtime_publication_revisions[source_key] = (
+            self._runtime_publication_revisions.get(source_key, 0) + 1
+        )
+        current = self.data if isinstance(self.data, dict) else {}
+        self.async_set_updated_data(dict(current))
+
     def _ensure_coordinator_runtime(self, attr_name: str) -> object:
         """Instantiate and cache a coordinator sub-runtime (single factory for __init__ / __getattr__)."""
 
@@ -979,8 +1198,69 @@ class EnphaseCoordinator(
         raise AttributeError(f"{type(self).__name__} has no attribute {name!r}")
 
     async def _async_setup(self) -> None:
-        """Prepare lightweight state before the first refresh."""
+        """Restore coordinator-owned state and start bounded bootstrap work."""
+
         self._phase_timings = {}
+        started = time.monotonic()
+        await self.discovery_snapshot.async_restore_state()
+        self.record_setup_phase("snapshot_restore_s", started)
+        await self.refresh_runner.async_start_startup_power()
+
+    def begin_setup_tracking(
+        self,
+        started_mono: float,
+        phase_timings: dict[str, float],
+        milestones: dict[str, float],
+    ) -> None:
+        """Attach config-entry setup timing collectors to this coordinator."""
+
+        self._setup_started_mono = started_mono
+        self._setup_phase_timings = phase_timings
+        self._setup_milestones = milestones
+
+    def record_setup_phase(self, key: str, started_mono: float) -> None:
+        """Record a setup phase when config-entry setup tracking is active."""
+
+        timings = getattr(self, "_setup_phase_timings", None)
+        if isinstance(timings, dict):
+            timings[key] = round(max(0.0, time.monotonic() - started_mono), 3)
+
+    def mark_setup_milestone(self, key: str) -> None:
+        """Record elapsed setup time for a named milestone."""
+
+        started = getattr(self, "_setup_started_mono", None)
+        milestones = getattr(self, "_setup_milestones", None)
+        if isinstance(started, (int, float)) and isinstance(milestones, dict):
+            milestones[key] = round(max(0.0, time.monotonic() - started), 3)
+
+    def finish_setup_tracking(self, total_seconds: float) -> None:
+        """Finalize setup timing and milestone state."""
+
+        timings = getattr(self, "_setup_phase_timings", None)
+        if isinstance(timings, dict):
+            timings["total_s"] = round(max(0.0, total_seconds), 3)
+        milestones = getattr(self, "_setup_milestones", None)
+        if isinstance(milestones, dict):
+            milestones["setup_complete"] = round(max(0.0, total_seconds), 3)
+
+    async def async_bootstrap_first_refresh(self) -> None:
+        """Run the minimal setup refresh without exposing private setup flags."""
+
+        started = time.monotonic()
+        self._minimal_setup_refresh_active = True
+        try:
+            await self.async_config_entry_first_refresh()
+        finally:
+            self._minimal_setup_refresh_active = False
+            self.record_setup_phase("first_refresh_s", started)
+
+    async def async_cancel_startup_power(self) -> None:
+        """Cancel and await the startup-power task after failed setup."""
+
+        task = getattr(self, "_startup_power_task", None)
+        if isinstance(task, asyncio.Future) and not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
     def _build_endpoint_family_policies(self) -> dict[str, EndpointFamilyPolicy]:
         """Return cooldown/cache policies for read-only endpoint families."""
@@ -2078,8 +2358,7 @@ class EnphaseCoordinator(
         return bool(getattr(self, "_devices_inventory_ready", False))
 
     def _publish_internal_state_update(self) -> None:
-        current = self.data if isinstance(self.data, dict) else {}
-        self.async_set_updated_data(dict(current))
+        self.publish_runtime_state_update("coordinator")
 
     async def async_ensure_system_dashboard_diagnostics(self) -> None:
         await self.inventory_runtime.async_ensure_system_dashboard_diagnostics()
@@ -3499,7 +3778,9 @@ class EnphaseCoordinator(
             context.request_metrics = request_metrics
             outcome = "success"
             try:
-                return await self._async_update_data_impl(context)
+                data = await self._async_update_data_impl(context)
+                snapshot = self._build_integration_snapshot(data)
+                return CoordinatorData(data, snapshot)
             except asyncio.CancelledError:
                 outcome = "cancelled"
                 raise

--- a/custom_components/enphase_ev/current_power_runtime.py
+++ b/custom_components/enphase_ev/current_power_runtime.py
@@ -21,9 +21,9 @@ CURRENT_POWER_CACHE_TTL_S = 60.0
 CURRENT_POWER_ENDPOINT_FAMILY = "current_power"
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class CurrentPowerSample:
-    """Typed snapshot of site current-power fields mirrored on the coordinator."""
+    """Immutable site current-power snapshot owned by the runtime."""
 
     w: float | None = None
     sample_utc: datetime | None = None
@@ -31,19 +31,13 @@ class CurrentPowerSample:
     reported_precision: int | None = None
     source: str | None = None
 
-    def apply_to(self, coord: EnphaseCoordinator) -> None:
-        coord._current_power_consumption_w = self.w
-        coord._current_power_consumption_sample_utc = self.sample_utc
-        coord._current_power_consumption_reported_units = self.reported_units
-        coord._current_power_consumption_reported_precision = self.reported_precision
-        coord._current_power_consumption_source = self.source
-
 
 class CurrentPowerRuntime:
     """Fetch and cache site current power consumption from the app API."""
 
     def __init__(self, coordinator: EnphaseCoordinator) -> None:
         self.coordinator = coordinator
+        self._sample = CurrentPowerSample()
         self._cache_until_mono: float | None = None
         self.using_stale = False
         self._extreme_validator = ExtremePowerValidator()
@@ -53,6 +47,43 @@ class CurrentPowerRuntime:
         self._last_observed_sample_utc: datetime | None = None
         self._validation_state = "unavailable"
         self._validation_reason: str | None = None
+
+    @property
+    def snapshot(self) -> CurrentPowerSample:
+        """Return the current immutable power sample."""
+
+        return self._sample
+
+    def replace_snapshot(self, **changes: object) -> None:
+        """Update one or more sample fields for legacy coordinator setters."""
+
+        values: dict[str, object] = {
+            "w": self._sample.w,
+            "sample_utc": self._sample.sample_utc,
+            "reported_units": self._sample.reported_units,
+            "reported_precision": self._sample.reported_precision,
+            "source": self._sample.source,
+        }
+        values.update(changes)
+        self._sample = CurrentPowerSample(
+            w=values["w"] if isinstance(values["w"], (float, int)) else None,
+            sample_utc=(
+                values["sample_utc"]
+                if isinstance(values["sample_utc"], datetime)
+                else None
+            ),
+            reported_units=(
+                values["reported_units"]
+                if isinstance(values["reported_units"], str)
+                else None
+            ),
+            reported_precision=(
+                values["reported_precision"]
+                if isinstance(values["reported_precision"], int)
+                else None
+            ),
+            source=values["source"] if isinstance(values["source"], str) else None,
+        )
 
     def clear(self) -> None:
         """Reset cached current power consumption samples."""
@@ -66,7 +97,7 @@ class CurrentPowerRuntime:
         self._last_observed_sample_utc = None
         self._validation_state = "unavailable"
         self._validation_reason = None
-        CurrentPowerSample().apply_to(self.coordinator)
+        self._sample = CurrentPowerSample()
 
     @staticmethod
     def _parse_sample_utc(sample_time: object) -> datetime | None:
@@ -103,24 +134,18 @@ class CurrentPowerRuntime:
     def diagnostics(self) -> dict[str, object]:
         """Return a sanitized summary of current-power validation state."""
 
-        coord = self.coordinator
-        accepted_sample = getattr(coord, "_current_power_consumption_sample_utc", None)
+        accepted = self._sample
+        accepted_sample = accepted.sample_utc
         return {
-            "accepted_value_w": getattr(coord, "_current_power_consumption_w", None),
+            "accepted_value_w": accepted.w,
             "accepted_sample_utc": (
                 accepted_sample.isoformat()
                 if isinstance(accepted_sample, datetime)
                 else None
             ),
-            "accepted_reported_units": getattr(
-                coord, "_current_power_consumption_reported_units", None
-            ),
-            "accepted_reported_precision": getattr(
-                coord, "_current_power_consumption_reported_precision", None
-            ),
-            "accepted_source": getattr(
-                coord, "_current_power_consumption_source", None
-            ),
+            "accepted_reported_units": accepted.reported_units,
+            "accepted_reported_precision": accepted.reported_precision,
+            "accepted_source": accepted.source,
             "last_observed_value": self._last_observed_value,
             "last_observed_units": self._last_observed_units,
             "last_normalized_value_w": self._last_normalized_value_w,
@@ -136,17 +161,7 @@ class CurrentPowerRuntime:
         }
 
     def _cached_state_present(self) -> bool:
-        coord = self.coordinator
-        return any(
-            getattr(coord, attr, None) is not None
-            for attr in (
-                "_current_power_consumption_w",
-                "_current_power_consumption_sample_utc",
-                "_current_power_consumption_reported_units",
-                "_current_power_consumption_reported_precision",
-                "_current_power_consumption_source",
-            )
-        )
+        return self._sample != CurrentPowerSample()
 
     def refresh_due(self) -> bool:
         """Return True when current-power data can be refreshed."""
@@ -245,13 +260,13 @@ class CurrentPowerRuntime:
             coord._note_endpoint_family_success(CURRENT_POWER_ENDPOINT_FAMILY)
             return
 
-        CurrentPowerSample(
+        self._sample = CurrentPowerSample(
             w=normalized_w,
             sample_utc=sampled_at,
             reported_units=units,
             reported_precision=precision,
             source="app-api:get_latest_power",
-        ).apply_to(coord)
+        )
         self._cache_until_mono = now + CURRENT_POWER_CACHE_TTL_S
         self.using_stale = False
         coord._note_endpoint_family_success(CURRENT_POWER_ENDPOINT_FAMILY)

--- a/custom_components/enphase_ev/current_power_runtime.py
+++ b/custom_components/enphase_ev/current_power_runtime.py
@@ -55,7 +55,7 @@ class CurrentPowerRuntime:
         return self._sample
 
     def replace_snapshot(self, **changes: object) -> None:
-        """Update one or more sample fields for legacy coordinator setters."""
+        """Update one or more fields in the runtime-owned sample."""
 
         values: dict[str, object] = {
             "w": self._sample.w,

--- a/custom_components/enphase_ev/evse_feature_flags_runtime.py
+++ b/custom_components/enphase_ev/evse_feature_flags_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Mapping, cast
 
 from .const import (
     EVSE_FEATURE_FLAGS_CACHE_TTL,
@@ -14,6 +14,7 @@ from .const import (
 from .log_redaction import redact_text
 from .payload_debug import debug_payload_shape, debug_render_summary, debug_sorted_keys
 from .parsing_helpers import coerce_optional_bool
+from .snapshot_helpers import freeze_snapshot_mapping
 
 if TYPE_CHECKING:
     from .coordinator import EnphaseCoordinator
@@ -21,28 +22,40 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 
-@dataclass(slots=True)
+@dataclass(frozen=True, slots=True)
 class EvseFeatureFlagsSnapshot:
-    """Typed view of EVSE feature-flag cache state on the coordinator."""
+    """Immutable view of EVSE feature-flag state owned by the runtime."""
 
-    payload: dict[str, object] | None
-    site_feature_flags: dict[str, object]
-    charger_feature_flags_by_serial: dict[str, dict[str, object]]
+    payload: Mapping[str, object] | None
+    site_feature_flags: Mapping[str, object]
+    charger_feature_flags_by_serial: Mapping[str, Mapping[str, object]]
     charger_serial_count: int
 
     @classmethod
     def from_coordinator(cls, coord: EnphaseCoordinator) -> EvseFeatureFlagsSnapshot:
+        runtime = getattr(coord, "evse_feature_flags_runtime", None)
+        if isinstance(runtime, EvseFeatureFlagsRuntime):
+            return runtime.snapshot
         site = getattr(coord, "_evse_site_feature_flags", None)
         by_serial = getattr(coord, "_evse_feature_flags_by_serial", None)
         payload = getattr(coord, "_evse_feature_flags_payload", None)
         raw_by_serial = by_serial if isinstance(by_serial, dict) else {}
         return cls(
-            payload=dict(payload) if isinstance(payload, dict) else None,
-            site_feature_flags=dict(site) if isinstance(site, dict) else {},
-            charger_feature_flags_by_serial=dict(
-                (str(k), dict(v))
-                for k, v in raw_by_serial.items()
-                if isinstance(v, dict)
+            payload=(
+                freeze_snapshot_mapping(payload) if isinstance(payload, dict) else None
+            ),
+            site_feature_flags=freeze_snapshot_mapping(
+                site if isinstance(site, dict) else {}
+            ),
+            charger_feature_flags_by_serial=cast(
+                Mapping[str, Mapping[str, object]],
+                freeze_snapshot_mapping(
+                    {
+                        str(k): freeze_snapshot_mapping(v)
+                        for k, v in raw_by_serial.items()
+                        if isinstance(v, dict)
+                    }
+                ),
             ),
             charger_serial_count=len(raw_by_serial),
         )
@@ -55,12 +68,12 @@ def evse_feature_flag_debug_summary(
 
     charger_flag_keys: set[str] = set()
     for flags in snapshot.charger_feature_flags_by_serial.values():
-        if not isinstance(flags, dict):
+        if not isinstance(flags, Mapping):
             continue
-        charger_flag_keys.update(debug_sorted_keys(flags))
+        charger_flag_keys.update(debug_sorted_keys(dict(flags)))
     payload = snapshot.payload
-    meta = payload.get("meta") if isinstance(payload, dict) else None
-    error = payload.get("error") if isinstance(payload, dict) else None
+    meta = payload.get("meta") if isinstance(payload, Mapping) else None
+    error = payload.get("error") if isinstance(payload, Mapping) else None
     return {
         "site_flag_keys": sorted(
             str(key) for key in snapshot.site_feature_flags.keys()
@@ -77,31 +90,85 @@ class EvseFeatureFlagsRuntime:
 
     def __init__(self, coordinator: EnphaseCoordinator) -> None:
         self.coordinator = coordinator
+        self._cache_until_mono: float | None = None
+        self._payload: dict[str, object] | None = None
+        self._site_feature_flags: dict[str, object] = {}
+        self._charger_feature_flags_by_serial: dict[str, object] = {}
+
+    @property
+    def snapshot(self) -> EvseFeatureFlagsSnapshot:
+        """Return an immutable copy of the current feature-flag state."""
+
+        raw_by_serial = self._charger_feature_flags_by_serial
+        return EvseFeatureFlagsSnapshot(
+            payload=(
+                freeze_snapshot_mapping(self._payload)
+                if self._payload is not None
+                else None
+            ),
+            site_feature_flags=freeze_snapshot_mapping(self._site_feature_flags),
+            charger_feature_flags_by_serial=cast(
+                Mapping[str, Mapping[str, object]],
+                freeze_snapshot_mapping(
+                    {
+                        str(key): freeze_snapshot_mapping(value)
+                        for key, value in raw_by_serial.items()
+                        if isinstance(value, dict)
+                    }
+                ),
+            ),
+            charger_serial_count=len(raw_by_serial),
+        )
+
+    @property
+    def cache_until_mono(self) -> float | None:
+        """Return the monotonic cache deadline."""
+
+        return self._cache_until_mono
+
+    @cache_until_mono.setter
+    def cache_until_mono(self, value: float | None) -> None:
+        self._cache_until_mono = value
+
+    def replace_payload(self, value: object) -> None:
+        """Replace the raw payload through the compatibility coordinator API."""
+
+        self._payload = dict(value) if isinstance(value, dict) else None
+
+    def replace_site_feature_flags(self, value: object) -> None:
+        """Replace site flags through the compatibility coordinator API."""
+
+        self._site_feature_flags = dict(value) if isinstance(value, dict) else {}
+
+    def replace_charger_feature_flags(self, value: object) -> None:
+        """Replace per-charger flags through the compatibility coordinator API."""
+
+        self._charger_feature_flags_by_serial = (
+            {str(key): item for key, item in value.items()}
+            if isinstance(value, dict)
+            else {}
+        )
 
     def debug_feature_flag_summary(self) -> dict[str, object]:
         """Return a sanitized summary of EVSE feature-flag discovery."""
 
-        return evse_feature_flag_debug_summary(
-            EvseFeatureFlagsSnapshot.from_coordinator(self.coordinator)
-        )
+        return evse_feature_flag_debug_summary(self.snapshot)
 
     def _cached_state_present(self) -> bool:
-        coord = self.coordinator
         return bool(
-            getattr(coord, "_evse_feature_flags_payload", None) is not None
-            or getattr(coord, "_evse_site_feature_flags", None)
-            or getattr(coord, "_evse_feature_flags_by_serial", None)
+            self._payload is not None
+            or self._site_feature_flags
+            or self._charger_feature_flags_by_serial
         )
 
     def refresh_due(self, *, force: bool = False) -> bool:
         """Return True when feature flags should refresh or cached state should clear."""
 
-        coord = self.coordinator
         now = time.monotonic()
-        if not force and coord._evse_feature_flags_cache_until:
-            if now < coord._evse_feature_flags_cache_until:
+        if not force and self._cache_until_mono:
+            if now < self._cache_until_mono:
                 return False
-        fetcher = getattr(coord.client, "evse_feature_flags", None)
+        fetcher = getattr(self.coordinator.client, "evse_feature_flags", None)
         if not callable(fetcher):
             return self._cached_state_present()
         return True
@@ -109,17 +176,15 @@ class EvseFeatureFlagsRuntime:
     def feature_flag(self, key: str, sn: str | None = None) -> object | None:
         """Return a parsed EVSE feature flag for the site or charger."""
 
-        coord = self.coordinator
         key_text = str(key).strip()
         if not key_text:
             return None
         if sn:
-            serial_flags = getattr(coord, "_evse_feature_flags_by_serial", {}) or {}
-            raw = serial_flags.get(str(sn), {}).get(key_text)
+            serial_flags = self._charger_feature_flags_by_serial.get(str(sn))
+            raw = serial_flags.get(key_text) if isinstance(serial_flags, dict) else None
             if raw is not None:
                 return cast(object, raw)
-        site_flags = getattr(coord, "_evse_site_feature_flags", {}) or {}
-        return cast(object | None, site_flags.get(key_text))
+        return self._site_feature_flags.get(key_text)
 
     def feature_flag_enabled(self, key: str, sn: str | None = None) -> bool | None:
         """Return a feature flag coerced to a tri-state boolean."""
@@ -144,9 +209,8 @@ class EvseFeatureFlagsRuntime:
     def parse_payload(self, payload: object) -> None:
         """Cache site and charger feature flags from the EVSE management payload."""
 
-        coord = self.coordinator
-        coord._evse_site_feature_flags = {}
-        coord._evse_feature_flags_by_serial = {}
+        self._site_feature_flags = {}
+        self._charger_feature_flags_by_serial = {}
         if not isinstance(payload, dict):
             return
         data = payload.get("data")
@@ -167,24 +231,24 @@ class EvseFeatureFlagsRuntime:
                     charger_flags[key] = flags
                 continue
             site_flags[key] = raw_value
-        coord._evse_site_feature_flags = site_flags
-        coord._evse_feature_flags_by_serial = charger_flags
+        self._site_feature_flags = site_flags
+        self._charger_feature_flags_by_serial = dict(charger_flags)
 
     async def async_refresh(self, *, force: bool = False) -> None:
         """Refresh EVSE feature flags used for capability gating."""
 
         coord = self.coordinator
         now = time.monotonic()
-        if not force and coord._evse_feature_flags_cache_until:
-            if now < coord._evse_feature_flags_cache_until:
+        if not force and self._cache_until_mono:
+            if now < self._cache_until_mono:
                 return
         fetcher = getattr(coord.client, "evse_feature_flags", None)
         if not callable(fetcher):
             # Older client versions do not expose feature flags, so cached state
             # must clear.
-            coord._evse_feature_flags_payload = None
-            coord._evse_site_feature_flags = {}
-            coord._evse_feature_flags_by_serial = {}
+            self._payload = None
+            self._site_feature_flags = {}
+            self._charger_feature_flags_by_serial = {}
             return
         country = getattr(coord, "_battery_country_code", None)
         try:
@@ -195,25 +259,21 @@ class EvseFeatureFlagsRuntime:
                 redact_text(err, site_ids=(coord.site_id,)),
             )
             # Failed flag discovery should not hammer the management endpoint.
-            coord._evse_feature_flags_cache_until = (
-                now + EVSE_FEATURE_FLAGS_FAILURE_BACKOFF_S
-            )
+            self._cache_until_mono = now + EVSE_FEATURE_FLAGS_FAILURE_BACKOFF_S
             return
         if not isinstance(payload, dict):
-            coord._evse_feature_flags_payload = None
-            coord._evse_site_feature_flags = {}
-            coord._evse_feature_flags_by_serial = {}
-            coord._evse_feature_flags_cache_until = (
-                now + EVSE_FEATURE_FLAGS_FAILURE_BACKOFF_S
-            )
+            self._payload = None
+            self._site_feature_flags = {}
+            self._charger_feature_flags_by_serial = {}
+            self._cache_until_mono = now + EVSE_FEATURE_FLAGS_FAILURE_BACKOFF_S
             _LOGGER.debug(
                 "EVSE feature flags payload shape was invalid: %s",
                 debug_render_summary(debug_payload_shape(payload)),
             )
             return
-        coord._evse_feature_flags_payload = dict(payload)
+        self._payload = dict(payload)
         self.parse_payload(payload)
-        coord._evse_feature_flags_cache_until = now + EVSE_FEATURE_FLAGS_CACHE_TTL
+        self._cache_until_mono = now + EVSE_FEATURE_FLAGS_CACHE_TTL
         coord._debug_log_summary_if_changed(
             "evse_feature_flags",
             "EVSE feature flag summary",

--- a/custom_components/enphase_ev/grid_profile_runtime.py
+++ b/custom_components/enphase_ev/grid_profile_runtime.py
@@ -206,6 +206,16 @@ class GridProfileRuntime:
         self._lock = asyncio.Lock()
         self._apply_lock = asyncio.Lock()
 
+    def _publish_state_update(self) -> None:
+        """Publish a grid-profile transition through the coordinator boundary."""
+
+        publish = getattr(self.coordinator, "publish_runtime_state_update", None)
+        if callable(publish):
+            publish("grid_profile")
+            return
+        # Compatibility for the lightweight coordinator used by isolated tests.
+        self.coordinator.async_update_listeners()
+
     @property
     def installer_access_confirmed(self) -> bool:
         return self.support_state == SUPPORT_CONFIRMED
@@ -423,21 +433,21 @@ class GridProfileRuntime:
         if region is not None and self._derive_region_code() is None:
             self.site_region_code = region.region_code
         self.staged_profile_id = None
-        self.coordinator.async_update_listeners()
+        self._publish_state_update()
 
     def set_list_mode(self, option: str) -> None:
         self.staged_commonly_used = option != ALL_PROFILES_OPTION
         self.staged_profile_id = None
-        self.coordinator.async_update_listeners()
+        self._publish_state_update()
 
     def set_search_query(self, query: str | None) -> None:
         self.staged_query = _clean_text(query) or ""
-        self.coordinator.async_update_listeners()
+        self._publish_state_update()
 
     def set_staged_profile(self, profile_id: str | None) -> None:
         profile = self.profile_for_id(profile_id)
         self.staged_profile_id = profile.profile_id if profile is not None else None
-        self.coordinator.async_update_listeners()
+        self._publish_state_update()
 
     def _derive_country(self) -> str | None:
         for source in (
@@ -1002,12 +1012,12 @@ class GridProfileRuntime:
                 else:
                     self.support_state = SUPPORT_CONFIRMED
                     self.coordinator._note_endpoint_family_failure(family, err)
-                self.coordinator.async_update_listeners()
+                self._publish_state_update()
                 return self.browse()
             self.support_state = SUPPORT_CONFIRMED
             self.installer_access_ever_confirmed = True
             self.coordinator._note_endpoint_family_success(family, success_ttl_s=300.0)
-            self.coordinator.async_update_listeners()
+            self._publish_state_update()
             return self.browse()
 
     async def async_refresh(
@@ -1043,13 +1053,13 @@ class GridProfileRuntime:
             )
             if denied_error is not None:
                 self._mark_denied(denied_error)
-                self.coordinator.async_update_listeners()
+                self._publish_state_update()
                 return self.browse()
             if errors and (
                 successful_requests == 0 or not self.installer_access_ever_confirmed
             ):
                 self._mark_denied(errors[0])
-                self.coordinator.async_update_listeners()
+                self._publish_state_update()
                 return self.browse()
             self.country_code = await self._async_derive_country()
             derived_region_code = self._derive_region_code()
@@ -1118,7 +1128,7 @@ class GridProfileRuntime:
                         is not None
                     ):
                         break
-            self.coordinator.async_update_listeners()
+            self._publish_state_update()
             return self.browse()
 
     async def async_load_profiles(
@@ -1160,13 +1170,13 @@ class GridProfileRuntime:
             )
         except Exception as err:  # noqa: BLE001
             self._mark_denied(err)
-            self.coordinator.async_update_listeners()
+            self._publish_state_update()
             return []
         self.coordinator._note_endpoint_family_success(
             ACTIVATION_GRID_PROFILE_FAMILY,
             success_ttl_s=300.0,
         )
-        self.coordinator.async_update_listeners()
+        self._publish_state_update()
         return profiles
 
     def filtered_regions(self, query: str | None = None) -> list[ActivationRegion]:
@@ -1334,7 +1344,7 @@ class GridProfileRuntime:
                 self.pending_profile_id = None
                 self.pending_gateway_serial = None
                 self.pending_started_mono = None
-                self.coordinator.async_update_listeners()
+                self._publish_state_update()
             if self._pending_refresh_task is asyncio.current_task():
                 self._pending_refresh_task = None
 

--- a/custom_components/enphase_ev/integration_snapshot.py
+++ b/custom_components/enphase_ev/integration_snapshot.py
@@ -1,0 +1,72 @@
+"""Immutable publication state for the Enphase coordinator."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping, cast
+
+from .current_power_runtime import CurrentPowerSample
+from .evse_feature_flags_runtime import EvseFeatureFlagsSnapshot
+from .snapshot_helpers import freeze_snapshot_mapping
+
+type ChargerPayload = Mapping[str, object]
+type ChargerPayloads = Mapping[str, ChargerPayload]
+
+
+def freeze_charger_data(
+    data: Mapping[str, Mapping[str, object]],
+) -> ChargerPayloads:
+    """Return a read-only, detached view of normalized charger data."""
+
+    return cast(
+        ChargerPayloads,
+        freeze_snapshot_mapping(
+            {
+                str(serial): freeze_snapshot_mapping(payload)
+                for serial, payload in data.items()
+            }
+        ),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrationSnapshot:
+    """State used to decide whether coordinator listeners need an update.
+
+    ``revision`` is observational metadata and is deliberately excluded from
+    equality. Equality is based on the normalized charger payload and explicit
+    runtime-manager state, so an unchanged cloud response no longer hides a
+    manager-owned state transition.
+    """
+
+    chargers: ChargerPayloads
+    evse_feature_flags: EvseFeatureFlagsSnapshot
+    current_power: CurrentPowerSample
+    runtime_revisions: tuple[tuple[str, int], ...] = ()
+    revision: int = field(default=0, compare=False)
+
+
+class CoordinatorData(dict[str, dict[str, object]]):
+    """Dictionary-compatible coordinator data with aggregate equality.
+
+    Entity platforms and compatibility tests still receive the historical dict
+    interface while Home Assistant compares the complete integration snapshot.
+    """
+
+    __slots__ = ("snapshot",)
+
+    def __init__(
+        self,
+        data: Mapping[str, Mapping[str, object]],
+        snapshot: IntegrationSnapshot,
+    ) -> None:
+        super().__init__((str(key), dict(value)) for key, value in data.items())
+        self.snapshot = snapshot
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, CoordinatorData):
+            return self.snapshot == other.snapshot
+        return super().__eq__(other)
+
+    def __ne__(self, other: object) -> bool:
+        return not self == other

--- a/custom_components/enphase_ev/snapshot_helpers.py
+++ b/custom_components/enphase_ev/snapshot_helpers.py
@@ -1,0 +1,28 @@
+"""Helpers for immutable runtime snapshots."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Mapping
+
+
+def freeze_snapshot_value(value: object) -> object:
+    """Recursively detach mutable containers for a public snapshot."""
+
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {key: freeze_snapshot_value(item) for key, item in value.items()}
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(freeze_snapshot_value(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return frozenset(freeze_snapshot_value(item) for item in value)
+    return value
+
+
+def freeze_snapshot_mapping(value: Mapping[str, object]) -> Mapping[str, object]:
+    """Return a recursively read-only, detached mapping."""
+
+    return MappingProxyType(
+        {key: freeze_snapshot_value(item) for key, item in value.items()}
+    )

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -266,11 +266,6 @@ class HeatpumpState:
     _heatpump_daily_split_last_success_mono: float | None = None
     _heatpump_daily_split_last_success_utc: datetime | None = None
     _heatpump_daily_split_using_stale: bool = False
-    _current_power_consumption_w: float | None = None
-    _current_power_consumption_sample_utc: datetime | None = None
-    _current_power_consumption_reported_units: str | None = None
-    _current_power_consumption_reported_precision: int | None = None
-    _current_power_consumption_source: str | None = None
     _heatpump_power_w: float | None = None
     _heatpump_power_sample_utc: datetime | None = None
     _heatpump_power_start_utc: datetime | None = None
@@ -305,10 +300,6 @@ class EVSEState:
         str, tuple[bool | None, bool | None, bool, bool, float]
     ] = field(default_factory=dict)
     _app_auth_pending: dict[str, tuple[bool, float]] = field(default_factory=dict)
-    _evse_feature_flags_cache_until: float | None = None
-    _evse_feature_flags_payload: PayloadMap | None = None
-    _evse_site_feature_flags: PayloadMap = field(default_factory=dict)
-    _evse_feature_flags_by_serial: PayloadMapByKey = field(default_factory=dict)
     _last_charging: dict[str, bool] = field(default_factory=dict)
     _last_actual_charging: dict[str, bool | None] = field(default_factory=dict)
     _pending_charging: dict[str, tuple[bool, float]] = field(default_factory=dict)

--- a/docs/adr/0001-runtime-state-ownership.md
+++ b/docs/adr/0001-runtime-state-ownership.md
@@ -1,0 +1,70 @@
+# ADR 0001: Runtime State Ownership And Publication
+
+- Status: Accepted
+- Date: 2026-07-14
+
+## Context
+
+The integration historically grouped hundreds of coordinator fields in mutable
+dataclasses and projected them back onto `EnphaseCoordinator` with descriptors.
+Runtime managers then read and wrote those projected private fields. This kept
+entity compatibility but obscured ownership, made update significance depend on
+unchanged charger dictionaries, and coupled managers to coordinator internals.
+
+## Decision
+
+One `EnphaseCoordinator` remains the Home Assistant update and lifecycle
+boundary for a config entry. Feature runtimes own their endpoint-family caches,
+parsing state, stale-state decisions, and immutable public snapshots.
+
+Dependencies flow in this direction:
+
+```text
+entity platform -> coordinator public API -> feature runtime -> cloud client
+                                      \-> immutable integration snapshot
+```
+
+Feature runtimes may use narrow coordinator services such as endpoint-health,
+authentication-circuit, task-tracking, and publication APIs. They must not add
+new projected private state to the coordinator. Existing projected state is
+migrated incrementally because entities, diagnostics, and tests have long-lived
+compatibility contracts.
+
+The coordinator publishes an immutable `IntegrationSnapshot` containing
+normalized charger data, manager snapshots, and explicit manager revisions.
+`CoordinatorData` preserves the historical dictionary interface while using the
+aggregate snapshot for equality. A manager with state not otherwise represented
+in the aggregate calls `publish_runtime_state_update(source)`; managers do not
+call Home Assistant listeners directly.
+
+Coordinator-owned one-time preparation runs in `_async_setup`. Config-entry
+setup calls public bootstrap, warmup, cancellation, timing, and milestone APIs;
+it does not manipulate coordinator lifecycle flags.
+
+## Incremental Migration Rules
+
+1. New feature state lives on its runtime and is exposed through a frozen,
+   read-only snapshot.
+2. Compatibility coordinator properties may delegate to a runtime during a
+   migration, but dynamic `StateBackedAttribute` projection is not added.
+3. Entity properties perform lookups and presentation only; payload parsing and
+   derived domain values belong to runtimes or domain helpers.
+4. Runtime-to-coordinator calls use public methods or a narrow typed protocol.
+5. Each migrated family adds contract tests for snapshot immutability,
+   publication, and preserved coordinator compatibility.
+6. Compatibility properties and reflective runtime factories are removed once
+   no supported entity, diagnostic path, or test contract depends on them.
+
+The current-power and EVSE feature-flag families are the first migrated state
+owners. Grid-profile state uses explicit runtime publication revisions. Other
+families follow the same pattern without requiring a big-bang rewrite.
+
+## Consequences
+
+- Home Assistant listeners observe manager-only transitions even when charger
+  payloads are unchanged.
+- Ownership and update significance are explicit and testable.
+- Existing entity IDs, coordinator data access, and diagnostics remain stable.
+- Temporary compatibility properties add some duplication during migration.
+- The aggregate snapshot must be extended, or a manager revision published,
+  whenever a new observable runtime state family is added.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,9 +26,11 @@ flowchart TD
 
 `config_flow.py` handles user login, MFA, site selection, device-category selection, reconfigure, and reauth entry updates. It stores the tokens and cookies needed for refreshes in the config entry. The password is stored only when the user opts into remembered credentials so the integration can attempt automatic token refresh.
 
-`__init__.py` handles config entry setup and unload. It creates the coordinator,
-restores compact discovery state, starts an independent power-acquisition task,
-and blocks only on the authoritative status refresh before forwarding platforms.
+`__init__.py` handles config entry setup and unload. It creates the coordinator
+and invokes its public bootstrap API. Coordinator-owned `_async_setup` restores
+compact discovery state and starts an independent power-acquisition task before
+the authoritative status refresh. Config-entry setup blocks only on that refresh
+before forwarding platforms.
 Translation and integration-version priming run concurrently with that work.
 Optional endpoint families then warm up in feature-aware stages, publishing after
 each stage so one slow family does not hold back unrelated state. Schedule sync and
@@ -103,6 +105,12 @@ Runtime managers keep endpoint-family behavior out of the main coordinator:
 - `current_power_runtime.py`, `evse_feature_flags_runtime.py`, `auth_refresh_runtime.py`, and `ac_battery_runtime.py` handle smaller endpoint families.
 
 These managers should own cache lifetimes, stale data decisions, and endpoint-specific parsing for their family. The coordinator should expose their normalized state through properties and helper methods.
+
+New manager state is published through immutable snapshots rather than projected
+private coordinator fields. The aggregate integration snapshot determines update
+equality while preserving the historical dictionary-shaped `coordinator.data`
+interface. See [ADR 0001](adr/0001-runtime-state-ownership.md) for dependency,
+ownership, and incremental migration rules.
 
 ## Inventory And Entity Gating
 

--- a/tests/components/enphase_ev/test_integration_snapshot.py
+++ b/tests/components/enphase_ev/test_integration_snapshot.py
@@ -1,0 +1,155 @@
+"""Tests for aggregate coordinator publication state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.enphase_ev.current_power_runtime import CurrentPowerSample
+from custom_components.enphase_ev.evse_feature_flags_runtime import (
+    EvseFeatureFlagsSnapshot,
+)
+from custom_components.enphase_ev.integration_snapshot import (
+    CoordinatorData,
+    IntegrationSnapshot,
+    freeze_charger_data,
+)
+from custom_components.enphase_ev.snapshot_helpers import freeze_snapshot_value
+
+
+def _snapshot(
+    *,
+    power: float | None = None,
+    runtime_revisions: tuple[tuple[str, int], ...] = (),
+    revision: int = 1,
+) -> IntegrationSnapshot:
+    return IntegrationSnapshot(
+        chargers=freeze_charger_data({"EVSE-1": {"charging": False}}),
+        evse_feature_flags=EvseFeatureFlagsSnapshot(
+            payload=None,
+            site_feature_flags={},
+            charger_feature_flags_by_serial={},
+            charger_serial_count=0,
+        ),
+        current_power=CurrentPowerSample(w=power),
+        runtime_revisions=runtime_revisions,
+        revision=revision,
+    )
+
+
+def test_snapshot_is_read_only_and_revision_is_not_update_equality() -> None:
+    first = _snapshot(revision=1)
+    second = _snapshot(revision=2)
+
+    assert first == second
+    with pytest.raises(TypeError):
+        first.chargers["EVSE-1"]["charging"] = True  # type: ignore[index]
+
+
+def test_snapshot_recursively_freezes_nested_charger_data() -> None:
+    source = {"EVSE-1": {"nested": {"values": [1, 2]}}}
+    frozen = freeze_charger_data(source)
+    source["EVSE-1"]["nested"] = {"values": [3]}
+
+    nested = frozen["EVSE-1"]["nested"]
+    assert nested == {"values": (1, 2)}
+    with pytest.raises(TypeError):
+        nested["other"] = True  # type: ignore[index,operator]
+
+    assert freeze_snapshot_value({1, 2}) == frozenset({1, 2})
+
+
+def test_coordinator_data_preserves_dict_api_and_uses_aggregate_equality() -> None:
+    first = CoordinatorData({"EVSE-1": {"charging": False}}, _snapshot())
+    runtime_changed = CoordinatorData(
+        {"EVSE-1": {"charging": False}},
+        _snapshot(runtime_revisions=(("grid_profile", 1),), revision=2),
+    )
+
+    assert first == {"EVSE-1": {"charging": False}}
+    assert first != runtime_changed
+    assert first["EVSE-1"]["charging"] is False
+
+
+def test_runtime_snapshots_drive_coordinator_publication(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    data = {"EVSE-1": {"charging": False}}
+
+    coord.async_set_updated_data(data)
+    first = coord.integration_snapshot
+    assert first is not None
+    assert first.revision == 1
+
+    coord.async_set_updated_data(data)
+    unchanged = coord.integration_snapshot
+    assert unchanged is not None
+    assert unchanged.revision == 1
+
+    coord._current_power_consumption_w = 123.0  # noqa: SLF001
+    coord._current_power_consumption_sample_utc = datetime.now(UTC)  # noqa: SLF001
+    coord.publish_runtime_state_update("current_power")
+    changed = coord.integration_snapshot
+    assert changed is not None
+    assert changed.revision == 2
+    assert changed.current_power.w == 123.0
+    assert coord.current_power_snapshot.w == 123.0
+    assert changed.runtime_revisions == (("current_power", 1),)
+
+
+def test_evse_feature_flag_runtime_snapshot_is_detached(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord._evse_feature_flags_payload = {"data": {}}  # noqa: SLF001
+    coord._evse_site_feature_flags = {"remote_start": True}  # noqa: SLF001
+    coord._evse_feature_flags_by_serial = {  # noqa: SLF001
+        "EVSE-1": {"plug_and_charge": False}
+    }
+
+    snapshot = coord.evse_feature_flags_snapshot
+    coord._evse_site_feature_flags = {}  # noqa: SLF001
+
+    assert snapshot.site_feature_flags == {"remote_start": True}
+    with pytest.raises(TypeError):
+        snapshot.site_feature_flags["other"] = True  # type: ignore[index]
+
+
+def test_migrated_state_compatibility_before_runtime_construction(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    current_power_runtime = coord.__dict__.pop("current_power_runtime")
+    feature_flags_runtime = coord.__dict__.pop("evse_feature_flags_runtime")
+    try:
+        coord._current_power_consumption_w = 50.0  # noqa: SLF001
+        assert coord._current_power_consumption_w == 50.0  # noqa: SLF001
+
+        coord._evse_feature_flags_cache_until = 42.0  # noqa: SLF001
+        coord._evse_feature_flags_payload = {"data": {}}  # noqa: SLF001
+        coord._evse_site_feature_flags = {"site": True}  # noqa: SLF001
+        coord._evse_feature_flags_by_serial = {  # noqa: SLF001
+            "EVSE-1": {"charger": True}
+        }
+        assert coord._evse_feature_flags_cache_until == 42.0  # noqa: SLF001
+        assert coord._evse_feature_flags_payload == {"data": {}}  # noqa: SLF001
+        assert coord._evse_site_feature_flags == {"site": True}  # noqa: SLF001
+        assert coord._evse_feature_flags_by_serial == {  # noqa: SLF001
+            "EVSE-1": {"charger": True}
+        }
+    finally:
+        coord.__dict__["current_power_runtime"] = current_power_runtime
+        coord.__dict__["evse_feature_flags_runtime"] = feature_flags_runtime
+
+
+def test_feature_flag_snapshot_supports_legacy_coordinator_shape() -> None:
+    coord = SimpleNamespace(
+        _evse_feature_flags_payload={"meta": {}},
+        _evse_site_feature_flags={"site": True},
+        _evse_feature_flags_by_serial={"EVSE-1": {"charger": True}},
+    )
+
+    snapshot = EvseFeatureFlagsSnapshot.from_coordinator(coord)  # type: ignore[arg-type]
+
+    assert snapshot.payload == {"meta": {}}
+    assert snapshot.site_feature_flags == {"site": True}
+    assert snapshot.charger_serial_count == 1

--- a/tests/components/enphase_ev/test_integration_snapshot.py
+++ b/tests/components/enphase_ev/test_integration_snapshot.py
@@ -87,8 +87,10 @@ def test_runtime_snapshots_drive_coordinator_publication(coordinator_factory) ->
     assert unchanged is not None
     assert unchanged.revision == 1
 
-    coord._current_power_consumption_w = 123.0  # noqa: SLF001
-    coord._current_power_consumption_sample_utc = datetime.now(UTC)  # noqa: SLF001
+    coord.current_power_runtime.replace_snapshot(
+        w=123.0,
+        sample_utc=datetime.now(UTC),
+    )
     coord.publish_runtime_state_update("current_power")
     changed = coord.integration_snapshot
     assert changed is not None
@@ -100,14 +102,13 @@ def test_runtime_snapshots_drive_coordinator_publication(coordinator_factory) ->
 
 def test_evse_feature_flag_runtime_snapshot_is_detached(coordinator_factory) -> None:
     coord = coordinator_factory()
-    coord._evse_feature_flags_payload = {"data": {}}  # noqa: SLF001
-    coord._evse_site_feature_flags = {"remote_start": True}  # noqa: SLF001
-    coord._evse_feature_flags_by_serial = {  # noqa: SLF001
-        "EVSE-1": {"plug_and_charge": False}
-    }
+    runtime = coord.evse_feature_flags_runtime
+    runtime.replace_payload({"data": {}})
+    runtime.replace_site_feature_flags({"remote_start": True})
+    runtime.replace_charger_feature_flags({"EVSE-1": {"plug_and_charge": False}})
 
     snapshot = coord.evse_feature_flags_snapshot
-    coord._evse_site_feature_flags = {}  # noqa: SLF001
+    runtime.replace_site_feature_flags({})
 
     assert snapshot.site_feature_flags == {"remote_start": True}
     with pytest.raises(TypeError):


### PR DESCRIPTION
## Summary

Refactor coordinator state ownership, update publication, and config-entry lifecycle boundaries.

- Move current-power and EVSE feature-flag state into runtime-owned immutable snapshots.
- Remove those fields from dynamic state projection while retaining compatibility properties.
- Publish aggregate `IntegrationSnapshot` state through dictionary-compatible coordinator data.
- Route grid-profile transitions through the coordinator publication API.
- Move discovery restore and startup-power preparation into coordinator `_async_setup`.
- Expose public setup, warmup, cancellation, timing, and milestone APIs.
- Add ADR 0001 and immutable snapshot/public-contract regression tests.

This focused draft is included for isolated review. The fully integrated merge candidate is #784; do not merge both PRs.

## Related Issues

- Integrated merge candidate: #784

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/current_power_runtime.py custom_components/enphase_ev/evse_feature_flags_runtime.py custom_components/enphase_ev/grid_profile_runtime.py custom_components/enphase_ev/integration_snapshot.py custom_components/enphase_ev/snapshot_helpers.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_integration_snapshot.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/current_power_runtime.py,custom_components/enphase_ev/evse_feature_flags_runtime.py,custom_components/enphase_ev/grid_profile_runtime.py,custom_components/enphase_ev/integration_snapshot.py,custom_components/enphase_ev/snapshot_helpers.py,custom_components/enphase_ev/state_models.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
```

Results: 3,864 full-suite tests passed; 3,732 integration tests passed; 7,334 touched statements reported 100% coverage; strict mypy passed across 76 source modules.

## Checklist

- [x] `CHANGELOG.md` is not required because user-facing behavior is preserved.
- [x] I updated `docs/architecture.md` and added ADR 0001.
- [x] Translation files are unchanged because no user-facing strings changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics payload shape or screenshots are required for this internal state-ownership refactor.
