### PR TITLE
Prepare release 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,32 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v4.0.0 - 2026-07-17
+
+### 🚧 Breaking changes
 - Replaced the optional Grid Control Status sensor and Request Grid Toggle OTP
   button with a guided workflow under Configure > Advanced > Grid Mode. Existing
   control entities and the retired enable option are removed automatically; the
-  read-only Grid Mode sensor remains available.
+  read-only Grid Mode sensor remains available. (#789)
 - Changed `request_grid_toggle_otp` and `set_grid_mode` to admin-only actions that
   require an explicit Enphase config entry. Entity, device, and site ID routing is
   no longer accepted; the bundled Grid Mode OTP blueprints now use config-entry
   selection, and the script blueprint exposes separate OTP-request and mode-apply
-  operations.
+  operations. (#789)
 
 ### ✨ New features
 - None
@@ -25,9 +42,10 @@ All notable changes to this project will be documented in this file.
 - Made Grid Mode eligibility checks on demand so the control endpoint is refreshed
   only while using the workflow or advanced actions. Successful changes are shown
   as accepted while the Grid Mode sensor continues observing the physical result.
+  (#789)
 
 ### 🔄 Other changes
-- None
+- Bumped the integration manifest version to `4.0.0`.
 
 ## v4.0.0b2 - 2026-07-15
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "4.0.0b2"
+  "version": "4.0.0"
 }


### PR DESCRIPTION
## Summary

Prepare the final v4.0.0 release by promoting the integration manifest from `4.0.0b2` to `4.0.0` and moving the post-beta Grid Mode workflow changes into a dated release section.

The changelog retains a fresh Unreleased section and references the merged Grid Mode work from #789.

## Related Issues

- Related implementation: #789

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (release preparation)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/button.py,custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/const.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/services.py --fail-under=100"
```

Results:

- 3,898 full-suite tests passed.
- 3,766 integration tests passed.
- 43 service-translation tests passed.
- 100% targeted coverage across all nine Python modules changed since v4.0.0b2: 16,849 statements, 0 missed.
- Ruff, Black, pre-commit, strict mypy, import-time profiling, and both Platinum quality-scale checks passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation when behaviour or options changed (completed in #789).
- [x] I verified translations are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results; all current main checks are green.
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

A Home Assistant 2026.7.2 instance running v4.0.0b2 was inspected before release preparation. The integration config entry was loaded, Service Status was healthy, no Enphase system-log entries were present, no endpoint families were degraded, and the 50-sample refresh history contained no failed, cancelled, or stale refreshes.

The latest refresh completed in 3.358 seconds; rolling p50 was 3.379 seconds and p95 was 21.543 seconds against the 30-second budget. The final post-beta Grid Mode migration remains covered by the repository and CI suites but should receive a final installed-candidate smoke test before publishing the GitHub release.
