### PR TITLE
Suppress Heat Pump HEMS polling when unselected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 - Populated Grid Profile sensor metadata such as profile group, PEL support,
   277 V compatibility, and recommendation status from the cached Activation
   profile catalog.
+- Stopped background Heat Pump HEMS inventory polling when the Heat Pump device
+  group is explicitly disabled, and downgraded defensive HEMS auth messages to
+  debug logging when no Heat Pump context exists.
 
 ### 🔧 Improvements
 - Applied non-topology integration options without reloading the config entry, and

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -225,6 +225,17 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 _CallbackT = TypeVar("_CallbackT", bound=Callable[..., object])
+_HEATPUMP_HEMS_AUTH_ENDPOINTS = frozenset(
+    {
+        "hems_devices",
+        "hems_support_preflight",
+        "show_livestream",
+        "heat_pump_events",
+        "iq_er_events",
+        "hems_heatpump_state",
+        "hems_energy_consumption",
+    }
+)
 
 
 def _typed_callback(func: _CallbackT) -> _CallbackT:
@@ -1205,6 +1216,9 @@ class EnphaseCoordinator(
         self._phase_timings = {}
         started = time.monotonic()
         await self.discovery_snapshot.async_restore_state()
+        if not self._heatpump_hems_polling_enabled():
+            self.inventory_runtime._mark_hems_inventory_polling_disabled()
+            self._clear_disabled_heatpump_hems_auth_state()
         self.record_setup_phase("snapshot_restore_s", started)
         await self.refresh_runner.async_start_startup_power()
 
@@ -5848,8 +5862,8 @@ class EnphaseCoordinator(
         """Return True when HEMS auth failures should be surfaced to the user."""
 
         selected = getattr(self, "_selected_type_keys", None)
-        if isinstance(selected, (set, list, tuple)) and selected:
-            return any(normalize_type_key(key) == "heatpump" for key in selected)
+        if selected is not None:
+            return self._heatpump_hems_polling_enabled()
         inventory_view = getattr(self, "inventory_view", None)
         has_type = getattr(inventory_view, "has_type", None)
         if callable(has_type):
@@ -5868,6 +5882,23 @@ class EnphaseCoordinator(
             except Exception:  # noqa: BLE001 - defensive diagnostics guard
                 return False
         return False
+
+    def _heatpump_hems_polling_enabled(self) -> bool:
+        """Return whether configured device groups require Heat Pump HEMS polling."""
+
+        selected = getattr(self, "_selected_type_keys", None)
+        if selected is None:
+            return True
+        return any(normalize_type_key(key) == "heatpump" for key in selected)
+
+    def _clear_disabled_heatpump_hems_auth_state(self) -> None:
+        """Clear auth state created only by disabled Heat Pump HEMS endpoints."""
+
+        if self._heatpump_hems_polling_enabled():
+            return
+        if self._hems_auth_last_endpoint not in _HEATPUMP_HEMS_AUTH_ENDPOINTS:
+            return
+        self._clear_hems_auth_circuit(persist=True, reset_failure_count=True)
 
     def _note_hems_auth_failure(
         self,
@@ -5898,12 +5929,13 @@ class EnphaseCoordinator(
         self._hems_auth_backoff_ends_utc = now + timedelta(seconds=delay)
         self._last_error = "hems_auth_degraded"
         self._persist_hems_auth_circuit_state()
+        repair_context_available = self._hems_auth_repair_context_available()
         diagnostics = getattr(self, "diagnostics", None)
         if diagnostics is not None:
             repairs_enabled = bool(
                 getattr(diagnostics, "degraded_service_repair_issues_enabled", True)
             )
-            if self._hems_auth_repair_context_available() or not repairs_enabled:
+            if repair_context_available or not repairs_enabled:
                 diagnostics.create_hems_auth_degraded_issue()
             else:
                 clear_issue = getattr(
@@ -5911,7 +5943,10 @@ class EnphaseCoordinator(
                 )
                 if callable(clear_issue):
                     clear_issue()
-        _LOGGER.warning(
+        log_hems_auth_failure = (
+            _LOGGER.warning if repair_context_available else _LOGGER.debug
+        )
+        log_hems_auth_failure(
             "Pausing optional HEMS polling for site %s after HEMS auth failure: endpoint=%s status=%s reason=%s failure_count=%s retry_at=%s",
             redact_site_id(self.site_id),
             self._hems_auth_last_endpoint,

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -450,6 +450,7 @@ class CoordinatorDiagnostics:
             "hems_auth_last_endpoint": getattr(coord, "_hems_auth_last_endpoint", None),
             "hems_auth_last_status": getattr(coord, "_hems_auth_last_status", None),
             "hems_auth_last_reason": getattr(coord, "_hems_auth_last_reason", None),
+            "hems_inventory_polling_enabled": coord._heatpump_hems_polling_enabled(),
             "auth_blocked_active": coord._auth_block_active(),
             "auth_blocked_until": _iso(getattr(coord, "_auth_blocked_until_utc", None)),
             "auth_block_reason": getattr(coord, "_auth_block_reason", None),

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -1311,7 +1311,11 @@ class InventoryRuntime:
         ordered = list(getattr(self, "_type_device_order", []) or [])
         key = "heatpump"
 
-        members_out = self._hems_group_members("heat-pump", "heat_pump", "heatpump")
+        members_out = (
+            self._hems_group_members("heat-pump", "heat_pump", "heatpump")
+            if self.coordinator._heatpump_hems_polling_enabled()
+            else []
+        )
         if members_out:
             status_counts: dict[str, int] = {
                 "total": len(members_out),
@@ -2178,6 +2182,10 @@ class InventoryRuntime:
 
     async def _async_refresh_hems_devices(self, *, force: bool = False) -> None:
         coord = self.coordinator
+        if not coord._heatpump_hems_polling_enabled():
+            self._mark_hems_inventory_polling_disabled()
+            coord._clear_disabled_heatpump_hems_auth_state()
+            return
         now = time.monotonic()
         cache_ttl = self._hems_devices_cache_ttl_s()
         family = HEMS_INVENTORY_ENDPOINT_FAMILY
@@ -2395,8 +2403,23 @@ class InventoryRuntime:
             self._debug_hems_inventory_summary(),
         )
 
+    def _mark_hems_inventory_polling_disabled(self) -> None:
+        """Discard Heat Pump HEMS inventory state when its group is disabled."""
+
+        self._update_shared_state(
+            _hems_devices_payload=None,
+            _hems_devices_last_success_mono=None,
+            _hems_devices_last_success_utc=None,
+            _hems_devices_using_stale=False,
+            _hems_inventory_ready=True,
+            _hems_devices_cache_until=None,
+        )
+        self._merge_heatpump_type_bucket()
+
     def hems_devices_refresh_due(self, *, force: bool = False) -> bool:
         coord = self.coordinator
+        if not coord._heatpump_hems_polling_enabled():
+            return False
         now = time.monotonic()
         health = coord._endpoint_family_state(HEMS_INVENTORY_ENDPOINT_FAMILY)
         if health.cooldown_active and coord._endpoint_family_wait_active(

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -7529,6 +7529,7 @@ Current implementation policy:
 - Keep ordinary slow coordinator polling at **60 seconds or slower** by default.
 - Keep temporary fast polling at **30 seconds or slower**, and reserve it for user actions or short-lived state transitions.
 - Do not poll low-volatility inventory/topology endpoints on every coordinator refresh. Current minimum cache windows include site-device inventory and system-dashboard detail fan-out at **600 seconds**, HEMS device inventory at **60 seconds**, heat-pump runtime state at **60 seconds**, and Storm Alert at **300 seconds**.
+- Run recurring HEMS device inventory and Heat Pump runtime polling only when the Heat Pump device group is selected. Setup and reconfiguration may still probe HEMS inventory so a newly installed Heat Pump can be discovered, and the separate HEMS lifetime-energy fallback remains available for EVSE or water-heater channels.
 - Derive heat-pump power from HEMS energy deltas on a slower cadence; current heat-pump power/daily energy refreshes use the HEMS daily-consumption cache window of **300 seconds**.
 - Endpoint failures must use stale data, endpoint-family cooldowns, or optional-service degradation before increasing polling pressure.
 - Optional HEMS/Heat Pump auth failures must not trigger global stored-password refresh. They are isolated behind the HEMS auth circuit and backoff so wallbox, battery, gateway, and other non-HEMS data can continue.

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -4664,6 +4664,7 @@ def test_hems_auth_circuit_is_coordinator_backed(
     coordinator_factory,
     mock_issue_registry,
     monkeypatch,
+    caplog,
 ):
     coord = coordinator_factory()
     _enable_degraded_service_repairs(mock_issue_registry, monkeypatch)
@@ -4683,6 +4684,8 @@ def test_hems_auth_circuit_is_coordinator_backed(
     assert metrics["hems_auth_last_endpoint"] == "hems_devices"
     assert metrics["hems_auth_last_reason"] == "unauthorized"
     assert "hems_auth" in metrics["degraded_services"]
+    coord._clear_disabled_heatpump_hems_auth_state()  # noqa: SLF001
+    assert coord._hems_auth_circuit_active() is True  # noqa: SLF001
     first_issue = mock_issue_registry.created[-1]
     assert first_issue[1] == "hems_auth_degraded"
     assert first_issue[2]["translation_placeholders"]["failure_count"] == "1"
@@ -4694,6 +4697,13 @@ def test_hems_auth_circuit_is_coordinator_backed(
     second_issue = mock_issue_registry.created[-1]
     assert second_issue[1] == "hems_auth_degraded"
     assert second_issue[2]["translation_placeholders"]["failure_count"] == "2"
+    matching = [
+        record
+        for record in caplog.records
+        if "Pausing optional HEMS polling" in record.getMessage()
+    ]
+    assert len(matching) == 2
+    assert all(record.levelno == logging.WARNING for record in matching)
 
     coord._hems_auth_backoff_until = time.monotonic() - 1  # noqa: SLF001
     assert coord._hems_auth_circuit_active() is False  # noqa: SLF001
@@ -4706,18 +4716,29 @@ def test_hems_auth_circuit_suppresses_repair_without_heatpump_context(
     coordinator_factory,
     mock_issue_registry,
     monkeypatch,
+    caplog,
 ):
     coord = coordinator_factory()
+    coord._selected_type_keys = {"envoy", "iqevse"}  # noqa: SLF001
     _enable_degraded_service_repairs(mock_issue_registry, monkeypatch)
 
-    assert coord._note_hems_auth_failure(  # noqa: SLF001
-        coord_mod.Unauthorized(),
-        endpoint="hems_devices",
-    )
+    with caplog.at_level(logging.DEBUG, logger=coord_mod.__name__):
+        assert coord._note_hems_auth_failure(  # noqa: SLF001
+            coord_mod.Unauthorized(),
+            endpoint="hems_devices",
+        )
 
     assert coord._hems_auth_circuit_active() is True  # noqa: SLF001
     assert coord._hems_auth_failure_count == 1  # noqa: SLF001
     assert not mock_issue_registry.created
+    matching = [
+        record
+        for record in caplog.records
+        if "Pausing optional HEMS polling" in record.getMessage()
+    ]
+    assert len(matching) == 1
+    assert matching[0].levelno == logging.DEBUG
+    assert coord.collect_site_metrics()["hems_inventory_polling_enabled"] is False
 
 
 def test_hems_auth_repair_context_respects_disabled_heatpump_group(
@@ -4735,6 +4756,10 @@ def test_hems_auth_repair_context_respects_disabled_heatpump_group(
         endpoint="hems_devices",
     )
     assert not mock_issue_registry.created
+
+    coord._selected_type_keys = set()  # noqa: SLF001
+    assert coord._hems_auth_repair_context_available() is False  # noqa: SLF001
+    assert coord._heatpump_hems_polling_enabled() is False  # noqa: SLF001
 
 
 def test_hems_auth_repair_context_handles_defensive_fallbacks(
@@ -4758,6 +4783,27 @@ def test_hems_auth_repair_context_handles_defensive_fallbacks(
     coord.heatpump_runtime.heatpump_entities_established = None
 
     assert coord._hems_auth_repair_context_available() is False  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_async_setup_clears_disabled_heatpump_hems_auth_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._selected_type_keys = {"envoy", "iqevse"}  # noqa: SLF001
+    coord._note_hems_auth_failure(  # noqa: SLF001
+        coord_mod.Unauthorized(), endpoint="hems_support_preflight"
+    )
+    coord.discovery_snapshot.async_restore_state = AsyncMock()
+    coord.refresh_runner.async_start_startup_power = AsyncMock()
+
+    await coord._async_setup()  # noqa: SLF001
+
+    coord.discovery_snapshot.async_restore_state.assert_awaited_once_with()
+    coord.refresh_runner.async_start_startup_power.assert_awaited_once_with()
+    assert coord._hems_auth_circuit_active() is False  # noqa: SLF001
+    assert coord._hems_auth_failure_count == 0  # noqa: SLF001
+    assert coord.inventory_runtime._hems_inventory_ready is True  # noqa: SLF001
 
 
 def test_hems_auth_circuit_restores_and_persists_config_entry_state(

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -2168,6 +2168,7 @@ async def test_inventory_runtime_refresh_hems_devices_uses_heatpump_runtime_pref
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
+    coord._selected_type_keys = {"heatpump"}  # noqa: SLF001
     runtime = coord.inventory_runtime
 
     async def _mark_unsupported(*, force: bool = False) -> None:
@@ -2190,6 +2191,94 @@ async def test_inventory_runtime_refresh_hems_devices_uses_heatpump_runtime_pref
     runtime._merge_heatpump_type_bucket.assert_called_once_with()  # noqa: SLF001
     assert runtime._hems_inventory_ready is True  # noqa: SLF001
     assert runtime._hems_devices_payload is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_disables_hems_inventory_without_heatpump(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._selected_type_keys = {"envoy", "iqevse"}  # noqa: SLF001
+    runtime = coord.inventory_runtime
+    runtime._hems_devices_payload = {"existing": True}  # noqa: SLF001
+    runtime._hems_devices_last_success_mono = time.monotonic()  # noqa: SLF001
+    runtime._hems_devices_last_success_utc = datetime.now(timezone.utc)  # noqa: SLF001
+    runtime._hems_devices_using_stale = True  # noqa: SLF001
+    runtime._devices_inventory_payload = {  # noqa: SLF001
+        "result": [
+            {
+                "type": "hemsDevices",
+                "devices": [
+                    {
+                        "heat-pump": [
+                            {
+                                "device-uid": "legacy-heat-pump",
+                                "device-type": "HEAT_PUMP",
+                            }
+                        ]
+                    }
+                ],
+            }
+        ]
+    }
+    coord._note_hems_auth_failure(  # noqa: SLF001
+        api.Unauthorized(), endpoint="hems_devices"
+    )
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("unused")
+    )
+    coord.client.hems_devices = AsyncMock(side_effect=AssertionError("unused"))
+
+    await runtime._async_refresh_hems_devices(force=True)  # noqa: SLF001
+
+    coord.heatpump_runtime.async_refresh_hems_support_preflight.assert_not_awaited()
+    coord.client.hems_devices.assert_not_awaited()
+    assert runtime.hems_devices_refresh_due(force=True) is False
+    assert runtime._hems_devices_payload is None  # noqa: SLF001
+    assert runtime._hems_devices_last_success_mono is None  # noqa: SLF001
+    assert runtime._hems_devices_last_success_utc is None  # noqa: SLF001
+    assert runtime._hems_devices_using_stale is False  # noqa: SLF001
+    assert runtime._hems_inventory_ready is True  # noqa: SLF001
+    assert coord.inventory_view.has_type("heatpump") is False
+    assert "heatpump" not in coord.inventory_view.iter_type_keys()
+    assert coord._hems_auth_circuit_active() is False  # noqa: SLF001
+    assert coord.collect_site_metrics()["hems_inventory_polling_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_preserves_non_heatpump_hems_auth_circuit(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._selected_type_keys = set()  # noqa: SLF001
+    runtime = coord.inventory_runtime
+    coord._note_hems_auth_failure(  # noqa: SLF001
+        api.Unauthorized(), endpoint="hems_consumption_lifetime"
+    )
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("unused")
+    )
+    coord.client.hems_devices = AsyncMock(side_effect=AssertionError("unused"))
+
+    await runtime._async_refresh_hems_devices(force=True)  # noqa: SLF001
+
+    coord.heatpump_runtime.async_refresh_hems_support_preflight.assert_not_awaited()
+    coord.client.hems_devices.assert_not_awaited()
+    assert coord._hems_auth_circuit_active() is True  # noqa: SLF001
+    assert coord._hems_auth_last_endpoint == "hems_consumption_lifetime"  # noqa: SLF001
+
+
+def test_inventory_runtime_hems_inventory_enabled_for_heatpump_and_legacy_entries(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+
+    coord._selected_type_keys = None  # noqa: SLF001
+    assert runtime.hems_devices_refresh_due(force=True) is True
+
+    coord._selected_type_keys = {"heatpump"}  # noqa: SLF001
+    assert runtime.hems_devices_refresh_due(force=True) is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Treat the configured Heat Pump device-group selection as authoritative for recurring HEMS inventory polling.
- Clear stale Heat Pump inventory and Heat-Pump-only auth backoff state when Heat Pump is explicitly unselected, while preserving the HEMS lifetime-energy fallback.
- Downgrade defensive HEMS auth failures to debug logging when no Heat Pump context exists, and expose the polling decision in diagnostics.
- Add regression coverage for empty selections, forced refreshes, persisted auth circuits, legacy HEMS inventory, logging, and discovery compatibility.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/inventory_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_inventory_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/inventory_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Results:

- 3,788 integration tests passed.
- 3,920 repository tests passed.
- 100% targeted coverage for `coordinator.py`, `coordinator_diagnostics.py`, and `inventory_runtime.py`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation when behaviour changed.
- [x] I verified translations are complete and valid; no translation changes were required.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (checks are pending).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Diagnostics now include `hems_inventory_polling_enabled`. In this linked worktree, the pre-commit container required the host Git metadata to be mounted into the container; all hooks passed.
