### PR TITLE
Refactor cloud API and weather boundaries

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1777,12 +1777,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
 
 async def async_unload_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> bool:
     coord = None
+    runtime_data = None
     try:
-        coord = get_runtime_data(entry).coordinator
+        runtime_data = get_runtime_data(entry)
+        coord = runtime_data.coordinator
     except RuntimeError:
         pass
     unload_ok = await _async_unload_platforms_safe(hass, entry)
     if unload_ok:
+        if runtime_data is not None:
+            await runtime_data.async_stop_weather()
         if coord is not None and hasattr(coord, "schedule_sync"):
             await coord.schedule_sync.async_stop()
         async_cleanup_runtime_state = getattr(

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -46,6 +46,9 @@ from .const import (
     SITE_SEARCH_URL,
 )
 from . import api_parsers
+from .api_client import auth as api_auth
+from .api_client import site_surface as api_site_surface
+from .api_client import transport as api_transport
 from .api_models import (
     AuthTokens as AuthTokens,
     ChargerInfo as ChargerInfo,
@@ -1297,56 +1300,21 @@ async def _request_json(
     json_data: Any | None = None,
 ) -> Any:
     """Perform an HTTP request returning JSON with timeout handling."""
-
-    req_kwargs: dict[str, Any] = {}
-    if headers is not None:
-        req_kwargs["headers"] = headers
-    if data is not None:
-        req_kwargs["data"] = data
-    if json_data is not None:
-        req_kwargs["json"] = json_data
-
-    async with asyncio.timeout(timeout):
-        async with _enlighten_read_request_guard(method, url):
-            async with session.request(
-                method, url, allow_redirects=True, **req_kwargs
-            ) as resp:
-                if resp.status >= 500:
-                    raise EnlightenAuthUnavailable(
-                        f"Server error {resp.status} at {_request_label(method, url)}"
-                    )
-                if resp.status >= 400:
-                    body_text = ""
-                    try:
-                        body_text = await resp.text()
-                    except Exception:  # noqa: BLE001 - best effort auth diagnostics
-                        body_text = ""
-                    if _is_too_many_active_sessions_response(body_text):
-                        raise EnlightenAuthTooManySessions(
-                            "Too many active Enlighten sessions"
-                        )
-                resp.raise_for_status()
-                ctype = resp.headers.get("Content-Type", "")
-                if "json" not in ctype:
-                    text = await resp.text()
-                    if _is_too_many_active_sessions_response(text):
-                        raise EnlightenAuthTooManySessions(
-                            "Too many active Enlighten sessions"
-                        )
-                    raise EnlightenAuthUnavailable(
-                        _safe_response_error_message(
-                            status=int(resp.status),
-                            reason="Unexpected non-JSON response",
-                            headers=resp.headers,
-                            body_text=text,
-                        )
-                    )
-                payload = await resp.json()
-                if _is_too_many_active_sessions_response(payload):
-                    raise EnlightenAuthTooManySessions(
-                        "Too many active Enlighten sessions"
-                    )
-                return payload
+    return await api_transport.request_json(
+        session,
+        method,
+        url,
+        timeout=timeout,
+        headers=headers,
+        data=data,
+        json_data=json_data,
+        request_guard=_enlighten_read_request_guard,
+        request_label=_request_label,
+        safe_error_message=_safe_response_error_message,
+        is_session_limit=_is_too_many_active_sessions_response,
+        unavailable_error=EnlightenAuthUnavailable,
+        session_limit_error=EnlightenAuthTooManySessions,
+    )
 
 
 async def _request_mfa_json(
@@ -1359,120 +1327,54 @@ async def _request_mfa_json(
     data: Any | None = None,
 ) -> Any:
     """Perform an MFA HTTP request with tolerant JSON parsing."""
-
-    req_kwargs: dict[str, Any] = {}
-    if headers is not None:
-        req_kwargs["headers"] = headers
-    if data is not None:
-        req_kwargs["data"] = data
-
-    async with asyncio.timeout(timeout):
-        async with session.request(
-            method, url, allow_redirects=True, **req_kwargs
-        ) as resp:
-            if resp.status >= 500:
-                raise EnlightenAuthUnavailable(
-                    f"Server error {resp.status} at {_request_label(method, url)}"
-                )
-            if resp.status in (204, 205):
-                return {}
-            if resp.status >= 400:
-                body_text = ""
-                try:
-                    body_text = await resp.text()
-                except Exception:  # noqa: BLE001 - best effort auth diagnostics
-                    body_text = ""
-                if _is_too_many_active_sessions_response(body_text):
-                    raise EnlightenAuthTooManySessions(
-                        "Too many active Enlighten sessions"
-                    )
-            resp.raise_for_status()
-            ctype = resp.headers.get("Content-Type", "")
-            if "json" in ctype:
-                payload = await resp.json()
-                if _is_too_many_active_sessions_response(payload):
-                    raise EnlightenAuthTooManySessions(
-                        "Too many active Enlighten sessions"
-                    )
-                return payload
-            text = await resp.text()
-            if _is_too_many_active_sessions_response(text):
-                raise EnlightenAuthTooManySessions("Too many active Enlighten sessions")
-            if not text.strip():
-                return {}
-            try:
-                payload = json.loads(text)
-            except json.JSONDecodeError as err:
-                raise EnlightenAuthUnavailable(
-                    _safe_response_error_message(
-                        status=int(resp.status),
-                        reason="Unexpected MFA response",
-                        headers=resp.headers,
-                        body_text=text,
-                    )
-                ) from err
-            if _is_too_many_active_sessions_response(payload):
-                raise EnlightenAuthTooManySessions("Too many active Enlighten sessions")
-            return payload
+    return await api_transport.request_mfa_json(
+        session,
+        method,
+        url,
+        timeout=timeout,
+        headers=headers,
+        data=data,
+        request_label=_request_label,
+        safe_error_message=_safe_response_error_message,
+        is_session_limit=_is_too_many_active_sessions_response,
+        unavailable_error=EnlightenAuthUnavailable,
+        session_limit_error=EnlightenAuthTooManySessions,
+    )
 
 
 def _mfa_headers(cookies: dict[str, str] | None) -> dict[str, str]:
     """Return headers for MFA endpoints with cookie/XSRF handling."""
-
-    headers = _login_headers()
-    headers["Accept"] = "application/json, text/plain, */*"
-    cookie_header = _cookie_header_from_map(cookies)
-    if cookie_header:
-        headers["Cookie"] = cookie_header
-    xsrf_token = _extract_xsrf_token(cookies)
-    if xsrf_token:
-        headers["X-CSRF-Token"] = xsrf_token
-    return headers
+    return api_auth.mfa_headers(
+        cookies,
+        base_headers=_login_headers(),
+        cookie_header=_cookie_header_from_map,
+        xsrf_token=_extract_xsrf_token,
+    )
 
 
 def _login_headers() -> dict[str, str]:
     """Return headers for the initial Enlighten login request."""
-
-    return {
-        "Accept": "*/*",
-        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
-        "Referer": f"{BASE_URL}/",
-        "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
-        "X-Requested-With": "XMLHttpRequest",
-    }
+    return api_auth.login_headers(
+        base_url=BASE_URL,
+        user_agent=_ENLIGHTEN_BROWSER_USER_AGENT,
+    )
 
 
 def _login_form_headers() -> dict[str, str]:
     """Return browser-style headers for the HTML form login flow."""
-
-    return {
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Origin": BASE_URL,
-        "Referer": f"{BASE_URL}/",
-        "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
-    }
+    return api_auth.login_form_headers(
+        base_url=BASE_URL,
+        user_agent=_ENLIGHTEN_BROWSER_USER_AGENT,
+    )
 
 
 def _extract_login_session_from_cookies(
     cookies: dict[str, str] | None,
 ) -> tuple[str | None, str | None]:
     """Extract session details from post-login cookies."""
-
-    if not cookies:
-        return None, None
-
-    session_id = (
-        cookies.get("_enlighten_4_session")
-        or cookies.get("enlighten_session")
-        or cookies.get("_enlighten_session")
-    )
-    manager_token = cookies.get("enlighten_manager_token_production")
-    if not session_id and manager_token:
-        session_id = _jwt_session_id(manager_token)
-    return (
-        str(session_id) if session_id else None,
-        str(manager_token) if manager_token else None,
+    return api_auth.login_session_from_cookies(
+        cookies,
+        jwt_session_id=_jwt_session_id,
     )
 
 
@@ -6490,21 +6392,7 @@ class EnphaseEVClient:
         GET /systems/<site_id>/weather.json?locale=<locale>
         """
 
-        endpoint = f"/systems/{self._site}/weather.json"
-        url = URL(f"{BASE_URL}{endpoint}").with_query({"locale": str(locale)})
-        data = await self._json(
-            "GET",
-            str(url),
-            headers=self._systems_json_headers(),
-        )
-        if not isinstance(data, dict):
-            raise self._invalid_payload_error(
-                endpoint=endpoint,
-                summary="Weather payload must be an object",
-                failure_kind="shape",
-                payload=data,
-            )
-        return data
+        return await api_site_surface.weather(self, base_url=BASE_URL, locale=locale)
 
     @classmethod
     def _normalize_latest_power_payload(
@@ -6512,10 +6400,7 @@ class EnphaseEVClient:
     ) -> dict[str, object] | None:
         """Normalize app-api latest power payloads into a common shape."""
 
-        return cast(
-            dict[str, object] | None,
-            api_parsers.normalize_latest_power_payload(payload),
-        )
+        return api_site_surface.normalize_latest_power(payload)
 
     async def latest_power(self) -> dict[str, object] | None:
         """Return the latest site power sample for the configured site.
@@ -6523,64 +6408,21 @@ class EnphaseEVClient:
         GET /app-api/<site_id>/get_latest_power
         """
 
-        url = f"{BASE_URL}/app-api/{self._site}/get_latest_power"
-        data = await self._json("GET", url, headers=self._history_headers())
-        normalized = self._normalize_latest_power_payload(data)
-        if normalized is not None:
-            return normalized
-
-        top_level_keys: list[str] = []
-        nested_keys: list[str] = []
-        payload_type = type(data).__name__
-        if isinstance(data, dict):
-            top_level_keys = sorted(str(key) for key in data.keys())
-            nested = data.get("latest_power")
-            if not isinstance(nested, dict):
-                candidate = data.get("data")
-                if isinstance(candidate, dict):
-                    nested = candidate.get("latest_power")
-                    if not isinstance(nested, dict):
-                        nested = candidate
-            if isinstance(nested, dict):
-                nested_keys = sorted(str(key) for key in nested.keys())
-
-        _LOGGER.debug(
-            "Invalid latest power payload for site %s (payload_type=%s, top_level_keys=%s, nested_keys=%s)",
-            redact_site_id(self._site),
-            payload_type,
-            top_level_keys,
-            nested_keys,
-        )
-        return None
+        return await api_site_surface.latest_power(self, base_url=BASE_URL)
 
     async def show_livestream(
         self, *, allow_reauth: bool = True
     ) -> dict[str, object] | None:
         """Return live-status/vitals capability flags when available."""
 
-        url = f"{BASE_URL}/app-api/{self._site}/show_livestream"
-        try:
-            data = await self._json(
-                "GET",
-                url,
-                headers=self._system_dashboard_headers(),
-                allow_reauth=allow_reauth,
-            )
-        except Unauthorized:
-            if not allow_reauth:
-                raise
-            return None
-        except InvalidPayloadError as err:
-            if _is_optional_non_json_payload(err):
-                return None
-            raise
-        except aiohttp.ClientResponseError as err:
-            if err.status in (401, 403, 404):
-                if not allow_reauth and err.status in (401, 403):
-                    raise
-                return None
-            raise
-        return data if isinstance(data, dict) else None
+        return await api_site_surface.show_livestream(
+            self,
+            base_url=BASE_URL,
+            allow_reauth=allow_reauth,
+            unauthorized_error=Unauthorized,
+            invalid_payload_error=InvalidPayloadError,
+            optional_non_json=_is_optional_non_json_payload,
+        )
 
     async def site_livestream_authorizer(
         self,
@@ -6591,39 +6433,16 @@ class EnphaseEVClient:
     ) -> dict[str, object] | None:
         """Return signed AWS IoT connection details for the site live stream."""
 
-        query: dict[str, str] = {"serial_num": str(serial_num)}
-        if live_debug:
-            query["live_debug"] = "true"
-        endpoint = (
-            "/service/system_dashboard/api_internal/cs/sites/livestream"
-            if live_debug
-            else "/pv/aws_sigv4/livestream.json"
+        return await api_site_surface.livestream_authorizer(
+            self,
+            serial_num,
+            base_url=BASE_URL,
+            live_debug=live_debug,
+            allow_reauth=allow_reauth,
+            unauthorized_error=Unauthorized,
+            invalid_payload_error=InvalidPayloadError,
+            optional_non_json=_is_optional_non_json_payload,
         )
-        url = URL(f"{BASE_URL}{endpoint}").with_query(query)
-        headers = self._today_headers()
-        headers["X-Requested-With"] = "XMLHttpRequest"
-        try:
-            data = await self._json(
-                "GET",
-                str(url),
-                headers=headers,
-                allow_reauth=allow_reauth,
-            )
-        except Unauthorized:
-            if not allow_reauth:
-                raise
-            return None
-        except InvalidPayloadError as err:
-            if _is_optional_non_json_payload(err):
-                return None
-            raise
-        except aiohttp.ClientResponseError as err:
-            if err.status in (401, 403, 404):
-                if not allow_reauth and err.status in (401, 403):
-                    raise
-                return None
-            raise
-        return data if isinstance(data, dict) else None
 
     async def site_livestream_payload(
         self,

--- a/custom_components/enphase_ev/api_client/__init__.py
+++ b/custom_components/enphase_ev/api_client/__init__.py
@@ -1,0 +1,6 @@
+"""Internal implementation boundaries for the Enphase cloud client.
+
+The public compatibility facade remains :mod:`custom_components.enphase_ev.api`.
+These modules deliberately depend only on an injected ``aiohttp.ClientSession``
+and narrow callbacks so they can be extracted into a standalone library later.
+"""

--- a/custom_components/enphase_ev/api_client/auth.py
+++ b/custom_components/enphase_ev/api_client/auth.py
@@ -1,0 +1,72 @@
+"""Authentication request-shaping helpers for the Enphase cloud client."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+
+
+def login_headers(*, base_url: str, user_agent: str) -> dict[str, str]:
+    """Return headers for the initial Enlighten login request."""
+
+    return {
+        "Accept": "*/*",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "Referer": f"{base_url}/",
+        "User-Agent": user_agent,
+        "X-Requested-With": "XMLHttpRequest",
+    }
+
+
+def login_form_headers(*, base_url: str, user_agent: str) -> dict[str, str]:
+    """Return browser-style headers for the HTML form login flow."""
+
+    return {
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Origin": base_url,
+        "Referer": f"{base_url}/",
+        "User-Agent": user_agent,
+    }
+
+
+def mfa_headers(
+    cookies: dict[str, str] | None,
+    *,
+    base_headers: Mapping[str, str],
+    cookie_header: Callable[[dict[str, str] | None], str],
+    xsrf_token: Callable[[dict[str, str] | None], str | None],
+) -> dict[str, str]:
+    """Return headers for MFA endpoints with cookie/XSRF handling."""
+
+    headers = dict(base_headers)
+    headers["Accept"] = "application/json, text/plain, */*"
+    serialized_cookies = cookie_header(cookies)
+    if serialized_cookies:
+        headers["Cookie"] = serialized_cookies
+    token = xsrf_token(cookies)
+    if token:
+        headers["X-CSRF-Token"] = token
+    return headers
+
+
+def login_session_from_cookies(
+    cookies: Mapping[str, str] | None,
+    *,
+    jwt_session_id: Callable[[str | None], str | None],
+) -> tuple[str | None, str | None]:
+    """Extract session details from post-login cookies."""
+
+    if not cookies:
+        return None, None
+    session_id = (
+        cookies.get("_enlighten_4_session")
+        or cookies.get("enlighten_session")
+        or cookies.get("_enlighten_session")
+    )
+    manager_token = cookies.get("enlighten_manager_token_production")
+    if not session_id and manager_token:
+        session_id = jwt_session_id(manager_token)
+    return (
+        str(session_id) if session_id else None,
+        str(manager_token) if manager_token else None,
+    )

--- a/custom_components/enphase_ev/api_client/site_surface.py
+++ b/custom_components/enphase_ev/api_client/site_surface.py
@@ -1,0 +1,161 @@
+"""Site telemetry and livestream HTTP surface for the Enphase cloud client."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import aiohttp
+from yarl import URL
+
+from .. import api_parsers
+from ..log_redaction import redact_site_id
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def weather(client: Any, *, base_url: str, locale: str) -> dict[str, Any]:
+    """Return and validate current weather for a client site."""
+
+    endpoint = f"/systems/{client._site}/weather.json"
+    url = URL(f"{base_url}{endpoint}").with_query({"locale": str(locale)})
+    data = await client._json(
+        "GET",
+        str(url),
+        headers=client._systems_json_headers(),
+    )
+    if not isinstance(data, dict):
+        raise client._invalid_payload_error(
+            endpoint=endpoint,
+            summary="Weather payload must be an object",
+            failure_kind="shape",
+            payload=data,
+        )
+    return cast(dict[str, Any], data)
+
+
+def normalize_latest_power(payload: object) -> dict[str, object] | None:
+    """Normalize app-api latest-power payloads into a stable shape."""
+
+    return cast(
+        dict[str, object] | None,
+        api_parsers.normalize_latest_power_payload(payload),
+    )
+
+
+async def latest_power(client: Any, *, base_url: str) -> dict[str, object] | None:
+    """Return the latest normalized site power sample."""
+
+    url = f"{base_url}/app-api/{client._site}/get_latest_power"
+    data = await client._json("GET", url, headers=client._history_headers())
+    normalized = normalize_latest_power(data)
+    if normalized is not None:
+        return normalized
+
+    top_level_keys: list[str] = []
+    nested_keys: list[str] = []
+    payload_type = type(data).__name__
+    if isinstance(data, dict):
+        top_level_keys = sorted(str(key) for key in data)
+        nested = data.get("latest_power")
+        if not isinstance(nested, dict):
+            candidate = data.get("data")
+            if isinstance(candidate, dict):
+                nested = candidate.get("latest_power")
+                if not isinstance(nested, dict):
+                    nested = candidate
+        if isinstance(nested, dict):
+            nested_keys = sorted(str(key) for key in nested)
+
+    _LOGGER.debug(
+        "Invalid latest power payload for site %s (payload_type=%s, top_level_keys=%s, nested_keys=%s)",
+        redact_site_id(client._site),
+        payload_type,
+        top_level_keys,
+        nested_keys,
+    )
+    return None
+
+
+async def show_livestream(
+    client: Any,
+    *,
+    base_url: str,
+    allow_reauth: bool,
+    unauthorized_error: type[Exception],
+    invalid_payload_error: type[Exception],
+    optional_non_json: Any,
+) -> dict[str, object] | None:
+    """Return site live-status capability flags when available."""
+
+    url = f"{base_url}/app-api/{client._site}/show_livestream"
+    try:
+        data = await client._json(
+            "GET",
+            url,
+            headers=client._system_dashboard_headers(),
+            allow_reauth=allow_reauth,
+        )
+    except unauthorized_error:
+        if not allow_reauth:
+            raise
+        return None
+    except invalid_payload_error as err:
+        if optional_non_json(err):
+            return None
+        raise
+    except aiohttp.ClientResponseError as err:
+        if err.status in (401, 403, 404):
+            if not allow_reauth and err.status in (401, 403):
+                raise
+            return None
+        raise
+    return data if isinstance(data, dict) else None
+
+
+async def livestream_authorizer(
+    client: Any,
+    serial_num: str,
+    *,
+    base_url: str,
+    live_debug: bool,
+    allow_reauth: bool,
+    unauthorized_error: type[Exception],
+    invalid_payload_error: type[Exception],
+    optional_non_json: Any,
+) -> dict[str, object] | None:
+    """Return signed AWS IoT connection details for a site's live stream."""
+
+    query: dict[str, str] = {"serial_num": str(serial_num)}
+    if live_debug:
+        query["live_debug"] = "true"
+    endpoint = (
+        "/service/system_dashboard/api_internal/cs/sites/livestream"
+        if live_debug
+        else "/pv/aws_sigv4/livestream.json"
+    )
+    url = URL(f"{base_url}{endpoint}").with_query(query)
+    headers = client._today_headers()
+    headers["X-Requested-With"] = "XMLHttpRequest"
+    try:
+        data = await client._json(
+            "GET",
+            str(url),
+            headers=headers,
+            allow_reauth=allow_reauth,
+        )
+    except unauthorized_error:
+        if not allow_reauth:
+            raise
+        return None
+    except invalid_payload_error as err:
+        if optional_non_json(err):
+            return None
+        raise
+    except aiohttp.ClientResponseError as err:
+        if err.status in (401, 403, 404):
+            if not allow_reauth and err.status in (401, 403):
+                raise
+            return None
+        raise
+    return data if isinstance(data, dict) else None

--- a/custom_components/enphase_ev/api_client/transport.py
+++ b/custom_components/enphase_ev/api_client/transport.py
@@ -1,0 +1,140 @@
+"""Injected-session authentication transport for Enphase cloud requests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from contextlib import AbstractAsyncContextManager
+import json
+from typing import Any
+
+import aiohttp
+
+
+async def request_json(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    *,
+    timeout: int,
+    headers: dict[str, str] | None,
+    data: Any | None,
+    json_data: Any | None,
+    request_guard: Callable[[str, str], AbstractAsyncContextManager[None]],
+    request_label: Callable[[object, object], str],
+    safe_error_message: Callable[..., str],
+    is_session_limit: Callable[[object], bool],
+    unavailable_error: type[Exception],
+    session_limit_error: type[Exception],
+) -> Any:
+    """Perform an HTTP request returning JSON with timeout handling."""
+
+    req_kwargs: dict[str, Any] = {}
+    if headers is not None:
+        req_kwargs["headers"] = headers
+    if data is not None:
+        req_kwargs["data"] = data
+    if json_data is not None:
+        req_kwargs["json"] = json_data
+
+    async with asyncio.timeout(timeout):
+        async with request_guard(method, url):
+            async with session.request(
+                method, url, allow_redirects=True, **req_kwargs
+            ) as response:
+                if response.status >= 500:
+                    raise unavailable_error(
+                        f"Server error {response.status} at {request_label(method, url)}"
+                    )
+                if response.status >= 400:
+                    try:
+                        body_text = await response.text()
+                    except Exception:  # noqa: BLE001 - best-effort diagnostics
+                        body_text = ""
+                    if is_session_limit(body_text):
+                        raise session_limit_error("Too many active Enlighten sessions")
+                response.raise_for_status()
+                content_type = response.headers.get("Content-Type", "")
+                if "json" not in content_type:
+                    text = await response.text()
+                    if is_session_limit(text):
+                        raise session_limit_error("Too many active Enlighten sessions")
+                    raise unavailable_error(
+                        safe_error_message(
+                            status=int(response.status),
+                            reason="Unexpected non-JSON response",
+                            headers=response.headers,
+                            body_text=text,
+                        )
+                    )
+                payload = await response.json()
+                if is_session_limit(payload):
+                    raise session_limit_error("Too many active Enlighten sessions")
+                return payload
+
+
+async def request_mfa_json(
+    session: aiohttp.ClientSession,
+    method: str,
+    url: str,
+    *,
+    timeout: int,
+    headers: dict[str, str] | None,
+    data: Any | None,
+    request_label: Callable[[object, object], str],
+    safe_error_message: Callable[..., str],
+    is_session_limit: Callable[[object], bool],
+    unavailable_error: type[Exception],
+    session_limit_error: type[Exception],
+) -> Any:
+    """Perform an MFA HTTP request with tolerant JSON parsing."""
+
+    req_kwargs: dict[str, Any] = {}
+    if headers is not None:
+        req_kwargs["headers"] = headers
+    if data is not None:
+        req_kwargs["data"] = data
+
+    async with asyncio.timeout(timeout):
+        async with session.request(
+            method, url, allow_redirects=True, **req_kwargs
+        ) as response:
+            if response.status >= 500:
+                raise unavailable_error(
+                    f"Server error {response.status} at {request_label(method, url)}"
+                )
+            if response.status in (204, 205):
+                return {}
+            if response.status >= 400:
+                try:
+                    body_text = await response.text()
+                except Exception:  # noqa: BLE001 - best-effort diagnostics
+                    body_text = ""
+                if is_session_limit(body_text):
+                    raise session_limit_error("Too many active Enlighten sessions")
+            response.raise_for_status()
+            content_type = response.headers.get("Content-Type", "")
+            if "json" in content_type:
+                payload = await response.json()
+                if is_session_limit(payload):
+                    raise session_limit_error("Too many active Enlighten sessions")
+                return payload
+            text = await response.text()
+            if is_session_limit(text):
+                raise session_limit_error("Too many active Enlighten sessions")
+            if not text.strip():
+                return {}
+            try:
+                payload = json.loads(text)
+            except json.JSONDecodeError as err:
+                raise unavailable_error(
+                    safe_error_message(
+                        status=int(response.status),
+                        reason="Unexpected MFA response",
+                        headers=response.headers,
+                        body_text=text,
+                    )
+                ) from err
+            if is_session_limit(payload):
+                raise session_limit_error("Too many active Enlighten sessions")
+            return payload

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -450,7 +450,8 @@ async def async_get_config_entry_diagnostics(
     }
 
     try:
-        coord = get_runtime_data(entry).coordinator
+        runtime_data = get_runtime_data(entry)
+        coord = runtime_data.coordinator
     except RuntimeError:
         return _redact_diagnostics_payload(diag, site_ids=site_ids)
 
@@ -611,6 +612,18 @@ async def async_get_config_entry_diagnostics(
         "grid_profile": grid_profile,
         "firmware_catalog": firmware_catalog or None,
     }
+
+    weather_coordinator = runtime_data.weather_coordinator
+    if weather_coordinator is None:
+        diag["coordinator"]["weather"] = {
+            "role": "child_coordinator",
+            "discovery_state": "disabled",
+        }
+    else:
+        try:
+            diag["coordinator"]["weather"] = weather_coordinator.diagnostics()
+        except DIAGNOSTIC_CAPTURE_ERRORS:
+            diag["coordinator"]["weather"] = None
 
     schedule_sync = getattr(coord, "schedule_sync", None)
     if schedule_sync is not None and hasattr(schedule_sync, "diagnostics"):

--- a/custom_components/enphase_ev/runtime_data.py
+++ b/custom_components/enphase_ev/runtime_data.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -18,6 +20,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .evse_firmware import EvseFirmwareDetailsManager
     from .firmware_catalog import FirmwareCatalogManager
     from .gateway_software_update import GatewaySoftwareUpdateManager
+    from .weather import EnphaseWeatherCoordinator
 
 
 @dataclass(slots=True)
@@ -30,7 +33,23 @@ class EnphaseRuntimeData:
     gateway_software_update: GatewaySoftwareUpdateManager | None = None
     battery_schedule_editor: BatteryScheduleEditorManager | None = None
     evse_schedule_editor: EvseScheduleEditorManager | None = None
+    weather_coordinator: EnphaseWeatherCoordinator | None = None
+    weather_discovery_task: asyncio.Task[None] | None = None
     reload_suppression_count: int = 0
+
+    async def async_stop_weather(self) -> None:
+        """Stop and release the optional weather child coordinator."""
+
+        task = self.weather_discovery_task
+        self.weather_discovery_task = None
+        if isinstance(task, asyncio.Task) and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        coordinator = self.weather_coordinator
+        self.weather_coordinator = None
+        if coordinator is not None:
+            coordinator.mark_stopped()
 
 
 type EnphaseConfigEntry = ConfigEntry[EnphaseRuntimeData]

--- a/custom_components/enphase_ev/weather.py
+++ b/custom_components/enphase_ev/weather.py
@@ -29,7 +29,7 @@ from .api import (
 )
 from .const import DOMAIN, OPT_WEATHER_ENABLED
 from .device_info_helpers import _cloud_device_info
-from .log_redaction import redact_site_id
+from .log_redaction import redact_site_id, redact_text
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
 
 _LOGGER = logging.getLogger(__name__)
@@ -152,7 +152,14 @@ class EnphaseWeatherCoordinator(
 ):
     """Poll the optional Enlighten weather endpoint independently."""
 
-    def __init__(self, hass: HomeAssistant, client: Any, *, locale: str) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client: Any,
+        *,
+        locale: str,
+        site_id: str | None = None,
+    ) -> None:
         super().__init__(
             hass,
             _LOGGER,
@@ -161,6 +168,9 @@ class EnphaseWeatherCoordinator(
         )
         self._client = client
         self._locale = locale
+        self._site_id = site_id
+        self._discovery_state = "pending"
+        self._discovery_failures = 0
 
     async def _async_update_data(self) -> EnphaseWeatherData:
         try:
@@ -188,9 +198,41 @@ class EnphaseWeatherCoordinator(
         try:
             data = await self._async_update_data()
         except UpdateFailed:
+            self._discovery_state = "retrying"
+            self._discovery_failures += 1
             return False
         self.async_set_updated_data(data)
+        self._discovery_state = "available"
         return True
+
+    def mark_unsupported(self) -> None:
+        """Record that the optional endpoint is unsupported for this site."""
+
+        self._discovery_state = "unsupported"
+
+    def mark_stopped(self) -> None:
+        """Record explicit config-entry lifecycle shutdown."""
+
+        self._discovery_state = "stopped"
+
+    def diagnostics(self) -> dict[str, object]:
+        """Return a redacted health snapshot for config-entry diagnostics."""
+
+        last_exception = getattr(self, "last_exception", None)
+        safe_error = None
+        if last_exception is not None:
+            safe_error = redact_text(
+                last_exception,
+                site_ids=((self._site_id,) if self._site_id else ()),
+            )
+        return {
+            "role": "child_coordinator",
+            "discovery_state": self._discovery_state,
+            "discovery_failures": self._discovery_failures,
+            "last_update_success": bool(self.last_update_success),
+            "last_error": safe_error,
+            "update_interval_seconds": int(_WEATHER_UPDATE_INTERVAL.total_seconds()),
+        }
 
 
 class EnphaseSiteWeather(
@@ -247,6 +289,7 @@ async def _async_discover_weather(
         try:
             available = await coordinator.async_probe()
         except WeatherEndpointUnsupported:
+            coordinator.mark_unsupported()
             _LOGGER.debug(
                 "Weather endpoint unsupported for site %s; discovery stopped",
                 redact_site_id(site_id),
@@ -279,9 +322,11 @@ async def async_setup_entry(
 ) -> None:
     """Create weather only after an enabled endpoint probe succeeds."""
 
-    main_coordinator = get_runtime_data(entry).coordinator
+    runtime_data = get_runtime_data(entry)
+    main_coordinator = runtime_data.coordinator
     site_id = str(main_coordinator.site_id)
     if not bool(entry.options.get(OPT_WEATHER_ENABLED, False)):
+        await runtime_data.async_stop_weather()
         ent_reg = er.async_get(hass)
         entity_id = ent_reg.async_get_entity_id(
             "weather",
@@ -296,7 +341,9 @@ async def async_setup_entry(
         hass,
         main_coordinator.client,
         locale=locale,
+        site_id=site_id,
     )
+    runtime_data.weather_coordinator = coordinator
     task = entry.async_create_background_task(
         hass,
         _async_discover_weather(
@@ -311,3 +358,4 @@ async def async_setup_entry(
     )
     if callable(track_background_task):
         track_background_task(task)
+    runtime_data.weather_discovery_task = task

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,8 @@ flowchart TD
     D --> F["Runtime managers"]
     D --> G["InventoryView"]
     D --> H["Entity platforms"]
+    H --> W["Weather child coordinator"]
+    W --> E
     E --> I["Enphase cloud endpoints"]
     F --> D
     G --> H
@@ -81,7 +83,20 @@ path unless Home Assistant cannot safely create the integration without it.
 
 ## Cloud Client
 
-`api.py` is the HTTP boundary. It handles Enlighten login, MFA, credential refresh helpers, request headers, response parsing, invalid payload signatures, and endpoint-specific compatibility paths.
+`api.py` is the stable public compatibility facade for the HTTP boundary. It
+retains `EnphaseEVClient` and the existing authentication/error imports used by
+the integration. Cohesive implementations live under `api_client/`:
+
+- `transport.py` owns injected-`ClientSession` authentication requests and response handling.
+- `auth.py` owns login, MFA, cookie, and XSRF request shaping.
+- `site_surface.py` owns site telemetry and livestream HTTP surface behavior.
+
+The facade remains intentionally thin for migrated slices. New cloud behavior
+should be added to a cohesive internal surface rather than growing `api.py`.
+Internal modules must accept the Home Assistant-provided `ClientSession` and
+must not create or own a session. This keeps the boundary suitable for eventual
+extraction into an independent async client library without adding a runtime
+dependency today.
 
 Several Enphase surfaces behave like browser-backed applications rather than stable public APIs:
 
@@ -90,7 +105,20 @@ Several Enphase surfaces behave like browser-backed applications rather than sta
 - Scheduler and EVSE control endpoints can accept writes before read endpoints reflect the new state.
 - Some optional endpoints return HTML, login pages, or non-JSON success responses.
 
-Keep new endpoint handling inside `api.py` or narrow parser/helper modules so coordinator and entity code remain normalized.
+Keep new endpoint handling inside `api_client/` or narrow parser modules so
+coordinator and entity code remain normalized. Preserve compatibility exports
+from `api.py` when moving existing behavior.
+
+### Weather child coordinator
+
+Weather is the deliberate exception to the one-main-coordinator polling model.
+It is optional, discovered independently, and uses a 15-minute cadence that
+should not affect core integration availability. The weather platform therefore
+owns an `EnphaseWeatherCoordinator` child. The config entry's typed runtime data
+tracks both the child and its discovery task, unload explicitly cancels/releases
+them, and config-entry diagnostics report discovery and update health. Entities
+must not create additional independent coordinators without documenting the
+lifecycle and diagnostics ownership here.
 
 ## Runtime Managers
 

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -783,7 +783,15 @@ async def test_config_entry_diagnostics_includes_coordinator(
         }
     )
     coord._scheduler_backoff_ends_utc = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    config_entry.runtime_data = EnphaseRuntimeData(
+        coordinator=coord,
+        weather_coordinator=SimpleNamespace(
+            diagnostics=lambda: {
+                "role": "child_coordinator",
+                "discovery_state": "available",
+            }
+        ),
+    )
 
     diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
 
@@ -796,6 +804,10 @@ async def test_config_entry_diagnostics_includes_coordinator(
         "X-Test",
     ]
     assert diag["coordinator"]["headers_info"]["has_scheduler_bearer"] is True
+    assert diag["coordinator"]["weather"] == {
+        "role": "child_coordinator",
+        "discovery_state": "available",
+    }
     assert diag["coordinator"]["last_scheduler_modes"] == {RANDOM_SERIAL: "FAST"}
     assert diag["coordinator"]["session_history"]["cache_keys"] == 1
     assert diag["coordinator"]["current_power"] == {
@@ -1063,11 +1075,17 @@ async def test_config_entry_diagnostics_handles_system_events_capture_error(
     coord.system_events_runtime = SimpleNamespace(
         diagnostics=lambda: (_ for _ in ()).throw(RuntimeError("boom"))
     )
-    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    config_entry.runtime_data = EnphaseRuntimeData(
+        coordinator=coord,
+        weather_coordinator=SimpleNamespace(
+            diagnostics=lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+        ),
+    )
 
     diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
 
     assert diag["coordinator"]["system_events"] == {}
+    assert diag["coordinator"]["weather"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_weather.py
+++ b/tests/components/enphase_ev/test_weather.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import contextmanager
 from collections.abc import Coroutine
 from types import SimpleNamespace
@@ -164,6 +165,8 @@ async def test_setup_schedules_discovery_and_creates_cloud_weather_after_success
     assert added == []
     client.weather.assert_not_awaited()
     assert len(scheduled) == 1
+    assert config_entry.runtime_data.weather_coordinator is not None
+    assert config_entry.runtime_data.weather_discovery_task is not None
     assert scheduled[0][1] == "enphase_ev_weather_discovery"
     coordinator.track_entry_background_task.assert_called_once()
 
@@ -186,6 +189,14 @@ async def test_setup_schedules_discovery_and_creates_cloud_weather_after_success
         ("enphase_ev", f"type:{RANDOM_SITE_ID}:cloud")
     }
     client.weather.assert_awaited_once_with(locale="en-AU")
+    assert config_entry.runtime_data.weather_coordinator.diagnostics() == {
+        "role": "child_coordinator",
+        "discovery_state": "available",
+        "discovery_failures": 0,
+        "last_update_success": True,
+        "last_error": None,
+        "update_interval_seconds": 900,
+    }
 
 
 @pytest.mark.asyncio
@@ -290,3 +301,36 @@ async def test_weather_coordinator_uses_optional_scope_and_retains_data_on_failu
 
     assert coordinator.last_update_success is False
     assert coordinator.data is original
+    assert coordinator.diagnostics()["last_error"] == "offline"
+
+
+@pytest.mark.asyncio
+async def test_runtime_data_explicitly_stops_weather_child_coordinator(hass) -> None:
+    """The entry runtime owns discovery cancellation and child release."""
+
+    coordinator = EnphaseWeatherCoordinator(
+        hass,
+        SimpleNamespace(weather=AsyncMock()),
+        locale="en",
+        site_id=RANDOM_SITE_ID,
+    )
+    started = asyncio.Event()
+
+    async def _pending() -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    task = hass.async_create_task(_pending())
+    await started.wait()
+    runtime_data = EnphaseRuntimeData(
+        coordinator=SimpleNamespace(),
+        weather_coordinator=coordinator,
+        weather_discovery_task=task,
+    )
+
+    await runtime_data.async_stop_weather()
+
+    assert task.cancelled()
+    assert runtime_data.weather_coordinator is None
+    assert runtime_data.weather_discovery_task is None
+    assert coordinator.diagnostics()["discovery_state"] == "stopped"


### PR DESCRIPTION
## Summary

Extract cohesive authentication, transport, and site-surface behavior behind the compatible `api.py` facade, and make weather an explicitly owned child coordinator.

- Add internal `api_client` modules for request transport, authentication shaping, and site telemetry/livestream surfaces.
- Preserve existing `EnphaseEVClient` APIs and monkeypatch targets.
- Store weather coordinator/task ownership in typed config-entry runtime data.
- Add explicit weather cleanup and sanitized child-coordinator diagnostics.
- Document the API and weather boundaries.

This focused draft is included for isolated review. The fully integrated merge candidate is #784; do not merge both PRs.

## Related Issues

- Integrated merge candidate: #784

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/api.py custom_components/enphase_ev/api_client custom_components/enphase_ev/diagnostics.py custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/weather.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_weather.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/api.py,custom_components/enphase_ev/api_client/__init__.py,custom_components/enphase_ev/api_client/auth.py,custom_components/enphase_ev/api_client/site_surface.py,custom_components/enphase_ev/api_client/transport.py,custom_components/enphase_ev/diagnostics.py,custom_components/enphase_ev/runtime_data.py,custom_components/enphase_ev/weather.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
```

Results: 3,858 full-suite tests passed; 3,726 integration tests passed; all touched source statements reported 100% coverage; strict full-package mypy passed.

## Checklist

- [x] `CHANGELOG.md` is not required because user-facing behavior is preserved.
- [x] I updated `docs/architecture.md`.
- [x] Translation files are unchanged because no user-facing strings changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Weather child-coordinator discovery and health are now exposed through sanitized diagnostics. No screenshots are required.
