### PR TITLE
Populate Grid Profile sensor attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Populated Grid Profile sensor metadata such as profile group, PEL support,
+  277 V compatibility, and recommendation status from the cached Activation
+  profile catalog.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -3740,7 +3740,7 @@ class EnphaseCoordinator(
                 async with self._grid_profile_metadata_refresh_lock:
                     with request_metrics_scope("grid_profile_metadata"):
                         with enlighten_optional_read_scope():
-                            await refresh(force=force, load_profiles=False)
+                            await refresh(force=force, load_profiles=True)
         except TimeoutError:
             _LOGGER.debug(
                 "Stopped optional grid-profile metadata refresh for site %s after %.1f seconds",

--- a/tests/components/enphase_ev/test_grid_profile_runtime.py
+++ b/tests/components/enphase_ev/test_grid_profile_runtime.py
@@ -612,7 +612,7 @@ async def test_coordinator_refreshes_grid_profile_metadata_after_first_poll() ->
     assert len(created_tasks) == 1
     await task
 
-    refresh.assert_awaited_once_with(force=False, load_profiles=False)
+    refresh.assert_awaited_once_with(force=False, load_profiles=True)
     assert coordinator._grid_profile_metadata_task is None
 
     refresh.reset_mock()
@@ -672,7 +672,7 @@ async def test_coordinator_serializes_startup_and_steady_grid_profile_refreshes(
     calls: list[bool] = []
 
     async def _refresh(*, force: bool, load_profiles: bool) -> None:
-        assert load_profiles is False
+        assert load_profiles is True
         calls.append(force)
         if force:
             first_started.set()


### PR DESCRIPTION
## Summary

Populate the Grid Profile sensor's profile group, PEL support, 277 V compatibility, and recommendation attributes from the cached Activation profile catalog.

The background metadata refresh previously skipped catalog loading, so the current profile name and ID could resolve while catalog-backed attributes remained unknown. The refresh now loads the catalog outside the core coordinator path and reuses the existing one-hour cache.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_grid_profile_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro -v /Users/james/.codex/worktrees/9a78/ha-enphase-ev-charger:/Users/james/.codex/worktrees/9a78/ha-enphase-ev-charger:delegated ha-dev bash -lc "python -m pre_commit run --all-files"
```

- Integration tests: 3,766 passed.
- Full repository tests: 3,898 passed.
- Targeted coordinator coverage: 100%.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation does not require an update because supported behavior and options are unchanged.
- [x] Translations are unchanged.
- [x] I ran targeted coverage for the touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The Grid Profile entity already resolved its current state from the Gateway. This change fills the catalog-backed attributes during the bounded background metadata refresh.
