### PR TITLE
Fix Grid Profile Activation authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Bootstrapped Grid Profile access with the short-lived Activation token embedded
+  by the authenticated Enlighten Settings page, matching the working web UI
+  bearer and Manager-cookie request shape.
+- Stopped unavailable Grid Profile access from marking the overall Enphase site
+  service as degraded; the optional endpoint health remains visible in diagnostics.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -13,6 +13,7 @@ import base64
 from builtins import ExceptionGroup
 import copy
 import hashlib
+from html import unescape
 import json
 import logging
 import re
@@ -77,6 +78,10 @@ _BATTERY_CONFIG_VARIANT_LEAN = "official_web_lean"
 _BATTERY_CONFIG_VARIANT_SESSION_COOKIE = "official_web_session_cookie"
 _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH = "cookie_eauth_compatible"
 _BATTERY_CONFIG_VARIANT_MIXED = "mixed_auth_compatible"
+_ACTIVATION_UI_URL_RE = re.compile(
+    r"(?:(?:https?:)?//[^\"'<>\s]+)?/app/activation_ui/\?[^\"'<>\s]+",
+    re.IGNORECASE,
+)
 _ENLIGHTEN_READ_CONCURRENCY_LIMIT = 3
 _ENLIGHTEN_OPTIONAL_READ_CONCURRENCY_LIMIT = 2
 _SYSTEM_EVENTS_PAGE_SIZE = 200
@@ -762,6 +767,30 @@ def _decode_jwt_exp(token: str) -> int | None:
     exp = payload.get("exp")
     if isinstance(exp, (int, float)):
         return int(exp)
+    return None
+
+
+def _activation_context_from_settings_html(
+    payload: str,
+) -> tuple[str, str] | None:
+    """Extract the Activation UI JWT and referer embedded by Enlighten settings."""
+
+    normalized = unescape(payload).replace(r"\u0026", "&").replace(r"\/", "/")
+    for match in _ACTIVATION_UI_URL_RE.finditer(normalized):
+        candidate = match.group(0)
+        if candidate.startswith("//"):
+            candidate = f"https:{candidate}"
+        elif candidate.startswith("/"):
+            candidate = f"{BASE_URL}{candidate}"
+        try:
+            activation_url = URL(candidate)
+        except Exception:  # noqa: BLE001 - malformed unrelated page content
+            continue
+        if activation_url.host != URL(BASE_URL).host:
+            continue
+        token = activation_url.query.get("token")
+        if token and token.count(".") >= 2:
+            return str(token), str(activation_url)
     return None
 
 
@@ -2082,6 +2111,8 @@ class EnphaseEVClient:
         self._battery_config_write_bases: dict[str, dict[str, Any]] = {}
         self._cookie = cookie or ""
         self._eauth = eauth or None
+        self._activation_token: str | None = None
+        self._activation_referer: str | None = None
         self._hems_site_supported: bool | None = None
         self._system_dashboard_summary_payload: dict[str, object] | None = None
         self._reauth_cb: Callable[[], Awaitable[bool]] | None = reauth_callback
@@ -2147,10 +2178,16 @@ class EnphaseEVClient:
     ) -> None:
         """Update headers when auth credentials change."""
 
+        credentials_changed = bool(
+            (eauth is not None and (eauth or None) != self._eauth)
+            or (cookie is not None and (cookie or "") != self._cookie)
+        )
         if eauth is not None:
             self._eauth = eauth or None
         if cookie is not None:
             self._cookie = cookie or ""
+        if credentials_changed:
+            self._clear_activation_auth_context()
 
         if self._cookie:
             self._h["Cookie"] = self._cookie
@@ -2697,24 +2734,26 @@ class EnphaseEVClient:
     def _activation_reference_headers(self) -> dict[str, str | None]:
         """Return headers for Activation reference-data calls."""
 
-        token = self._battery_config_single_auth_token()
+        token = self._activation_auth_token()
         return {
             "Accept": "application/json, text/plain, */*",
-            "Cookie": self._cookie or None,
+            "Cookie": self._activation_cookie(token),
             "enlm-token": token,
-            "Referer": f"{BASE_URL}/app/activation_ui/?system_id={self._site}",
+            "Referer": self._activation_referer
+            or f"{BASE_URL}/app/activation_ui/?system_id={self._site}",
             "X-Requested-With": None,
         }
 
     def _activation_headers(self, *, write: bool = False) -> dict[str, str | None]:
         """Return cloud Activation API headers."""
 
-        token = self._battery_config_single_auth_token()
+        token = self._activation_auth_token()
         headers: dict[str, str | None] = {
             "Accept": "application/json, text/plain, */*",
             "Authorization": f"Bearer {token}" if token else None,
-            "Cookie": self._cookie or None,
-            "Referer": f"{BASE_URL}/app/activation_ui/?system_id={self._site}",
+            "Cookie": self._activation_cookie(token),
+            "Referer": self._activation_referer
+            or f"{BASE_URL}/app/activation_ui/?system_id={self._site}",
             "X-Requested-With": None,
             "e-auth-token": None,
         }
@@ -2723,42 +2762,131 @@ class EnphaseEVClient:
             headers["Origin"] = BASE_URL
         return headers
 
+    def _activation_auth_token(self) -> str | None:
+        """Return the settings-page Activation token, with stored-auth fallback."""
+
+        token = self._activation_token
+        if token:
+            expires_at = _decode_jwt_exp(token)
+            if (
+                expires_at is None
+                or expires_at > int(datetime.now(timezone.utc).timestamp()) + 60
+            ):
+                return token
+            self._clear_activation_auth_context()
+        return self._battery_config_single_auth_token()
+
+    def _clear_activation_auth_context(self) -> None:
+        """Discard the in-memory Activation JWT and its matching referer."""
+
+        self._activation_token = None
+        self._activation_referer = None
+
+    def _activation_cookie(self, token: str | None) -> str | None:
+        """Return session cookies with the Activation Manager token synchronized."""
+
+        cookies = _cookie_map_from_header(self._cookie)
+        if token and token == self._activation_token:
+            cookies["enlighten_manager_token_production"] = token
+        return _cookie_header_from_map(cookies) or None
+
+    async def async_prepare_activation_auth(self, *, force: bool = False) -> bool:
+        """Bootstrap the same Activation JWT embedded by the Enlighten settings UI."""
+
+        if (
+            not force
+            and self._activation_token
+            and self._activation_auth_token() == self._activation_token
+        ):
+            return True
+        url = f"{BASE_URL}/systems/{self._site}/details"
+        try:
+            payload = await self._text(
+                "GET",
+                url,
+                headers={
+                    "Accept": "text/html,application/xhtml+xml",
+                    "Referer": f"{BASE_URL}/systems/{self._site}",
+                    "X-Requested-With": None,
+                },
+            )
+        except (
+            aiohttp.ClientError,
+            asyncio.TimeoutError,
+            EnphaseLoginWallUnauthorized,
+            Unauthorized,
+        ) as err:
+            _LOGGER.debug(
+                "Activation auth bootstrap unavailable for site %s: %s",
+                redact_site_id(self._site),
+                redact_text(err, site_ids=(self._site,)),
+            )
+            return False
+        context = _activation_context_from_settings_html(payload)
+        if context is None:
+            _LOGGER.debug(
+                "Activation UI token was not present in settings for site %s",
+                redact_site_id(self._site),
+            )
+            return False
+        self._activation_token, self._activation_referer = context
+        return True
+
     async def _activation_payload(
         self,
         method: str,
         url: str,
         *,
-        headers: dict[str, str | None],
+        headers: dict[str, str | None] | Callable[[], dict[str, str | None]],
         **kwargs: Any,
     ) -> object:
         """Return Activation JSON, mapping denied access to optional unavailable."""
 
-        try:
-            return await self._json(
-                method,
-                url,
-                headers=headers,
-                allow_reauth=False,
-                use_cookie_header_only=True,
-                **kwargs,
-            )
-        except EnphaseLoginWallUnauthorized as err:
-            raise ActivationAccessDenied("Activation login wall") from err
-        except Unauthorized as err:
-            raise ActivationAccessDenied("Activation access denied") from err
-        except InvalidPayloadError as err:
-            raise OptionalEndpointUnavailable("Activation payload unavailable") from err
-        except aiohttp.ClientResponseError as err:
-            if err.status in {401, 403, 404}:
+        auth_retry_attempted = False
+        while True:
+            request_headers = headers() if callable(headers) else headers
+            try:
+                return await self._json(
+                    method,
+                    url,
+                    headers=request_headers,
+                    allow_reauth=False,
+                    use_cookie_header_only=True,
+                    **kwargs,
+                )
+            except EnphaseLoginWallUnauthorized as err:
+                raise ActivationAccessDenied("Activation login wall") from err
+            except Unauthorized as err:
+                if not auth_retry_attempted and self._activation_token is not None:
+                    auth_retry_attempted = True
+                    self._clear_activation_auth_context()
+                    await self.async_prepare_activation_auth(force=True)
+                    continue
                 raise ActivationAccessDenied("Activation access denied") from err
-            raise
+            except InvalidPayloadError as err:
+                raise OptionalEndpointUnavailable(
+                    "Activation payload unavailable"
+                ) from err
+            except aiohttp.ClientResponseError as err:
+                if (
+                    err.status in {401, 403}
+                    and not auth_retry_attempted
+                    and self._activation_token is not None
+                ):
+                    auth_retry_attempted = True
+                    self._clear_activation_auth_context()
+                    await self.async_prepare_activation_auth(force=True)
+                    continue
+                if err.status in {401, 403, 404}:
+                    raise ActivationAccessDenied("Activation access denied") from err
+                raise
 
     async def _activation_json(
         self,
         method: str,
         url: str,
         *,
-        headers: dict[str, str | None],
+        headers: dict[str, str | None] | Callable[[], dict[str, str | None]],
         **kwargs: Any,
     ) -> JsonDict:
         """Return Activation object JSON."""
@@ -5704,7 +5832,7 @@ class EnphaseEVClient:
         return await self._activation_json(
             "GET",
             url,
-            headers=self._activation_reference_headers(),
+            headers=self._activation_reference_headers,
         )
 
     async def async_get_activation_record(self) -> JsonDict:
@@ -5718,7 +5846,7 @@ class EnphaseEVClient:
             "GET",
             url,
             params={"expand": "owner,host"},
-            headers=self._activation_headers(),
+            headers=self._activation_headers,
         )
 
     async def async_get_activation_device_list(self) -> JsonDict:
@@ -5731,7 +5859,7 @@ class EnphaseEVClient:
         result = await self._activation_payload(
             "GET",
             url,
-            headers=self._activation_headers(),
+            headers=self._activation_headers,
         )
         if isinstance(result, dict):
             return result
@@ -5760,7 +5888,7 @@ class EnphaseEVClient:
                 "country": country,
                 "state": state,
             },
-            headers=self._activation_headers(write=True),
+            headers=lambda: self._activation_headers(write=True),
         )
 
     async def async_apply_grid_profile(
@@ -5788,7 +5916,7 @@ class EnphaseEVClient:
             "PUT",
             url,
             json=[envoy_payload],
-            headers=self._activation_headers(write=True),
+            headers=lambda: self._activation_headers(write=True),
             allow_empty_success=True,
         )
         if isinstance(result, dict):

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -49,6 +49,7 @@ _DEGRADED_SERVICE_REPAIR_ISSUES: tuple[tuple[str, str], ...] = (
 _DEGRADED_SERVICE_REPAIR_ISSUE_IDS = frozenset(
     issue_id for _flag_attr, issue_id in _DEGRADED_SERVICE_REPAIR_ISSUES
 )
+_NON_DEGRADING_OPTIONAL_ENDPOINT_FAMILIES = frozenset({"activation_grid_profile"})
 
 
 class CoordinatorDiagnostics:
@@ -1057,7 +1058,8 @@ class CoordinatorDiagnostics:
         degraded_endpoint_families = [
             family
             for family, state in endpoint_family_health.items()
-            if _endpoint_family_degraded(state)
+            if family not in _NON_DEGRADING_OPTIONAL_ENDPOINT_FAMILIES
+            and _endpoint_family_degraded(state)
         ]
         metrics["degraded_endpoint_families"] = degraded_endpoint_families
         metrics["endpoint_failure_details"] = {

--- a/custom_components/enphase_ev/grid_profile_runtime.py
+++ b/custom_components/enphase_ev/grid_profile_runtime.py
@@ -981,6 +981,13 @@ class GridProfileRuntime:
             ACTIVATION_GRID_PROFILE_FAMILY, err
         )
 
+    async def _async_prepare_activation_auth(self) -> None:
+        """Allow the client to acquire the settings-page Activation JWT."""
+
+        prepare = getattr(self.client, "async_prepare_activation_auth", None)
+        if callable(prepare):
+            await prepare()
+
     @staticmethod
     def _is_access_denied(err: Exception) -> bool:
         if isinstance(err, aiohttp.ClientResponseError) and err.status in {
@@ -1001,6 +1008,7 @@ class GridProfileRuntime:
             if not self.coordinator._endpoint_family_should_run(family, force=force):
                 return self.browse()
             try:
+                await self._async_prepare_activation_auth()
                 devices = await self.client.async_get_activation_device_list()
                 self._parse_activation_devices(devices)
             except Exception as err:  # noqa: BLE001
@@ -1029,6 +1037,7 @@ class GridProfileRuntime:
                 return self.browse()
             errors: list[Exception] = []
             successful_requests = 0
+            await self._async_prepare_activation_auth()
             if force or self.reference_payload is None:
                 try:
                     reference = await self.client.async_get_activation_reference_data()
@@ -1160,6 +1169,7 @@ class GridProfileRuntime:
         if force:
             self.catalog_cache.pop(key, None)
         try:
+            await self._async_prepare_activation_auth()
             payload = await self.client.async_get_grid_profiles_filtered(
                 country=country,
                 state=state,
@@ -1439,6 +1449,7 @@ class GridProfileRuntime:
         assert profile is not None
         assert target is not None
         try:
+            await self._async_prepare_activation_auth()
             await self.client.async_apply_grid_profile(
                 gateway_serial=target.serial_num,
                 part_num=target.part_num,

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -203,11 +203,12 @@ Status labels:
 | BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | BatteryConfig write shape plus `X-XSRF-Token`; ordinary time/limit edits can omit `isEnabled`, while explicit schedule-entry toggle writes may include it; verified working update uses the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) from a stateless client session; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | Runtime |
 | BatteryConfig schedule legacy delete alias | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>/delete` | same BatteryConfig write planner as schedule create/update; cookie-backed browser request is the verified working compatibility shape on affected sites | Runtime |
 | BatteryConfig disclaimer accept | `POST` | `/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/<site_id>` | same BatteryConfig write planner as other battery settings mutations | Runtime |
-| Activation reference data | `GET` | `/service/activation_service/api/details/reference_data` | Activation UI authenticated session cookies plus `enlm-token` / manager token context; browser capture did not include an explicit `Authorization` header | Runtime |
-| Activation record | `GET` | `/service/activation_backend/api/gateway/v4/activations/<site_id>?expand=owner,host` | Activation UI authenticated session cookies plus Activation bearer auth; requires account role with Activation access | Runtime |
-| Activation device list and grid-profile status | `GET` | `/service/activation_backend/api/gateway/v4/systems/<site_id>/devices/list` | Activation UI authenticated session cookies plus `Authorization: Bearer <activation_jwt>`; requires installer-level Activation access | Runtime |
-| Grid profile discovery | `POST` | `/service/activation_backend/api/gateway/v4/systems/<site_id>/grid_profiles_filtered` | Activation UI authenticated session cookies plus `Authorization: Bearer <activation_jwt>`; requires installer-level Activation access | Runtime |
-| Apply grid profile | `PUT` | `/service/activation_backend/api/gateway/v4/systems/<site_id>/envoys` | same Activation UI bearer/cookie shape as discovery; requires installer-level Activation access | Runtime |
+| Activation auth bootstrap | `GET` | `/systems/<site_id>/details` | authenticated Enlighten Settings HTML embeds a same-origin `/app/activation_ui/` URL containing the short-lived Activation JWT and exact referer context; token and referer are retained in memory only | Runtime |
+| Activation reference data | `GET` | `/service/activation_service/api/details/reference_data` | authenticated session cookies with `enlighten_manager_token_production` synchronized to the bootstrapped Activation JWT, plus the JWT in `enlm-token`; browser capture did not include an explicit `Authorization` header | Runtime |
+| Activation record | `GET` | `/service/activation_backend/api/gateway/v4/activations/<site_id>?expand=owner,host` | synchronized Activation cookie, exact embedded Activation UI referer, and `Authorization: Bearer <activation_jwt>`; requires account role with Activation access | Runtime |
+| Activation device list and grid-profile status | `GET` | `/service/activation_backend/api/gateway/v4/systems/<site_id>/devices/list` | same synchronized Activation bearer/cookie/referer context; requires installer-level Activation access | Runtime |
+| Grid profile discovery | `POST` | `/service/activation_backend/api/gateway/v4/systems/<site_id>/grid_profiles_filtered` | same synchronized Activation bearer/cookie/referer context; requires installer-level Activation access | Runtime |
+| Apply grid profile | `PUT` | `/service/activation_backend/api/gateway/v4/systems/<site_id>/envoys` | same synchronized Activation bearer/cookie/referer context as discovery; requires installer-level Activation access | Runtime |
 | PES in-app banner/status | `GET` | `/service/pes_management/systems/<site_id>/inapp?type=<type>` | authenticated session cookies | Browser capture only |
 | Login | `POST` | `/login/login.json` | credentials; session/XSRF cookies are established by the response rather than pre-required | Runtime |
 
@@ -6843,13 +6844,38 @@ Observed behavior:
 
 ## 5A. Activation Grid Profile APIs (Installer-Level)
 
-The Activation UI exposes grid-profile discovery and assignment endpoints that are separate from BatteryConfig and the homeowner grid on/off controls. These calls were captured from the Enlighten Activation web UI on 2026-07-08 while inspecting Australian grid profiles.
+The Activation UI exposes grid-profile discovery and assignment endpoints that are separate from BatteryConfig and the homeowner grid on/off controls. These calls were captured from the Enlighten Activation web UI on 2026-07-08 while inspecting Australian grid profiles. A follow-up capture on 2026-07-22 confirmed that the classic Enlighten Settings page embeds the working Activation JWT and referer in its Activation UI iframe URL.
 
 Operational constraints:
 - These endpoints require an account/session with installer-level Activation access. Homeowner/owner sessions should not be assumed to have access.
 - A successful apply response means the cloud accepted or queued the grid-profile update; it does not prove the Gateway has finished applying the profile.
 - Grid profile changes are safety- and compliance-sensitive. Any runtime control should require explicit opt-in, strong confirmation text, and should expose the pending/in-progress state rather than treating the write as instant.
 - Do not log raw Authorization headers, cookies, Activation URLs with user identifiers, site IDs, gateway serials, part numbers, JWTs, email addresses, or local Gateway IP addresses.
+
+### 5A.0 Activation Authentication Bootstrap
+```http
+GET /systems/<site_id>/details
+```
+
+The authenticated classic Enlighten Settings HTML contains a same-origin iframe
+URL with this sanitized shape:
+```text
+https://enlighten.enphaseenergy.com/app/activation_ui/?locale=<locale>&token=<activation_jwt>&siteid=<site_id>&gridprofile=gridprofile&envoyserialnumber=<gateway_serial>
+```
+
+The 2026-07-22 browser capture confirmed that requests made by this iframe use
+the query-string JWT both as `Authorization: Bearer <activation_jwt>` and as the
+value of the `enlighten_manager_token_production` cookie. The full iframe URL is
+also sent as the request `Referer`.
+
+Current runtime behavior:
+- Fetch the Settings page with the authenticated Enlighten session before an Activation refresh, profile-list request, or profile write.
+- HTML-decode the embedded iframe URL and accept it only when its host is `enlighten.enphaseenergy.com` and its path is `/app/activation_ui/`.
+- Retain the extracted JWT and exact iframe referer in memory only. Do not persist either value to config-entry data or diagnostics.
+- Replace the `enlighten_manager_token_production` value in the outbound serialized cookie header with the extracted JWT so the cookie and bearer contexts agree, while preserving the other authenticated session cookies.
+- Treat a JWT as expired 60 seconds before its `exp` claim and reacquire it from the Settings page. A normal credential refresh also clears the cached Activation JWT and referer.
+- If the Settings page or embedded token is temporarily unavailable, preserve the original session cookies and fall back to the Manager JWT already present in the cookie, then to the stored Enlighten access token.
+- If an Activation backend request rejects a bootstrapped JWT with `401` or `403`, discard the cached JWT/referer, force one Settings-page bootstrap, rebuild the headers, and retry once. A second rejection is treated as an optional Activation permission failure rather than a core authentication failure.
 
 ### 5A.1 Reference Data
 ```
@@ -6861,9 +6887,9 @@ Observed request headers:
 ```http
 Accept: application/json, text/plain, */*
 Accept-Language: en-AU,en;q=0.9
-Cookie: <authenticated Enlighten session cookies>
-enlm-token: <manager_or_activation_token>
-Referer: https://enlighten.enphaseenergy.com/app/activation_ui/?...
+Cookie: enlighten_manager_token_production=<activation_jwt>; <other_session_cookies>
+enlm-token: <activation_jwt>
+Referer: <exact_bootstrapped_activation_ui_url>
 ```
 
 Example response excerpt:
@@ -6963,7 +6989,8 @@ Accept: application/json, text/plain, */*
 Content-Type: application/json
 Authorization: Bearer <activation_jwt>
 Origin: https://enlighten.enphaseenergy.com
-Referer: https://enlighten.enphaseenergy.com/app/activation_ui/?...
+Cookie: enlighten_manager_token_production=<activation_jwt>; <other_session_cookies>
+Referer: <exact_bootstrapped_activation_ui_url>
 ```
 
 Observed request body:
@@ -7076,7 +7103,8 @@ Accept: application/json, text/plain, */*
 Content-Type: application/json
 Authorization: Bearer <activation_jwt>
 Origin: https://enlighten.enphaseenergy.com
-Referer: https://enlighten.enphaseenergy.com/app/activation_ui/?...
+Cookie: enlighten_manager_token_production=<activation_jwt>; <other_session_cookies>
+Referer: <exact_bootstrapped_activation_ui_url>
 ```
 
 Observed request body for an Australian zero-export profile:
@@ -7343,7 +7371,7 @@ There is no single universal header set; the implementation varies headers by en
 | HEMS | bearer-preferred auth plus cookies/base headers; `username` and `requestId` when available |
 | BatteryConfig reads | current web shape: fresh session `Cookie`, `Username`, `requestid`, battery-profile `Origin`/`Referer`, Chrome-style `User-Agent`, and no `Authorization` or `e-auth-token`; token-backed primary and lean variants remain as fallbacks |
 | BatteryConfig writes | acquire fresh XSRF by preferring `GET /service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` and its `x-csrf-token` response header, then falling back to `/battery/sites/<site_id>/schedules/isValid`; if that fallback returns `4xx`, still harvest `BP-XSRF-Token` from error response cookies or the session cookie jar, then try a final cookie-based `GET /siteSettings/<site_id>` bootstrap before giving up and keeping the existing token; writes then use an endpoint-specific compatibility planner; on affected sites the verified working shape is a stateless raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`), with official-web primary, official-web lean, and mixed-auth fallbacks retained |
-| Activation reference data and grid profile reads/writes | Activation UI same-origin browser shape. Reference data was observed with authenticated Enlighten cookies plus `enlm-token`; profile discovery/apply were observed with authenticated cookies plus `Authorization: Bearer <activation_jwt>`, `Accept: application/json, text/plain, */*`, `Content-Type: application/json` for writes, `Origin: https://enlighten.enphaseenergy.com`, and an `/app/activation_ui/` referer; grid profile apply requires installer-level Activation permissions |
+| Activation reference data and grid profile reads/writes | Bootstrap the short-lived JWT and exact referer from the same-origin `/app/activation_ui/` URL embedded by authenticated `GET /systems/<site_id>/details`; keep both in memory, synchronize the JWT into `enlighten_manager_token_production`, use it as `enlm-token` for reference data and as `Authorization: Bearer` for Activation backend reads/writes, and retain stored Manager/access-token fallback; grid profile apply requires installer-level Activation permissions |
 
 - Base Enlighten reads:
   - `Cookie: <serialized cookie jar>`
@@ -7373,13 +7401,18 @@ There is no single universal header set; the implementation varies headers by en
   - mixed-auth compatibility fallback restores `Authorization`, `Cookie`, and `X-CSRF-Token`
   - cookie-backed compatibility writes must use a stateless request session so aiohttp does not merge cookie-jar state into the raw `Cookie` header
 - Activation grid profile:
+  - bootstrap with authenticated `GET /systems/<site_id>/details`
+  - extract the JWT and exact referer from the same-origin `/app/activation_ui/` iframe URL; reject non-Enlighten hosts
+  - retain the bootstrap context in memory only, refresh it before JWT expiry, and clear it when normal credentials change
   - `Accept: application/json, text/plain, */*`
-  - `enlm-token: <manager_or_activation_token>` for `GET /activation_service/api/details/reference_data` in the observed browser capture
-  - `Authorization: Bearer <activation_jwt>` for grid profile discovery/apply in the observed browser capture
+  - synchronize `enlighten_manager_token_production=<activation_jwt>` into the authenticated cookie header while preserving the remaining session cookies
+  - `enlm-token: <activation_jwt>` for `GET /activation_service/api/details/reference_data`
+  - `Authorization: Bearer <activation_jwt>` for Activation record/device reads and grid profile discovery/apply
   - `Content-Type: application/json` for `POST`/`PUT`
-  - authenticated Enlighten session cookies
   - `Origin: https://enlighten.enphaseenergy.com`
-  - `Referer: https://enlighten.enphaseenergy.com/app/activation_ui/?...`
+  - `Referer: <exact_bootstrapped_activation_ui_url>`
+  - preserve the original cookies and fall back to the stored Manager-cookie JWT, then the stored Enlighten access token, if bootstrap is temporarily unavailable
+  - on `401`/`403` for a bootstrapped JWT, clear the cached context, force one bootstrap, rebuild the request headers, and retry once
   - requires installer-level Activation access in the observed capture
 
 ---
@@ -7555,7 +7588,7 @@ Endpoint-specific variations are documented in the affected sections so implemen
 
 Cross-cutting unresolved items:
 - Local LAN endpoints (`/ivp/pdm/*`, `/ivp/peb/*`) exist but require installer permissions; they are outside the current owner-account cloud runtime.
-- Activation grid-profile control requires installer-level access in the observed capture. The integration still needs a confirmed way to detect Activation role eligibility, obtain the same Activation bearer token reliably, and read a redacted activation-record payload before exposing runtime controls.
+- Activation grid-profile control requires installer-level access in the observed capture. The runtime now obtains the same Activation bearer/cookie/referer context as the Enlighten UI; the remaining open question is whether Enphase exposes an explicit role/capability flag that can avoid probing the optional Activation endpoints to confirm eligibility.
 - Real EVSE MQTT frames have not yet been captured, even though the broker accepts exact-topic subscriptions. The charger card's instantaneous voltage/current/power source remains the main open telemetry capture target.
 - Heat-pump write-path behavior remains unresolved; current HEMS captures cover inventory, runtime state, event diagnostics, timeseries, and stream toggles only.
 

--- a/docs/api/grid_profile_control_plan.md
+++ b/docs/api/grid_profile_control_plan.md
@@ -23,6 +23,14 @@ No local Gateway endpoints are used in v1.
 ## Runtime Design
 
 - Add an optional `activation_grid_profile` endpoint family with cooldown/backoff and suppressed non-installer failures.
+- Bootstrap the short-lived Activation JWT from the authenticated
+  `/systems/<site_id>/details` page that embeds `/app/activation_ui/`, keep it
+  in memory only, and synchronize it into both the bearer header and
+  `enlighten_manager_token_production` cookie used by the working Enlighten UI.
+- Preserve the original cookie header for stored-token fallback, and force one
+  bootstrap/header rebuild when an Activation backend rejects a cached JWT.
+- Keep Activation access failures visible in endpoint diagnostics and backoff,
+  but do not roll this optional installer capability into overall degraded service.
 - Derive country from Activation/site metadata first, then BatteryConfig country, then system-dashboard country.
 - Expose `regions[user_country]` only.
 - Cache profile catalogs by `(country, region_code, commonly_used)`.

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -309,6 +309,29 @@ def test_battery_endpoint_family_failure_reports_degraded_service(
     assert "battery_status" in metrics["degraded_services"]
 
 
+def test_grid_profile_failure_does_not_degrade_service(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(coord_mod.random, "uniform", lambda _a, _b: 1.0)
+
+    err = OptionalEndpointUnavailable("Activation access denied")
+    assert (
+        coord._note_endpoint_family_failure("activation_grid_profile", err) is True
+    )  # noqa: SLF001
+
+    metrics = coord.collect_site_metrics()
+    assert (
+        metrics["endpoint_family_health"]["activation_grid_profile"][
+            "consecutive_failures"
+        ]
+        == 1
+    )
+    assert metrics["degraded_endpoint_families"] == []
+    assert "activation_grid_profile" not in metrics["degraded_services"]
+    assert "activation_grid_profile" in metrics["endpoint_failure_details"]
+
+
 def test_degraded_endpoint_family_rollup_tolerates_unexpected_health(
     coordinator_factory, monkeypatch
 ) -> None:

--- a/tests/components/enphase_ev/test_grid_profile_runtime.py
+++ b/tests/components/enphase_ev/test_grid_profile_runtime.py
@@ -45,6 +45,142 @@ def _make_api_client() -> api.EnphaseEVClient:
     return api.EnphaseEVClient(_DefaultSession(), "3381244", "TOKEN", "COOKIE")
 
 
+async def test_activation_auth_bootstraps_embedded_settings_token() -> None:
+    client = _make_api_client()
+    client.update_credentials(
+        cookie="session=current; enlighten_manager_token_production=stale"
+    )
+    token = "header.payload.signature"
+    client._text = AsyncMock(  # noqa: SLF001
+        return_value=(
+            '<iframe src="/app/activation_ui/?locale=en-AU&amp;token='
+            f'{token}&amp;siteid=3381244&amp;gridprofile=gridprofile"></iframe>'
+        )
+    )
+
+    assert await client.async_prepare_activation_auth() is True
+    assert await client.async_prepare_activation_auth() is True
+
+    headers = client._activation_headers()  # noqa: SLF001
+    assert headers["Authorization"] == f"Bearer {token}"
+    assert headers["Referer"] == (
+        "https://enlighten.enphaseenergy.com/app/activation_ui/"
+        f"?locale=en-AU&token={token}&siteid=3381244&gridprofile=gridprofile"
+    )
+    assert headers["Cookie"] == (
+        f"session=current; enlighten_manager_token_production={token}"
+    )
+    client._text.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+def test_activation_auth_parser_handles_protocol_relative_and_malformed_urls() -> None:
+    token = "header.payload.signature"
+    assert api._activation_context_from_settings_html(  # noqa: SLF001
+        "//enlighten.enphaseenergy.com/app/activation_ui/"
+        f"?locale=en-AU&token={token}&siteid=3381244"
+    ) == (
+        token,
+        "https://enlighten.enphaseenergy.com/app/activation_ui/"
+        f"?locale=en-AU&token={token}&siteid=3381244",
+    )
+    assert (
+        api._activation_context_from_settings_html(  # noqa: SLF001
+            f"https://example.com/app/activation_ui/?token={token}"
+        )
+        is None
+    )
+    with patch.object(api, "URL", side_effect=ValueError):
+        assert (
+            api._activation_context_from_settings_html(  # noqa: SLF001
+                f"/app/activation_ui/?token={token}"
+            )
+            is None
+        )
+
+
+def test_activation_auth_expired_cached_token_uses_stored_fallback() -> None:
+    client = _make_api_client()
+    client._activation_token = "header.eyJleHAiOjF9.signature"  # noqa: SLF001
+
+    assert client._activation_auth_token() == "TOKEN"  # noqa: SLF001
+    assert client._activation_token is None  # noqa: SLF001
+    assert client._activation_referer is None  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "<html>No Activation UI</html>",
+        '<iframe src="/app/activation_ui/?token=not-a-jwt"></iframe>',
+    ],
+)
+async def test_activation_auth_bootstrap_preserves_fallback_without_valid_token(
+    payload: str,
+) -> None:
+    client = _make_api_client()
+    client.update_credentials(eauth="access-token", cookie="session=current")
+    client._text = AsyncMock(return_value=payload)  # noqa: SLF001
+
+    assert await client.async_prepare_activation_auth() is False
+    headers = client._activation_headers()  # noqa: SLF001
+    assert headers["Authorization"] == "Bearer access-token"
+    assert headers["Cookie"] == "session=current"
+
+
+@pytest.mark.parametrize(
+    "rejection",
+    [
+        Unauthorized("expired"),
+        aiohttp.ClientResponseError(None, (), status=403),
+    ],
+)
+async def test_activation_request_rebootstraps_rejected_cached_token(
+    rejection: Exception,
+) -> None:
+    client = _make_api_client()
+    client.update_credentials(eauth="fallback", cookie="session=current")
+    client._activation_token = "old.header.signature"  # noqa: SLF001
+    client._activation_referer = (
+        "https://enlighten.enphaseenergy.com/old"  # noqa: SLF001
+    )
+    new_token = "new.header.signature"
+    client._text = AsyncMock(  # noqa: SLF001
+        return_value=(
+            '<iframe src="/app/activation_ui/?token='
+            f'{new_token}&amp;siteid=3381244"></iframe>'
+        )
+    )
+    client._json = AsyncMock(  # noqa: SLF001
+        side_effect=[rejection, {"activation": "available"}]
+    )
+
+    assert await client.async_get_activation_record() == {"activation": "available"}
+
+    assert client._json.await_count == 2  # type: ignore[attr-defined]
+    first_headers = client._json.await_args_list[0].kwargs[  # type: ignore[attr-defined]
+        "headers"
+    ]
+    second_headers = client._json.await_args_list[1].kwargs[  # type: ignore[attr-defined]
+        "headers"
+    ]
+    assert first_headers["Authorization"] == "Bearer old.header.signature"
+    assert second_headers["Authorization"] == f"Bearer {new_token}"
+    assert second_headers["Cookie"] == (
+        f"session=current; enlighten_manager_token_production={new_token}"
+    )
+    client._text.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+async def test_activation_auth_bootstrap_soft_fails_when_settings_unavailable() -> None:
+    client = _make_api_client()
+    client._text = AsyncMock(side_effect=Unauthorized())  # noqa: SLF001
+
+    assert await client.async_prepare_activation_auth() is False
+    assert (
+        client._activation_headers()["Authorization"] == "Bearer TOKEN"
+    )  # noqa: SLF001
+
+
 async def test_activation_api_helpers_use_cloud_payloads() -> None:
     client = _make_api_client()
     calls: list[tuple[str, str, dict[str, Any]]] = []
@@ -272,6 +408,7 @@ async def test_activation_api_validates_response_shapes() -> None:
 
 class _FakeGridProfileClient:
     def __init__(self) -> None:
+        self.activation_auth_prepare_requests = 0
         self.profile_requests: list[tuple[str, str, bool]] = []
         self.apply_requests: list[dict[str, object]] = []
         self.reference_payload: dict[str, object] = {
@@ -367,6 +504,10 @@ class _FakeGridProfileClient:
         self.reference_requests = 0
         self.activation_record_requests = 0
         self.activation_device_requests = 0
+
+    async def async_prepare_activation_auth(self) -> bool:
+        self.activation_auth_prepare_requests += 1
+        return True
 
     async def async_get_activation_reference_data(self) -> dict[str, object]:
         self.reference_requests += 1
@@ -468,6 +609,7 @@ async def test_runtime_scopes_regions_profiles_and_applies_exact_payload() -> No
     assert runtime.country_code == "AU"
     assert runtime.site_region_code == "VIC"
     assert runtime.region_options == ["VIC, AU - Victoria"]
+    assert client.activation_auth_prepare_requests >= 1
     assert runtime.filtered_regions("Wellington") == []
     assert [region.region_code for region in runtime.filtered_regions("VIC")] == ["VIC"]
     assert client.profile_requests == [("AU", "VIC", True)]


### PR DESCRIPTION
## Summary

Fix Grid Profile access for accounts that can use the feature in Enlighten.

The integration previously reused the general Enlighten token for Activation API calls, while the working Enlighten UI bootstraps a short-lived Activation JWT from the authenticated system Settings page and sends it consistently as bearer, Manager cookie, and referer context. This change mirrors that authentication flow, retries once after a rejected cached Activation JWT, and preserves the existing stored-token fallback when bootstrap is unavailable.

Grid Profile remains an optional installer capability. Access failures continue to appear in endpoint diagnostics and backoff state, but no longer mark the overall Enphase site service as degraded.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/api.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/grid_profile_runtime.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py tests/components/enphase_ev/test_grid_profile_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/grid_profile_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log"
```

Results: 3,797 tests passed. Targeted coverage for all touched Python modules is 100%.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. No translation changes were required.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The authenticated Settings-page iframe capture confirmed the Activation JWT, synchronized Manager cookie, and exact referer request shape. Raw tokens, cookies, site IDs, and gateway identifiers are not included in this PR.
