### PR TITLE
Improve integration settings recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ All notable changes to this project will be documented in this file.
   profile catalog.
 
 ### 🔧 Improvements
-- None
+- Applied non-topology integration options without reloading the config entry, and
+  preserved the live coordinator and last known entity state across the remaining
+  device/topology reloads. This substantially reduces unavailable and unknown
+  entity states after saving integration settings.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import re
 import time as _time
@@ -18,7 +19,20 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import CONF_INCLUDE_INVERTERS, CONF_SELECTED_TYPE_KEYS, DOMAIN
+from .const import (
+    CONF_EMAIL,
+    CONF_INCLUDE_INVERTERS,
+    CONF_PASSWORD,
+    CONF_REMEMBER_PASSWORD,
+    CONF_SELECTED_TYPE_KEYS,
+    CONF_SERIALS,
+    CONF_SITE_NAME,
+    CONF_SITE_ONLY,
+    DOMAIN,
+    OPT_MICROINVERTER_LIFETIME_ENERGY_ENABLED,
+    OPT_MICROINVERTER_POWER_ENABLED,
+    OPT_WEATHER_ENABLED,
+)
 from .device_info_helpers import (
     _cloud_device_info,
     _compose_charger_model_display,
@@ -63,6 +77,25 @@ if TYPE_CHECKING:  # pragma: no cover
     from .coordinator import EnphaseCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+_RUNTIME_HANDOFF_KEY = f"{DOMAIN}_runtime_handoffs"
+_RELOAD_REQUIRED_OPTION_KEYS = frozenset(
+    {
+        OPT_MICROINVERTER_LIFETIME_ENERGY_ENABLED,
+        OPT_MICROINVERTER_POWER_ENABLED,
+        OPT_WEATHER_ENABLED,
+    }
+)
+_HOT_APPLY_DATA_KEYS = frozenset({CONF_EMAIL, CONF_PASSWORD, CONF_REMEMBER_PASSWORD})
+_RUNTIME_HANDOFF_DATA_KEYS = frozenset(
+    {
+        CONF_INCLUDE_INVERTERS,
+        CONF_SELECTED_TYPE_KEYS,
+        CONF_SERIALS,
+        CONF_SITE_NAME,
+        CONF_SITE_ONLY,
+    }
+)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -242,30 +275,94 @@ def _is_disabled_by_integration(disabled_by: object) -> bool:
     return text == "integration"
 
 
-async def _async_update_listener(
-    hass: HomeAssistant, entry: EnphaseConfigEntry
+async def _async_update_listener_locked(
+    hass: HomeAssistant,
+    entry: EnphaseConfigEntry,
+    runtime_data: EnphaseRuntimeData | None,
 ) -> None:
-    runtime_data = getattr(entry, "runtime_data", None)
+    target_data = dict(entry.data)
+    target_options = dict(entry.options)
     if isinstance(runtime_data, EnphaseRuntimeData):
         suppression_count = int(getattr(runtime_data, "reload_suppression_count", 0))
         if suppression_count > 0:
             # Coordinator-owned config-entry data updates persist tokens/cooldowns
             # and must not recreate the coordinator/client.
             runtime_data.reload_suppression_count = suppression_count - 1
+            runtime_data.applied_data = target_data
+            runtime_data.applied_options = target_options
             return
     if getattr(entry, "disabled_by", None) is not None:
         return
     loaded_state = getattr(ConfigEntryState, "LOADED", None)
     if loaded_state is not None and entry.state is not loaded_state:
         return
+    if isinstance(runtime_data, EnphaseRuntimeData):
+        previous_data = runtime_data.applied_data
+        previous_options = runtime_data.applied_options
+        preserve_runtime = False
+        if previous_data is not None and previous_options is not None:
+            changed_data_keys = {
+                key
+                for key in previous_data.keys() | target_data.keys()
+                if previous_data.get(key) != target_data.get(key)
+            }
+            changed_option_keys = {
+                key
+                for key in previous_options.keys() | target_options.keys()
+                if previous_options.get(key) != target_options.get(key)
+            }
+            reload_required = bool(
+                changed_data_keys - _HOT_APPLY_DATA_KEYS
+                or changed_option_keys & _RELOAD_REQUIRED_OPTION_KEYS
+            )
+            preserve_runtime = not bool(
+                changed_data_keys - _HOT_APPLY_DATA_KEYS - _RUNTIME_HANDOFF_DATA_KEYS
+            )
+            if not reload_required:
+                coord = runtime_data.coordinator
+                try:
+                    coord.apply_auth_storage_config(target_data)
+                    await coord.async_apply_config_entry_options(previous_options)
+                except Exception:  # noqa: BLE001 - fall back to the proven reload path
+                    _LOGGER.exception(
+                        "Failed to apply Enphase options live; reloading entry %s",
+                        entry.entry_id,
+                    )
+                else:
+                    runtime_data.applied_data = target_data
+                    runtime_data.applied_options = target_options
+                    return
+
+        runtime_data.preserve_for_reload = preserve_runtime
     try:
-        await hass.config_entries.async_reload(entry.entry_id)
+        reloaded = await hass.config_entries.async_reload(entry.entry_id)
+        if reloaded is False and isinstance(runtime_data, EnphaseRuntimeData):
+            runtime_data.preserve_for_reload = False
     except OperationNotAllowed as err:
+        if isinstance(runtime_data, EnphaseRuntimeData):
+            runtime_data.preserve_for_reload = False
         _LOGGER.debug(
             "Skipping reload for entry %s while state is changing: %s",
             entry.entry_id,
             err,
         )
+    except BaseException:
+        if isinstance(runtime_data, EnphaseRuntimeData):
+            runtime_data.preserve_for_reload = False
+        raise
+
+
+async def _async_update_listener(
+    hass: HomeAssistant, entry: EnphaseConfigEntry
+) -> None:
+    runtime_data = getattr(entry, "runtime_data", None)
+    if not isinstance(runtime_data, EnphaseRuntimeData):
+        await _async_update_listener_locked(hass, entry, None)
+        return
+    async with runtime_data.update_listener_lock:
+        if getattr(entry, "runtime_data", None) is not runtime_data:
+            return
+        await _async_update_listener_locked(hass, entry, runtime_data)
 
 
 async def _async_unload_platforms_safe(
@@ -1590,7 +1687,11 @@ def _remove_retired_grid_profile_device_entities(
     )
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> bool:
+async def _async_setup_entry_impl(
+    hass: HomeAssistant,
+    entry: EnphaseConfigEntry,
+    preserved_runtime: EnphaseRuntimeData | None,
+) -> bool:
     setup_started = _time.monotonic()
     setup_timings: dict[str, float] = {}
 
@@ -1623,34 +1724,61 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     from .labels import async_prime_label_translations
 
     coordinator_started = _time.monotonic()
-    coord = EnphaseCoordinator(
-        hass,
-        entry.data,
-        config_entry=entry,
-        cookie_header_session=async_create_clientsession(
+    reused_runtime = isinstance(preserved_runtime, EnphaseRuntimeData)
+    if reused_runtime:
+        assert isinstance(preserved_runtime, EnphaseRuntimeData)
+        entry.runtime_data = preserved_runtime
+        preserved_runtime.preserve_for_reload = False
+        coord = preserved_runtime.coordinator
+        coord.apply_config_entry_data(entry.data)
+        coord.apply_auth_storage_config(entry.data)
+        await coord.async_apply_config_entry_options(dict(entry.options))
+        firmware_catalog = preserved_runtime.firmware_catalog
+        evse_firmware_details = preserved_runtime.evse_firmware_details
+        gateway_software_update = preserved_runtime.gateway_software_update
+        battery_schedule_editor = preserved_runtime.battery_schedule_editor
+        evse_schedule_editor = preserved_runtime.evse_schedule_editor
+        if (
+            firmware_catalog is None
+            or evse_firmware_details is None
+            or gateway_software_update is None
+            or battery_schedule_editor is None
+            or evse_schedule_editor is None
+        ):
+            raise RuntimeError("Incomplete preserved Enphase runtime")
+        preserved_runtime.applied_data = dict(entry.data)
+        preserved_runtime.applied_options = dict(entry.options)
+    else:
+        coord = EnphaseCoordinator(
             hass,
-            auto_cleanup=True,
-            cookie_jar=aiohttp.DummyCookieJar(),
-        ),
-    )
-    firmware_catalog = FirmwareCatalogManager(hass)
-    evse_firmware_details = EvseFirmwareDetailsManager(lambda: coord.client)
-    gateway_software_update = GatewaySoftwareUpdateManager(
-        lambda: coord.client,
-        lambda: coord.inventory_view.type_device_serial_number("envoy"),
-    )
-    battery_schedule_editor = BatteryScheduleEditorManager(coord)
-    evse_schedule_editor = EvseScheduleEditorManager(coord)
-    setattr(coord, "firmware_catalog_manager", firmware_catalog)
-    setattr(coord, "evse_firmware_details_manager", evse_firmware_details)
-    entry.runtime_data = EnphaseRuntimeData(
-        coordinator=coord,
-        firmware_catalog=firmware_catalog,
-        evse_firmware_details=evse_firmware_details,
-        gateway_software_update=gateway_software_update,
-        battery_schedule_editor=battery_schedule_editor,
-        evse_schedule_editor=evse_schedule_editor,
-    )
+            entry.data,
+            config_entry=entry,
+            cookie_header_session=async_create_clientsession(
+                hass,
+                auto_cleanup=True,
+                cookie_jar=aiohttp.DummyCookieJar(),
+            ),
+        )
+        firmware_catalog = FirmwareCatalogManager(hass)
+        evse_firmware_details = EvseFirmwareDetailsManager(lambda: coord.client)
+        gateway_software_update = GatewaySoftwareUpdateManager(
+            lambda: coord.client,
+            lambda: coord.inventory_view.type_device_serial_number("envoy"),
+        )
+        battery_schedule_editor = BatteryScheduleEditorManager(coord)
+        evse_schedule_editor = EvseScheduleEditorManager(coord)
+        setattr(coord, "firmware_catalog_manager", firmware_catalog)
+        setattr(coord, "evse_firmware_details_manager", evse_firmware_details)
+        entry.runtime_data = EnphaseRuntimeData(
+            coordinator=coord,
+            firmware_catalog=firmware_catalog,
+            evse_firmware_details=evse_firmware_details,
+            gateway_software_update=gateway_software_update,
+            battery_schedule_editor=battery_schedule_editor,
+            evse_schedule_editor=evse_schedule_editor,
+            applied_data=dict(entry.data),
+            applied_options=dict(entry.options),
+        )
     _record_phase("coordinator_init_s", coordinator_started)
     setup_milestones: dict[str, float] = {}
     begin_setup_tracking = getattr(coord, "begin_setup_tracking", None)
@@ -1684,7 +1812,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     )
     try:
         bootstrap_first_refresh = getattr(coord, "async_bootstrap_first_refresh", None)
-        if callable(bootstrap_first_refresh):
+        if reused_runtime:
+            setup_timings["first_refresh_s"] = 0.0
+        elif callable(bootstrap_first_refresh):
             await bootstrap_first_refresh()
         else:
             # Compatibility for lightweight coordinators supplied by downstream tests.
@@ -1819,6 +1949,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
             f"{DOMAIN}_startup_warmup",
         )
 
+    if reused_runtime:
+        _schedule_background_task(
+            coord.async_request_refresh(),
+            f"{DOMAIN}_reload_refresh",
+        )
+
     grid_profile_startup_probe = getattr(
         coord, "async_refresh_grid_profile_metadata", None
     )
@@ -1846,6 +1982,53 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     return True
 
 
+async def _async_cleanup_failed_runtime_handoff(
+    entry: EnphaseConfigEntry,
+    runtime_data: EnphaseRuntimeData,
+) -> None:
+    """Release a claimed runtime when config-entry setup does not complete."""
+
+    coord = runtime_data.coordinator
+    cleanup_steps = (
+        runtime_data.async_stop_weather,
+        getattr(getattr(coord, "schedule_sync", None), "async_stop", None),
+        getattr(coord, "async_cleanup_runtime_state", None),
+        getattr(coord, "async_close", None),
+    )
+    for cleanup in cleanup_steps:
+        if not callable(cleanup):
+            continue
+        try:
+            result = cleanup()
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # noqa: BLE001 - continue releasing the remaining resources
+            _LOGGER.exception(
+                "Failed cleaning up a preserved runtime for entry %s",
+                entry.entry_id,
+            )
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> bool:
+    """Set up an Enphase config entry, reusing a handed-off runtime when safe."""
+
+    handoffs = hass.data.get(_RUNTIME_HANDOFF_KEY)
+    preserved_runtime = (
+        handoffs.pop(entry.entry_id, None) if isinstance(handoffs, dict) else None
+    )
+    claimed_runtime = (
+        preserved_runtime if isinstance(preserved_runtime, EnphaseRuntimeData) else None
+    )
+    try:
+        return await _async_setup_entry_impl(hass, entry, claimed_runtime)
+    except BaseException:
+        if claimed_runtime is not None:
+            await _async_cleanup_failed_runtime_handoff(entry, claimed_runtime)
+            if getattr(entry, "runtime_data", None) is claimed_runtime:
+                entry.runtime_data = None
+        raise
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> bool:
     coord = None
     runtime_data = None
@@ -1860,15 +2043,28 @@ async def async_unload_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> 
             await runtime_data.async_stop_weather()
         if coord is not None and hasattr(coord, "schedule_sync"):
             await coord.schedule_sync.async_stop()
-        async_cleanup_runtime_state = getattr(
-            coord, "async_cleanup_runtime_state", None
+        preserve_runtime = bool(
+            runtime_data is not None and runtime_data.preserve_for_reload
         )
-        if callable(async_cleanup_runtime_state):
-            await async_cleanup_runtime_state()
-        elif coord is not None and hasattr(coord, "cleanup_runtime_state"):
-            coord.cleanup_runtime_state()
-        if coord is not None and hasattr(coord, "async_close"):
-            await coord.async_close()
+        if preserve_runtime:
+            async_quiesce_for_reload = getattr(coord, "async_quiesce_for_reload", None)
+            if callable(async_quiesce_for_reload):
+                preserve_runtime = await async_quiesce_for_reload() is not False
+            if not preserve_runtime and runtime_data is not None:
+                runtime_data.preserve_for_reload = False
+        if preserve_runtime:
+            handoffs = hass.data.setdefault(_RUNTIME_HANDOFF_KEY, {})
+            handoffs[entry.entry_id] = runtime_data
+        else:
+            async_cleanup_runtime_state = getattr(
+                coord, "async_cleanup_runtime_state", None
+            )
+            if callable(async_cleanup_runtime_state):
+                await async_cleanup_runtime_state()
+            elif coord is not None and hasattr(coord, "cleanup_runtime_state"):
+                coord.cleanup_runtime_state()
+            if coord is not None and hasattr(coord, "async_close"):
+                await coord.async_close()
         entry.runtime_data = None
         loaded_state = getattr(ConfigEntryState, "LOADED", None)
         has_loaded_entries = any(

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2078,6 +2078,7 @@ class EnphaseEVClient:
             tuple[str, str, str, str], str
         ] = {}
         self._battery_config_supports_mqtt: bool | None = None
+
         self._battery_config_write_bases: dict[str, dict[str, Any]] = {}
         self._cookie = cookie or ""
         self._eauth = eauth or None
@@ -2094,6 +2095,11 @@ class EnphaseEVClient:
             "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
         }
         self.update_credentials(eauth=eauth, cookie=cookie)
+
+    def set_timeout(self, timeout: int) -> None:
+        """Update the request timeout for subsequent API operations."""
+
+        self._timeout = int(timeout)
 
     def set_reauth_callback(
         self, callback: Callable[[], Awaitable[bool]] | None

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -2354,8 +2354,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[misc]
         new_data[CONF_SITE_ONLY] = site_only
         new_data[CONF_INCLUDE_INVERTERS] = "microinverter" in selected_type_keys
         new_data[CONF_SERIALS] = serials
-        self.hass.config_entries.async_update_entry(self._entry, data=new_data)
-
         options = dict(self._entry.options)
         options[OPT_SCHEDULE_SYNC_ENABLED] = bool(
             device_data.get(
@@ -2419,6 +2417,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[misc]
                 )
             )
             or self._default_nominal_voltage()
+        )
+        self.hass.config_entries.async_update_entry(
+            self._entry,
+            data=new_data,
+            options=options,
         )
         return self.async_create_entry(title="", data=options)
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -84,9 +84,12 @@ from .const import (
     CONF_SITE_NAME,
     CONF_TOKEN_EXPIRES_AT,
     DEFAULT_API_TIMEOUT,
+    DEFAULT_DEGRADED_SERVICE_REPAIR_ISSUES,
     DEFAULT_FAST_POLL_INTERVAL,
     DEFAULT_PRICING_EDITS_ENABLED,
+    DEFAULT_SCHEDULE_SYNC_ENABLED,
     DEFAULT_SCAN_INTERVAL,
+    DEFAULT_SYSTEM_EVENT_REPAIR_ISSUES,
     MAX_API_TIMEOUT,
     MAX_POLL_INTERVAL,
     MAX_SESSION_HISTORY_INTERVAL_MIN,
@@ -104,11 +107,14 @@ from .const import (
     HEMS_AUTH_BACKOFF_STEPS_S,
     HEMS_AUTH_MANUAL_CLEAR_COOLDOWN_S,
     OPT_API_TIMEOUT,
+    OPT_DEGRADED_SERVICE_REPAIR_ISSUES,
     OPT_FAST_POLL_INTERVAL,
     OPT_NOMINAL_VOLTAGE,
     OPT_PRICING_EDITS_ENABLED,
+    OPT_SCHEDULE_SYNC_ENABLED,
     OPT_SLOW_POLL_INTERVAL,
     OPT_SESSION_HISTORY_INTERVAL,
+    OPT_SYSTEM_EVENT_REPAIR_ISSUES,
     PHASE_SWITCH_CONFIG_SETTING,
     SAVINGS_OPERATION_MODE_SUBTYPE,
     DEFAULT_SESSION_HISTORY_INTERVAL_MIN,
@@ -1250,6 +1256,150 @@ class EnphaseCoordinator(
             self._minimal_setup_refresh_active = False
             self.record_setup_phase("first_refresh_s", started)
 
+    def apply_config_entry_data(self, config: Mapping[str, Any]) -> None:
+        """Apply topology configuration when reusing a coordinator for reload."""
+
+        site_id = str(config[CONF_SITE_ID])
+        if site_id != self.site_id:
+            raise ValueError("Cannot reuse a coordinator for a different site")
+
+        raw_serials = config.get(CONF_SERIALS) or []
+        if isinstance(raw_serials, (list, tuple, set)):
+            serial_order = [
+                normalized
+                for item in raw_serials
+                if item is not None and (normalized := str(item).strip())
+            ]
+        else:
+            normalized = str(raw_serials).strip()
+            serial_order = [normalized] if normalized else []
+        self.serials = set(serial_order)
+        self._serial_order = list(dict.fromkeys(serial_order))
+        self._configured_serials = set(self.serials)
+        self.site_only = bool(config.get(CONF_SITE_ONLY, False))
+        self.include_inverters = bool(config.get(CONF_INCLUDE_INVERTERS, True))
+
+        raw_selected = config.get(CONF_SELECTED_TYPE_KEYS)
+        selected: set[str] | None = None
+        if isinstance(raw_selected, (list, tuple, set)):
+            selected = {
+                normalized_type
+                for item in raw_selected
+                if (normalized_type := normalize_type_key(item))
+            }
+        elif isinstance(raw_selected, str):
+            normalized_type = normalize_type_key(raw_selected)
+            selected = {normalized_type} if normalized_type else None
+        self._selected_type_keys = selected
+        self.site_name = config.get(CONF_SITE_NAME)
+
+        for serial in self._serial_order:
+            self._ensure_serial_tracked(serial)
+        self.always_update = self.site_only or not self.serials
+
+    def apply_auth_storage_config(self, config: Mapping[str, Any]) -> None:
+        """Apply credential-storage preferences that do not affect the session."""
+
+        self._email = config.get(CONF_EMAIL)
+        self._stored_password = config.get(CONF_PASSWORD)
+        self._remember_password = bool(config.get(CONF_REMEMBER_PASSWORD))
+
+    async def async_apply_config_entry_options(
+        self,
+        previous_options: Mapping[str, Any],
+    ) -> None:
+        """Apply non-topology config-entry options without reloading entities."""
+
+        config_entry = self.config_entry
+        if config_entry is None:
+            return
+        options = config_entry.options
+
+        timeout = helper_coerce_int(
+            options.get(OPT_API_TIMEOUT, DEFAULT_API_TIMEOUT),
+            default=DEFAULT_API_TIMEOUT,
+        )
+        self.client.set_timeout(min(MAX_API_TIMEOUT, max(MIN_API_TIMEOUT, timeout)))
+
+        _fast, slow = normalize_poll_intervals(
+            options.get(OPT_FAST_POLL_INTERVAL, DEFAULT_FAST_POLL_INTERVAL),
+            options.get(
+                OPT_SLOW_POLL_INTERVAL,
+                self._configured_slow_poll_interval,
+            ),
+        )
+        self._configured_slow_poll_interval = slow
+        current_data = self.data if isinstance(self.data, dict) else {}
+        try:
+            polling_state = self._determine_polling_state(current_data)
+        except (
+            Exception
+        ):  # noqa: BLE001 - retain the current interval on bad cache data
+            polling_state = {"target": slow}
+        self._apply_refresh_polling_interval(polling_state)
+
+        nominal = coerce_nominal_voltage(options.get(OPT_NOMINAL_VOLTAGE))
+        if nominal is None:
+            nominal = resolve_nominal_voltage_for_hass(self.hass)
+        self._nominal_v = nominal
+
+        history_interval = helper_coerce_int(
+            options.get(
+                OPT_SESSION_HISTORY_INTERVAL,
+                DEFAULT_SESSION_HISTORY_INTERVAL_MIN,
+            ),
+            default=DEFAULT_SESSION_HISTORY_INTERVAL_MIN,
+        )
+        self._session_history_interval_min = min(
+            MAX_SESSION_HISTORY_INTERVAL_MIN,
+            max(MIN_SESSION_HISTORY_INTERVAL_MIN, history_interval),
+        )
+        self._session_history_cache_ttl_value = max(
+            MIN_SESSION_HISTORY_CACHE_TTL,
+            self._session_history_interval_min * 60,
+        )
+        self.session_history.cache_ttl = self._session_history_cache_ttl_value
+        self._pricing_edits_enabled = bool(
+            options.get(OPT_PRICING_EDITS_ENABLED, DEFAULT_PRICING_EDITS_ENABLED)
+        )
+
+        if not bool(
+            options.get(
+                OPT_DEGRADED_SERVICE_REPAIR_ISSUES,
+                DEFAULT_DEGRADED_SERVICE_REPAIR_ISSUES,
+            )
+        ):
+            self.diagnostics.clear_degraded_service_repair_issues()
+        if not bool(
+            options.get(
+                OPT_SYSTEM_EVENT_REPAIR_ISSUES,
+                DEFAULT_SYSTEM_EVENT_REPAIR_ISSUES,
+            )
+        ):
+            self.system_events_runtime.clear_repairs()
+
+        schedule_sync_changed = bool(
+            previous_options.get(
+                OPT_SCHEDULE_SYNC_ENABLED,
+                DEFAULT_SCHEDULE_SYNC_ENABLED,
+            )
+        ) != bool(
+            options.get(
+                OPT_SCHEDULE_SYNC_ENABLED,
+                DEFAULT_SCHEDULE_SYNC_ENABLED,
+            )
+        )
+        if schedule_sync_changed:
+            await self.schedule_sync.async_stop()
+            await self.schedule_sync.async_start()
+
+        published = {
+            serial: {**payload, "nominal_v": nominal}
+            for serial, payload in current_data.items()
+            if isinstance(payload, dict)
+        }
+        self.async_set_updated_data(published)
+
     async def async_cancel_startup_power(self) -> None:
         """Cancel and await the startup-power task after failed setup."""
 
@@ -2135,6 +2285,80 @@ class EnphaseCoordinator(
                     "Timed out waiting for %s Enphase runtime task(s) to stop",
                     len(pending),
                 )
+
+    async def async_quiesce_for_reload(self) -> bool:
+        """Stop entry background work while retaining cached runtime state."""
+
+        current_task = asyncio.current_task()
+        cancelled_tasks: set[asyncio.Future[Any]] = set()
+        quiesced = True
+
+        def _cancel(task: object) -> None:
+            if (
+                isinstance(task, asyncio.Future)
+                and task is not current_task
+                and not task.done()
+            ):
+                task.cancel()
+                cancelled_tasks.add(task)
+
+        reload_task_attrs = {
+            attr_name: getattr(self, attr_name, None)
+            for attr_name in (
+                "_warmup_task",
+                "_startup_power_task",
+                "_grid_profile_metadata_task",
+            )
+        }
+        for task in reload_task_attrs.values():
+            _cancel(task)
+
+        entry_background_tasks = getattr(self, "_entry_background_tasks", None)
+        for task in tuple(entry_background_tasks or ()):
+            _cancel(task)
+
+        session_manager = getattr(self, "session_history", None)
+        enrichment_tasks = getattr(session_manager, "_enrichment_tasks", None)
+        for task in tuple(enrichment_tasks or ()):
+            _cancel(task)
+
+        pending: set[asyncio.Future[Any]] = set()
+        if cancelled_tasks:
+            done, pending = await asyncio.wait(
+                cancelled_tasks,
+                timeout=RUNTIME_CLEANUP_TIMEOUT_S,
+            )
+            if done:
+                await asyncio.gather(*done, return_exceptions=True)
+            if pending:
+                quiesced = False
+                _LOGGER.warning(
+                    "Timed out waiting for %s Enphase reload task(s) to stop",
+                    len(pending),
+                )
+
+        for attr_name, task in reload_task_attrs.items():
+            if task not in pending and getattr(self, attr_name, None) is task:
+                setattr(self, attr_name, None)
+        if entry_background_tasks is not None:
+            entry_background_tasks.difference_update(
+                task for task in tuple(entry_background_tasks) if task not in pending
+            )
+        if enrichment_tasks is not None:
+            enrichment_tasks.difference_update(
+                task for task in tuple(enrichment_tasks) if task not in pending
+            )
+
+        try:
+            async with asyncio.timeout(RUNTIME_CLEANUP_TIMEOUT_S):
+                async with self._refresh_lock:
+                    pass
+        except TimeoutError:
+            quiesced = False
+            _LOGGER.warning(
+                "Timed out waiting for the active Enphase refresh to stop before reload"
+            )
+        return quiesced
 
     def track_entry_background_task(self, task: object) -> None:
         """Track config-entry background work for pre-client-close cancellation."""
@@ -3778,6 +4002,12 @@ class EnphaseCoordinator(
         task.add_done_callback(self._clear_grid_profile_metadata_task)
 
     async def _async_update_data(self) -> dict[str, dict[str, object]]:
+        async with self._refresh_lock:
+            return await self._async_update_data_locked()
+
+    async def _async_update_data_locked(self) -> dict[str, dict[str, object]]:
+        """Run one serialized coordinator refresh."""
+
         with request_metrics_scope("core_refresh") as request_metrics:
             context = self._start_refresh_pipeline()
             context.request_metrics = request_metrics

--- a/custom_components/enphase_ev/runtime_data.py
+++ b/custom_components/enphase_ev/runtime_data.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 
@@ -36,6 +36,13 @@ class EnphaseRuntimeData:
     weather_coordinator: EnphaseWeatherCoordinator | None = None
     weather_discovery_task: asyncio.Task[None] | None = None
     reload_suppression_count: int = 0
+    applied_data: dict[str, Any] | None = None
+    applied_options: dict[str, Any] | None = None
+    preserve_for_reload: bool = False
+    update_listener_lock: asyncio.Lock = field(
+        default_factory=asyncio.Lock,
+        repr=False,
+    )
 
     async def async_stop_weather(self) -> None:
         """Stop and release the optional weather child coordinator."""

--- a/custom_components/enphase_ev/schedule_sync.py
+++ b/custom_components/enphase_ev/schedule_sync.py
@@ -83,6 +83,8 @@ class ScheduleSync:
         self._meta_cache: dict[str, str | None] = {}
         self._config_cache: dict[str, dict[str, Any]] = {}
         self._lock = asyncio.Lock()
+        self._lifecycle_lock = asyncio.Lock()
+        self._lifecycle_generation = 0
         self._storage_collection: ScheduleStorageCollection | None = None
         self._unsub_interval: Callable[[], None] | None = None
         self._unsub_coordinator: Callable[[], None] | None = None
@@ -99,26 +101,39 @@ class ScheduleSync:
         self._stopping = False
 
     async def async_start(self) -> None:
-        self._disabled_cleanup_done = False
-        if not self._sync_enabled():
-            await self._disable_support()
-            return
-        await self._remove_all_helpers()
-        if self._stopping:
-            return
-        self._unsub_interval = async_track_time_interval(
-            self.hass, self._handle_interval, SYNC_INTERVAL
-        )
-        try:
-            self._unsub_coordinator = self._coordinator.async_add_listener(
-                self._handle_coordinator_update
+        async with self._lifecycle_lock:
+            self._lifecycle_generation += 1
+            generation = self._lifecycle_generation
+            self._stopping = True
+            await self._async_stop_locked()
+            self._stopping = False
+            self._disabled_cleanup_done = False
+            if not self._sync_enabled():
+                await self._async_disable_support_locked()
+                return
+            await self._remove_all_helpers()
+            if self._stopping or generation != self._lifecycle_generation:
+                return
+            self._unsub_interval = async_track_time_interval(
+                self.hass, self._handle_interval, SYNC_INTERVAL
             )
-        except Exception:
-            self._unsub_coordinator = None
+            try:
+                self._unsub_coordinator = self._coordinator.async_add_listener(
+                    self._handle_coordinator_update
+                )
+            except Exception:
+                self._unsub_coordinator = None
         await self.async_refresh(reason="startup")
 
     async def async_stop(self) -> None:
         self._stopping = True
+        self._lifecycle_generation += 1
+        async with self._lifecycle_lock:
+            await self._async_stop_locked()
+
+    async def _async_stop_locked(self) -> None:
+        """Stop subscriptions and tasks while holding the lifecycle lock."""
+
         if self._unsub_interval is not None:
             self._unsub_interval()
             self._unsub_interval = None
@@ -268,10 +283,19 @@ class ScheduleSync:
             self._last_status = "auth_blocked"
 
     async def _disable_support(self) -> None:
+        self._stopping = True
+        self._lifecycle_generation += 1
+        async with self._lifecycle_lock:
+            await self._async_disable_support_locked()
+
+    async def _async_disable_support_locked(self) -> None:
+        """Disable schedule support while holding the lifecycle lock."""
+
+        self._stopping = True
         if self._disabled_cleanup_done:
             return
         self._disabled_cleanup_done = True
-        await self.async_stop()
+        await self._async_stop_locked()
         await self._remove_all_helpers()
         self._slot_cache.clear()
         self._meta_cache.clear()

--- a/custom_components/enphase_ev/system_events.py
+++ b/custom_components/enphase_ev/system_events.py
@@ -950,6 +950,11 @@ class SystemEventsRuntime:
         self._repair_last_seen_utc.clear()
         self._repair_checkpoint_utc.clear()
 
+    def clear_repairs(self) -> None:
+        """Remove all System Event Repairs after the option is disabled."""
+
+        self._clear_repairs()
+
     def _sync_repairs(
         self,
         *,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,6 +38,14 @@ Optional endpoint families then warm up in feature-aware stages, publishing afte
 each stage so one slow family does not hold back unrelated state. Schedule sync and
 other long-running work start in the background.
 
+Config-entry update handling distinguishes live-applicable options from topology
+changes. Polling, timeout, history, voltage, scheduler, pricing, and notification
+options are applied to the existing coordinator and published without unloading
+entities. Changes that alter platform topology still reload the config entry, but
+the runtime is handed across that reload so platforms can recreate entities from
+the last published state immediately. The reused coordinator then refreshes in
+the background. Cold setup continues to require an authoritative first refresh.
+
 Device and entity registry cleanup is intentionally conservative. Startup migrations
 run once per migration version, while normal reconciliation runs only when the
 coordinator reports a topology change—not for ordinary telemetry updates. Cleanup

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -19,7 +19,10 @@ from custom_components.enphase_ev.const import (
     BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL,
     CONF_COOKIE,
     CONF_EAUTH,
+    CONF_EMAIL,
     CONF_INCLUDE_INVERTERS,
+    CONF_PASSWORD,
+    CONF_REMEMBER_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_SELECTED_TYPE_KEYS,
     CONF_SERIALS,
@@ -28,8 +31,15 @@ from custom_components.enphase_ev.const import (
     DEFAULT_SESSION_HISTORY_INTERVAL_MIN,
     DOMAIN,
     ISSUE_DNS_RESOLUTION,
+    OPT_API_TIMEOUT,
+    OPT_DEGRADED_SERVICE_REPAIR_ISSUES,
+    OPT_FAST_POLL_INTERVAL,
     OPT_NOMINAL_VOLTAGE,
+    OPT_PRICING_EDITS_ENABLED,
+    OPT_SCHEDULE_SYNC_ENABLED,
+    OPT_SLOW_POLL_INTERVAL,
     OPT_SESSION_HISTORY_INTERVAL,
+    OPT_SYSTEM_EVENT_REPAIR_ISSUES,
 )
 from custom_components.enphase_ev.evse_runtime import (
     FAST_TOGGLE_POLL_HOLD_S,
@@ -100,6 +110,128 @@ def _client_response_error(status: int, *, message: str = "", headers=None):
         message=message,
         headers=headers or {},
     )
+
+
+@pytest.mark.asyncio
+async def test_apply_config_entry_options_without_reload(
+    hass, coordinator_factory
+) -> None:
+    options = {
+        OPT_API_TIMEOUT: 20,
+        OPT_FAST_POLL_INTERVAL: 45,
+        OPT_SLOW_POLL_INTERVAL: 90,
+        OPT_NOMINAL_VOLTAGE: 240,
+        OPT_SESSION_HISTORY_INTERVAL: 2,
+        OPT_PRICING_EDITS_ENABLED: False,
+        OPT_DEGRADED_SERVICE_REPAIR_ISSUES: False,
+        OPT_SYSTEM_EVENT_REPAIR_ISSUES: False,
+        OPT_SCHEDULE_SYNC_ENABLED: True,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options=options)
+    entry.add_to_hass(hass)
+    coord = coordinator_factory(data={RANDOM_SERIAL: {"sn": RANDOM_SERIAL}})
+    coord.config_entry = entry
+    coord.diagnostics = SimpleNamespace(clear_degraded_service_repair_issues=Mock())
+    coord.system_events_runtime = SimpleNamespace(clear_repairs=Mock())
+    coord.schedule_sync = SimpleNamespace(
+        async_stop=AsyncMock(),
+        async_start=AsyncMock(),
+    )
+
+    await coord.async_apply_config_entry_options({OPT_SCHEDULE_SYNC_ENABLED: False})
+
+    assert coord.client._timeout == 20  # noqa: SLF001
+    assert coord._configured_slow_poll_interval == 90  # noqa: SLF001
+    assert coord.nominal_voltage == 240
+    assert coord._session_history_interval_min == 2  # noqa: SLF001
+    assert coord.session_history.cache_ttl == 120
+    assert coord.pricing_edits_enabled is False
+    assert coord.data[RANDOM_SERIAL]["nominal_v"] == 240
+    coord.diagnostics.clear_degraded_service_repair_issues.assert_called_once_with()
+    coord.system_events_runtime.clear_repairs.assert_called_once_with()
+    coord.schedule_sync.async_stop.assert_awaited_once_with()
+    coord.schedule_sync.async_start.assert_awaited_once_with()
+
+    coord._determine_polling_state = Mock(side_effect=RuntimeError("bad cache"))
+    await coord.async_apply_config_entry_options(options)
+    assert coord.update_interval == timedelta(seconds=90)
+
+    coord.config_entry = None
+    await coord.async_apply_config_entry_options(options)
+
+
+@pytest.mark.asyncio
+async def test_apply_config_entry_options_preserves_legacy_scan_interval(
+    hass, coordinator_factory
+) -> None:
+    config = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 300,
+        CONF_SITE_ONLY: False,
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config,
+        options={OPT_API_TIMEOUT: 20},
+    )
+    entry.add_to_hass(hass)
+    coord = coordinator_factory(config=config)
+    coord.config_entry = entry
+    coord.diagnostics = SimpleNamespace(clear_degraded_service_repair_issues=Mock())
+    coord.system_events_runtime = SimpleNamespace(clear_repairs=Mock())
+
+    await coord.async_apply_config_entry_options({OPT_API_TIMEOUT: 15})
+
+    assert coord._configured_slow_poll_interval == 300  # noqa: SLF001
+    assert coord.update_interval == timedelta(seconds=300)
+
+
+def test_apply_config_entry_data_and_auth_storage(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    coord.apply_config_entry_data(
+        {
+            CONF_SITE_ID: coord.site_id,
+            CONF_SERIALS: " EV-NEW ",
+            CONF_SITE_ONLY: False,
+            CONF_INCLUDE_INVERTERS: False,
+            CONF_SELECTED_TYPE_KEYS: ["envoy", "iqevse"],
+        }
+    )
+    coord.apply_auth_storage_config(
+        {
+            CONF_EMAIL: "new@example.com",
+            CONF_PASSWORD: "stored",
+            CONF_REMEMBER_PASSWORD: True,
+        }
+    )
+
+    assert coord.serials == {"EV-NEW"}
+    assert coord._serial_order == ["EV-NEW"]  # noqa: SLF001
+    assert coord._selected_type_keys == {"envoy", "iqevse"}  # noqa: SLF001
+    assert coord.include_inverters is False
+    assert coord._email == "new@example.com"  # noqa: SLF001
+    assert coord._stored_password == "stored"  # noqa: SLF001
+    assert coord._remember_password is True  # noqa: SLF001
+
+    coord.apply_config_entry_data(
+        {
+            CONF_SITE_ID: coord.site_id,
+            CONF_SERIALS: [],
+            CONF_SITE_ONLY: True,
+            CONF_SELECTED_TYPE_KEYS: "envoy",
+        }
+    )
+    assert coord._selected_type_keys == {"envoy"}  # noqa: SLF001
+    assert coord.always_update is True
+
+    with pytest.raises(ValueError, match="different site"):
+        coord.apply_config_entry_data({CONF_SITE_ID: "other"})
 
 
 @pytest.mark.asyncio
@@ -1931,6 +2063,84 @@ async def test_runtime_cleanup_timeout_is_bounded(
     await asyncio.gather(task, return_exceptions=True)
 
     assert "Timed out waiting for 1 Enphase runtime task" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reload_quiesce_cancels_background_work_without_clearing_state(
+    coordinator_factory,
+) -> None:
+    data = {RANDOM_SERIAL: {"sn": RANDOM_SERIAL, "status": "available"}}
+    coord = coordinator_factory(data=data)
+    topology_listener = Mock()
+    coord._topology_listeners.append(topology_listener)  # noqa: SLF001
+
+    warmup_task = asyncio.create_task(asyncio.sleep(60))
+    startup_power_task = asyncio.create_task(asyncio.sleep(60))
+    grid_profile_task = asyncio.create_task(asyncio.sleep(60))
+    entry_background_task = asyncio.create_task(asyncio.sleep(60))
+    enrichment_task = asyncio.create_task(asyncio.sleep(60))
+    coord._warmup_task = warmup_task  # noqa: SLF001
+    coord._startup_power_task = startup_power_task  # noqa: SLF001
+    coord._grid_profile_metadata_task = grid_profile_task  # noqa: SLF001
+    coord.track_entry_background_task(entry_background_task)
+    coord.session_history._enrichment_tasks.add(enrichment_task)  # noqa: SLF001
+
+    assert await coord.async_quiesce_for_reload() is True
+
+    assert warmup_task.cancelled()
+    assert startup_power_task.cancelled()
+    assert grid_profile_task.cancelled()
+    assert entry_background_task.cancelled()
+    assert enrichment_task.cancelled()
+    assert coord._warmup_task is None  # noqa: SLF001
+    assert coord._startup_power_task is None  # noqa: SLF001
+    assert coord._grid_profile_metadata_task is None  # noqa: SLF001
+    assert coord._entry_background_tasks == set()  # noqa: SLF001
+    assert coord.session_history._enrichment_tasks == set()  # noqa: SLF001
+    assert coord.data == data
+    assert coord._topology_listeners == [topology_listener]  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_reload_quiesce_timeout_is_bounded(
+    coordinator_factory, monkeypatch, caplog
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory()
+    task = asyncio.create_task(asyncio.sleep(60))
+    coord.track_entry_background_task(task)
+
+    async def _pending(tasks, *, timeout):
+        assert timeout == coord_mod.RUNTIME_CLEANUP_TIMEOUT_S
+        return set(), set(tasks)
+
+    monkeypatch.setattr(coord_mod.asyncio, "wait", _pending)
+    with caplog.at_level(logging.WARNING):
+        assert await coord.async_quiesce_for_reload() is False
+    assert task in coord._entry_background_tasks  # noqa: SLF001
+    await asyncio.gather(task, return_exceptions=True)
+
+    assert "Timed out waiting for 1 Enphase reload task" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_reload_quiesce_timeout_waiting_for_active_refresh(
+    coordinator_factory, monkeypatch, caplog
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory()
+    await coord._refresh_lock.acquire()  # noqa: SLF001
+    monkeypatch.setattr(coord_mod, "RUNTIME_CLEANUP_TIMEOUT_S", 0.001)
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            assert await coord.async_quiesce_for_reload() is False
+    finally:
+        coord._refresh_lock.release()  # noqa: SLF001
+
+    assert "active Enphase refresh" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -54,6 +55,7 @@ from custom_components.enphase_ev import (
 from custom_components.enphase_ev.const import (
     CONF_AUTH_BLOCK_REASON,
     CONF_AUTH_BLOCKED_UNTIL,
+    CONF_COOKIE,
     CONF_INCLUDE_INVERTERS,
     CONF_SERIALS,
     CONF_SELECTED_TYPE_KEYS,
@@ -61,6 +63,8 @@ from custom_components.enphase_ev.const import (
     CONF_SITE_ONLY,
     ISSUE_AUTH_BLOCKED,
     ISSUE_TOO_MANY_ACTIVE_SESSIONS,
+    OPT_API_TIMEOUT,
+    OPT_WEATHER_ENABLED,
 )
 from custom_components.enphase_ev.device_types import type_identifier
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
@@ -724,6 +728,100 @@ async def test_async_setup_entry_restores_discovery_before_first_refresh(
         "entities_forwarded",
         "setup_complete",
     }
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_reuses_handoff_without_blocking_refresh(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    first_refresh = Mock()
+
+    async def _first_refresh(coord) -> None:
+        first_refresh()
+        coord._has_successful_refresh = True
+        coord.async_set_updated_data(
+            {RANDOM_SERIAL: {"sn": RANDOM_SERIAL, "status": "available"}}
+        )
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.coordinator.EnphaseCoordinator.async_config_entry_first_refresh",
+        _first_refresh,
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.coordinator.EnphaseCoordinator.async_start_startup_warmup",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.coordinator.EnphaseCoordinator.async_refresh_grid_profile_metadata",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.schedule_sync.ScheduleSync.async_start",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.schedule_sync.ScheduleSync.async_stop",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        hass.config_entries,
+        "async_forward_entry_setups",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        hass.config_entries,
+        "async_forward_entry_unload",
+        AsyncMock(return_value=True),
+    )
+
+    assert await async_setup_entry(hass, config_entry)
+    original_runtime = config_entry.runtime_data
+    original_runtime.coordinator.async_request_refresh = AsyncMock()
+    original_runtime.preserve_for_reload = True
+
+    assert await async_unload_entry(hass, config_entry)
+    assert config_entry.runtime_data is None
+    assert await async_setup_entry(hass, config_entry)
+    await hass.async_block_till_done()
+
+    assert config_entry.runtime_data is original_runtime
+    assert config_entry.runtime_data.coordinator.data[RANDOM_SERIAL]["status"] == (
+        "available"
+    )
+    assert first_refresh.call_count == 1
+    original_runtime.coordinator.async_request_refresh.assert_awaited_once_with()
+    assert (
+        config_entry.runtime_data.coordinator.setup_phase_timings["first_refresh_s"]
+        == 0.0
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_rejects_incomplete_runtime_handoff(
+    hass: HomeAssistant, config_entry, caplog
+) -> None:
+    coordinator = SimpleNamespace(
+        apply_config_entry_data=Mock(),
+        apply_auth_storage_config=Mock(),
+        async_apply_config_entry_options=AsyncMock(),
+        async_cleanup_runtime_state=AsyncMock(
+            side_effect=RuntimeError("cleanup failed")
+        ),
+        async_close=AsyncMock(),
+    )
+    hass.data[enphase_init._RUNTIME_HANDOFF_KEY] = {
+        config_entry.entry_id: EnphaseRuntimeData(coordinator=coordinator)
+    }
+
+    with pytest.raises(RuntimeError, match="Incomplete preserved Enphase runtime"):
+        await async_setup_entry(hass, config_entry)
+
+    coordinator.async_cleanup_runtime_state.assert_awaited_once_with()
+    coordinator.async_close.assert_awaited_once_with()
+    coordinator.apply_auth_storage_config.assert_called_once_with(config_entry.data)
+    assert "Failed cleaning up a preserved runtime" in caplog.text
+    assert config_entry.runtime_data is None
+    assert config_entry.entry_id not in hass.data[enphase_init._RUNTIME_HANDOFF_KEY]
 
 
 @pytest.mark.asyncio
@@ -1852,6 +1950,204 @@ async def test_update_listener_reloads_entry(
 
 
 @pytest.mark.asyncio
+async def test_update_listener_hot_applies_runtime_options(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    coordinator = SimpleNamespace(
+        apply_auth_storage_config=Mock(),
+        async_apply_config_entry_options=AsyncMock(),
+    )
+    previous_options = {OPT_API_TIMEOUT: 10}
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={OPT_API_TIMEOUT: 20},
+    )
+    runtime_data = EnphaseRuntimeData(
+        coordinator=coordinator,
+        applied_data=dict(config_entry.data),
+        applied_options=previous_options,
+    )
+    config_entry.runtime_data = runtime_data
+    object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
+    reload_entry = AsyncMock()
+    monkeypatch.setattr(hass.config_entries, "async_reload", reload_entry)
+
+    await _async_update_listener(hass, config_entry)
+
+    reload_entry.assert_not_awaited()
+    coordinator.apply_auth_storage_config.assert_called_once_with(config_entry.data)
+    coordinator.async_apply_config_entry_options.assert_awaited_once_with(
+        previous_options
+    )
+    assert runtime_data.applied_options == {OPT_API_TIMEOUT: 20}
+
+
+@pytest.mark.asyncio
+async def test_update_listener_serializes_concurrent_option_updates(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    first_apply_started = asyncio.Event()
+    release_first_apply = asyncio.Event()
+    applied_timeouts: list[int] = []
+
+    async def _apply_options(_previous_options) -> None:
+        timeout = int(config_entry.options[OPT_API_TIMEOUT])
+        applied_timeouts.append(timeout)
+        if timeout == 20:
+            first_apply_started.set()
+            await release_first_apply.wait()
+
+    coordinator = SimpleNamespace(
+        apply_auth_storage_config=Mock(),
+        async_apply_config_entry_options=_apply_options,
+    )
+    runtime_data = EnphaseRuntimeData(
+        coordinator=coordinator,
+        applied_data=dict(config_entry.data),
+        applied_options={OPT_API_TIMEOUT: 10},
+    )
+    config_entry.runtime_data = runtime_data
+    object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
+    monkeypatch.setattr(hass.config_entries, "async_reload", AsyncMock())
+
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={OPT_API_TIMEOUT: 20},
+    )
+    first_listener = asyncio.create_task(_async_update_listener(hass, config_entry))
+    await first_apply_started.wait()
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={OPT_API_TIMEOUT: 30},
+    )
+    second_listener = asyncio.create_task(_async_update_listener(hass, config_entry))
+    release_first_apply.set()
+    await asyncio.gather(first_listener, second_listener)
+
+    assert applied_timeouts == [20, 30]
+    assert runtime_data.applied_options == {OPT_API_TIMEOUT: 30}
+
+
+@pytest.mark.asyncio
+async def test_update_listener_ignores_runtime_replaced_while_waiting(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    original_runtime = EnphaseRuntimeData(coordinator=SimpleNamespace())
+    replacement_runtime = EnphaseRuntimeData(coordinator=SimpleNamespace())
+    config_entry.runtime_data = original_runtime
+    await original_runtime.update_listener_lock.acquire()
+    reload_entry = AsyncMock()
+    monkeypatch.setattr(hass.config_entries, "async_reload", reload_entry)
+
+    listener = asyncio.create_task(_async_update_listener(hass, config_entry))
+    await asyncio.sleep(0)
+    config_entry.runtime_data = replacement_runtime
+    original_runtime.update_listener_lock.release()
+    await listener
+
+    reload_entry.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_listener_preserves_runtime_for_topology_reload(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={OPT_WEATHER_ENABLED: True},
+    )
+    runtime_data = EnphaseRuntimeData(
+        coordinator=SimpleNamespace(),
+        applied_data=dict(config_entry.data),
+        applied_options={OPT_WEATHER_ENABLED: False},
+    )
+    config_entry.runtime_data = runtime_data
+    object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
+    reload_entry = AsyncMock(return_value=True)
+    monkeypatch.setattr(hass.config_entries, "async_reload", reload_entry)
+
+    await _async_update_listener(hass, config_entry)
+
+    reload_entry.assert_awaited_once_with(config_entry.entry_id)
+    assert runtime_data.preserve_for_reload is True
+
+
+@pytest.mark.asyncio
+async def test_update_listener_does_not_preserve_runtime_for_credential_reload(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    runtime_data = EnphaseRuntimeData(
+        coordinator=SimpleNamespace(),
+        applied_data={**config_entry.data, CONF_COOKIE: "old-cookie"},
+        applied_options=dict(config_entry.options),
+    )
+    config_entry.runtime_data = runtime_data
+    object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
+    reload_entry = AsyncMock(return_value=True)
+    monkeypatch.setattr(hass.config_entries, "async_reload", reload_entry)
+
+    await _async_update_listener(hass, config_entry)
+
+    reload_entry.assert_awaited_once_with(config_entry.entry_id)
+    assert runtime_data.preserve_for_reload is False
+
+
+@pytest.mark.asyncio
+async def test_update_listener_falls_back_to_reload_when_hot_apply_fails(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    coordinator = SimpleNamespace(
+        apply_auth_storage_config=Mock(),
+        async_apply_config_entry_options=AsyncMock(side_effect=RuntimeError("boom")),
+    )
+    runtime_data = EnphaseRuntimeData(
+        coordinator=coordinator,
+        applied_data=dict(config_entry.data),
+        applied_options={OPT_API_TIMEOUT: 10},
+    )
+    config_entry.runtime_data = runtime_data
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={OPT_API_TIMEOUT: 20},
+    )
+    object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
+    reload_entry = AsyncMock(return_value=False)
+    monkeypatch.setattr(hass.config_entries, "async_reload", reload_entry)
+
+    await _async_update_listener(hass, config_entry)
+
+    reload_entry.assert_awaited_once_with(config_entry.entry_id)
+    assert runtime_data.preserve_for_reload is False
+
+
+@pytest.mark.asyncio
+async def test_update_listener_clears_handoff_flag_when_reload_raises(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    runtime_data = EnphaseRuntimeData(
+        coordinator=SimpleNamespace(),
+        applied_data=dict(config_entry.data),
+        applied_options={OPT_WEATHER_ENABLED: False},
+    )
+    config_entry.runtime_data = runtime_data
+    hass.config_entries.async_update_entry(
+        config_entry,
+        options={OPT_WEATHER_ENABLED: True},
+    )
+    object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
+    monkeypatch.setattr(
+        hass.config_entries,
+        "async_reload",
+        AsyncMock(side_effect=RuntimeError("reload failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="reload failed"):
+        await _async_update_listener(hass, config_entry)
+
+    assert runtime_data.preserve_for_reload is False
+
+
+@pytest.mark.asyncio
 async def test_update_listener_skips_reload_for_disabled_entry(
     hass: HomeAssistant, config_entry, monkeypatch
 ) -> None:
@@ -1887,10 +2183,13 @@ async def test_update_listener_ignores_operation_not_allowed(
     reload = AsyncMock(side_effect=config_entries.OperationNotAllowed("race"))
     monkeypatch.setattr(hass.config_entries, "async_reload", reload)
     object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
+    runtime_data = EnphaseRuntimeData(coordinator=SimpleNamespace())
+    config_entry.runtime_data = runtime_data
 
     await _async_update_listener(hass, config_entry)
 
     reload.assert_awaited_once_with(config_entry.entry_id)
+    assert runtime_data.preserve_for_reload is False
 
 
 @pytest.mark.asyncio
@@ -1914,6 +2213,75 @@ async def test_async_unload_entry_tolerates_platform_never_loaded(
 
     schedule_sync.async_stop.assert_awaited_once()
     coord.cleanup_runtime_state.assert_called_once()
+    assert config_entry.runtime_data is None
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_hands_off_preserved_runtime(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    schedule_sync = SimpleNamespace(async_stop=AsyncMock())
+    coord = SimpleNamespace(
+        schedule_sync=schedule_sync,
+        async_quiesce_for_reload=AsyncMock(return_value=True),
+        async_cleanup_runtime_state=AsyncMock(),
+        async_close=AsyncMock(),
+    )
+    runtime_data = EnphaseRuntimeData(
+        coordinator=coord,
+        preserve_for_reload=True,
+    )
+    config_entry.runtime_data = runtime_data
+    monkeypatch.setattr(
+        hass.config_entries,
+        "async_forward_entry_unload",
+        AsyncMock(return_value=True),
+    )
+
+    assert await async_unload_entry(hass, config_entry)
+
+    schedule_sync.async_stop.assert_awaited_once()
+    coord.async_quiesce_for_reload.assert_awaited_once_with()
+    coord.async_cleanup_runtime_state.assert_not_awaited()
+    coord.async_close.assert_not_awaited()
+    assert (
+        hass.data[enphase_init._RUNTIME_HANDOFF_KEY][config_entry.entry_id]
+        is runtime_data
+    )
+    assert config_entry.runtime_data is None
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_discards_handoff_when_quiesce_times_out(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    schedule_sync = SimpleNamespace(async_stop=AsyncMock())
+    coord = SimpleNamespace(
+        schedule_sync=schedule_sync,
+        async_quiesce_for_reload=AsyncMock(return_value=False),
+        async_cleanup_runtime_state=AsyncMock(),
+        async_close=AsyncMock(),
+    )
+    runtime_data = EnphaseRuntimeData(
+        coordinator=coord,
+        preserve_for_reload=True,
+    )
+    config_entry.runtime_data = runtime_data
+    monkeypatch.setattr(
+        hass.config_entries,
+        "async_forward_entry_unload",
+        AsyncMock(return_value=True),
+    )
+
+    assert await async_unload_entry(hass, config_entry)
+
+    coord.async_quiesce_for_reload.assert_awaited_once_with()
+    coord.async_cleanup_runtime_state.assert_awaited_once_with()
+    coord.async_close.assert_awaited_once_with()
+    assert runtime_data.preserve_for_reload is False
+    assert config_entry.entry_id not in hass.data.get(
+        enphase_init._RUNTIME_HANDOFF_KEY, {}
+    )
     assert config_entry.runtime_data is None
 
 

--- a/tests/components/enphase_ev/test_schedule_sync.py
+++ b/tests/components/enphase_ev/test_schedule_sync.py
@@ -619,6 +619,54 @@ async def test_schedule_sync_async_start_listener_error_when_enabled(hass) -> No
     assert sync._unsub_coordinator is None
 
 
+@pytest.mark.asyncio
+async def test_schedule_sync_serializes_overlapping_start_stop_start(
+    hass, monkeypatch
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"site_id": RANDOM_SITE_ID},
+        options={OPT_SCHEDULE_SYNC_ENABLED: True},
+    )
+    entry.add_to_hass(hass)
+    unsubscribe_interval = MagicMock()
+    unsubscribe_coordinator = MagicMock()
+    coordinator = SimpleNamespace(
+        async_add_listener=MagicMock(return_value=unsubscribe_coordinator)
+    )
+    sync = ScheduleSync(hass, coordinator, entry)
+    first_remove_started = asyncio.Event()
+    release_first_remove = asyncio.Event()
+    remove_calls = 0
+
+    async def _remove_helpers() -> None:
+        nonlocal remove_calls
+        remove_calls += 1
+        if remove_calls == 1:
+            first_remove_started.set()
+            await release_first_remove.wait()
+
+    sync._remove_all_helpers = _remove_helpers  # type: ignore[method-assign]
+    sync.async_refresh = AsyncMock()  # type: ignore[method-assign]
+    track_interval = MagicMock(return_value=unsubscribe_interval)
+    monkeypatch.setattr(schedule_sync_mod, "async_track_time_interval", track_interval)
+
+    first_start = asyncio.create_task(sync.async_start())
+    await first_remove_started.wait()
+    stop = asyncio.create_task(sync.async_stop())
+    await asyncio.sleep(0)
+    release_first_remove.set()
+    await asyncio.gather(first_start, stop)
+    await sync.async_start()
+
+    track_interval.assert_called_once()
+    coordinator.async_add_listener.assert_called_once()
+    sync.async_refresh.assert_awaited_once_with(reason="startup")
+    assert sync._unsub_interval is unsubscribe_interval
+    assert sync._unsub_coordinator is unsubscribe_coordinator
+    await sync.async_stop()
+
+
 def test_schedule_sync_notify_listeners_handles_exception(hass) -> None:
     sync = ScheduleSync(hass, SimpleNamespace(), None)
     calls: list[str] = []


### PR DESCRIPTION
## Summary

- Apply integration options that do not change entity topology without reloading the config entry.
- Preserve coordinator state, cached data, and runtime resources when a reload is required so entities recover sooner.
- Serialize settings updates, reload handoffs, and schedule synchronization to avoid overlapping lifecycle work.
- Add regression coverage for runtime reuse, cleanup failures, legacy options, and concurrent update paths.

This reduces the period where Enphase entities appear unavailable or unknown after changing integration settings.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/api.py custom_components/enphase_ev/config_flow.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/schedule_sync.py custom_components/enphase_ev/system_events.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_schedule_sync.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/api.py,custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/runtime_data.py,custom_components/enphase_ev/schedule_sync.py,custom_components/enphase_ev/system_events.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Results: 3,916 tests passed; 3,784 integration tests passed; targeted coverage is 100% for all seven changed integration modules.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid; no translation changes were required.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No UI changes. The reload handoff is bounded by a timeout and falls back to a cold cleanup if the existing runtime cannot quiesce safely.
