### PR TITLE
Prepare release 4.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,21 +11,38 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v4.0.1 - 2026-07-22
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
 - Populated Grid Profile sensor metadata such as profile group, PEL support,
   277 V compatibility, and recommendation status from the cached Activation
-  profile catalog.
+  profile catalog. (#791)
 - Stopped background Heat Pump HEMS inventory polling when the Heat Pump device
   group is explicitly disabled, and downgraded defensive HEMS auth messages to
-  debug logging when no Heat Pump context exists.
+  debug logging when no Heat Pump context exists. (#793)
 
 ### 🔧 Improvements
 - Applied non-topology integration options without reloading the config entry, and
   preserved the live coordinator and last known entity state across the remaining
   device/topology reloads. This substantially reduces unavailable and unknown
-  entity states after saving integration settings.
+  entity states after saving integration settings. (#792)
 
 ### 🔄 Other changes
-- None
+- Bumped the integration manifest version to `4.0.1`.
 
 ## v4.0.0 - 2026-07-17
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "4.0.0"
+  "version": "4.0.1"
 }


### PR DESCRIPTION
## Summary

Prepare the Enphase Energy integration release v4.0.1.

- Bump the integration manifest version from `4.0.0` to `4.0.1`.
- Move the accumulated fixes and improvement into a dated v4.0.1 changelog section.
- Reset the Unreleased section and add the relevant pull request references.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (release preparation)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Results:

- 3,788 integration tests passed.
- 3,920 full-repository tests passed.
- Ruff, pre-commit, quality-scale validation, import-time profiling, and strict mypy passed.

No Python files were changed, so separate Black and targeted Python coverage runs were not applicable.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation updates are not required because behavior and options did not change.
- [x] Translation verification is not applicable because translations did not change.
- [x] Targeted Python coverage is not applicable because no Python modules changed.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Release metadata only; no diagnostics or screenshots are required.
