### PR TITLE
Add capability-gated PowerMatch cloud control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- None
+- Add capability-gated PowerMatch cloud control for supported IQ Battery sites
 
 ### 🐛 Bug fixes
 - None

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
 - Optional IQ Battery Scheduler controls and CFG, DTG, and RBD schedule sensors
+- Capability-gated PowerMatch cloud control for supported IQ Battery sites with permitted BatteryConfig write access
 - Optional current site weather on the Enphase Cloud device, created only when the authenticated Enphase weather endpoint is available
 - Independent Microinverter Lifetime Energy and optional installer-level power telemetry
 - Site tariff visibility, editable rate entities, and tariff update actions

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -24,7 +24,7 @@ from http import HTTPStatus
 from time import monotonic
 from urllib.parse import unquote, urlencode
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, Awaitable, Callable, Iterable, cast
 
@@ -3710,6 +3710,7 @@ class EnphaseEVClient:
                 "dtgControl",
                 "cfgControl",
                 "rbdControl",
+                "powerMatchControl",
                 "evseStormEnabled",
                 "devices",
             }
@@ -3877,6 +3878,7 @@ class EnphaseEVClient:
         endpoint_family: str | None = None,
         write_intent: str = "generic",
         supports_mqtt: bool | None = None,
+        strip_devices: bool = False,
     ) -> JsonDict:
         """Issue a BatteryConfig write using endpoint-specific compatibility attempts."""
 
@@ -3888,6 +3890,8 @@ class EnphaseEVClient:
             params=params,
             json_body=json_body,
         )
+        if strip_devices:
+            attempts = [replace(attempt, strip_devices=True) for attempt in attempts]
         last_error: aiohttp.ClientResponseError | None = None
         seen_signatures: set[str] = set()
 
@@ -6024,6 +6028,7 @@ class EnphaseEVClient:
             endpoint_family="battery_settings",
             write_intent="battery_settings_update",
             supports_mqtt=self._battery_config_supports_mqtt,
+            strip_devices=strip_devices,
         )
 
     async def set_battery_profile(

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1000,33 +1000,52 @@ class BatteryRuntime:
         return max(0, min(100, int(value)))
 
     def _parse_battery_control_capability(
-        self, raw_control: object
+        self,
+        raw_control: object,
+        *,
+        fallback: BatteryControlCapability | None = None,
     ) -> BatteryControlCapability | None:
         if not isinstance(raw_control, dict):
             return None
+
+        def _field(raw_key: str, field_name: str) -> bool | None:
+            if raw_key in raw_control:
+                return self._coerce_optional_bool(raw_control.get(raw_key))
+            if fallback is None:
+                return None
+            fallback_value = getattr(fallback, field_name)
+            return fallback_value if isinstance(fallback_value, bool) else None
+
         return BatteryControlCapability(
-            show=self._coerce_optional_bool(raw_control.get("show")),
-            enabled=self._coerce_optional_bool(raw_control.get("enabled")),
-            locked=self._coerce_optional_bool(raw_control.get("locked")),
-            show_day_schedule=self._coerce_optional_bool(
-                raw_control.get("showDaySchedule")
+            show=_field("show", "show"),
+            enabled=_field("enabled", "enabled"),
+            locked=_field("locked", "locked"),
+            show_day_schedule=_field("showDaySchedule", "show_day_schedule"),
+            schedule_supported=_field("scheduleSupported", "schedule_supported"),
+            force_schedule_supported=_field(
+                "forceScheduleSupported", "force_schedule_supported"
             ),
-            schedule_supported=self._coerce_optional_bool(
-                raw_control.get("scheduleSupported")
-            ),
-            force_schedule_supported=self._coerce_optional_bool(
-                raw_control.get("forceScheduleSupported")
-            ),
-            force_schedule_opted=self._coerce_optional_bool(
-                raw_control.get("forceScheduleOpted")
-            ),
+            force_schedule_opted=_field("forceScheduleOpted", "force_schedule_opted"),
         )
 
     def _apply_battery_control_state(
-        self, attr_name: str, raw_control: object
+        self,
+        attr_name: str,
+        raw_control: object,
+        *,
+        preserve_missing: bool = False,
     ) -> BatteryControlCapability | None:
         state = self.battery_state
-        control = self._parse_battery_control_capability(raw_control)
+        previous = getattr(state, attr_name, None)
+        fallback = (
+            previous
+            if preserve_missing and isinstance(previous, BatteryControlCapability)
+            else None
+        )
+        control = self._parse_battery_control_capability(
+            raw_control,
+            fallback=fallback,
+        )
         setattr(state, attr_name, control)
         if attr_name == "_battery_cfg_control":
             if control is None:
@@ -1089,6 +1108,12 @@ class BatteryRuntime:
         if "rbdControl" in data or clear_missing_controls:
             self._apply_battery_control_state(
                 "_battery_rbd_control", data.get("rbdControl")
+            )
+        if "powerMatchControl" in data or clear_missing_controls:
+            self._apply_battery_control_state(
+                "_battery_power_match_control",
+                data.get("powerMatchControl"),
+                preserve_missing=not clear_missing_controls,
             )
         if "systemTask" in data:
             state._battery_system_task = self._coerce_optional_bool(
@@ -2302,6 +2327,7 @@ class BatteryRuntime:
         include_source: bool = True,
         merged_payload: bool = False,
         strip_devices: bool = False,
+        request_refresh: bool = True,
     ) -> None:
         coord = self.coordinator
         state = self.battery_state
@@ -2347,7 +2373,8 @@ class BatteryRuntime:
         self.set_cfg_settings_pending_from_payload(payload)
         state._battery_settings_cache_until = None
         coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
-        await coord.async_request_refresh()
+        if request_refresh:
+            await coord.async_request_refresh()
 
     def _profile_recovery_reserve_nudge(self, profile: str, reserve: int) -> int | None:
         normalized_profile = self.normalize_battery_profile_key(profile)
@@ -3631,7 +3658,7 @@ class BatteryRuntime:
         )
         coord._note_endpoint_family_success(family)
 
-    async def async_refresh_battery_settings(self, *, force: bool = False) -> None:
+    async def async_refresh_battery_settings(self, *, force: bool = False) -> bool:
         coord = self.coordinator
         state = self.battery_state
         now = time.monotonic()
@@ -3639,20 +3666,20 @@ class BatteryRuntime:
         pending_profile = getattr(state, "_battery_pending_profile", None)
         if not force and not pending_profile and state._battery_settings_cache_until:
             if now < state._battery_settings_cache_until:
-                return
+                return True
         if not coord._endpoint_family_should_run(
             family,
             force=force or bool(pending_profile),
         ):
-            return
+            return False
         fetcher = getattr(coord.client, "battery_settings_details", None)
         if not callable(fetcher):
-            return
+            return False
         try:
             payload = await fetcher()
         except Exception as err:  # noqa: BLE001
             coord._note_endpoint_family_failure(family, err)
-            return
+            return False
         redacted_payload = coord.redact_battery_payload(payload)
         if isinstance(redacted_payload, dict):
             state._battery_settings_payload = redacted_payload
@@ -3669,6 +3696,7 @@ class BatteryRuntime:
         )
         state._battery_settings_cache_until = now + success_ttl
         coord._note_endpoint_family_success(family, success_ttl_s=success_ttl)
+        return True
 
     async def async_refresh_battery_schedules(self, *, force: bool = False) -> None:
         coord = self.coordinator
@@ -4337,6 +4365,62 @@ class BatteryRuntime:
         self._raise_validation(
             "charge_from_grid_toggle_not_applied",
             message="Charge from grid toggle was not applied by Enphase.",
+        )
+
+    async def async_set_power_match(self, enabled: bool) -> None:
+        coord = self.coordinator
+        state = self.battery_state
+        refreshed = await self.async_refresh_battery_settings(force=True)
+        if not refreshed:
+            self._raise_validation(
+                "power_match_unavailable",
+                message="PowerMatch setting is unavailable.",
+            )
+        self._assert_battery_settings_feature_writable(
+            "PowerMatch setting is unavailable.",
+            unavailable_key="power_match_unavailable",
+        )
+        if not coord.power_match_control_available:
+            self._raise_validation(
+                "power_match_unavailable",
+                message="PowerMatch setting is unavailable.",
+            )
+        await self.async_assert_battery_settings_write_allowed()
+        target = bool(enabled)
+        if coord.battery_power_match_enabled is target:
+            coord.publish_runtime_state_update("power_match")
+            return
+        previous_control = state._battery_power_match_control
+
+        await self.async_apply_battery_settings_compat(
+            {"powerMatchControl": {"enabled": target}},
+            merged_payload=True,
+            strip_devices=True,
+            request_refresh=False,
+        )
+
+        authoritative_refresh_observed = False
+        for attempt in range(4):
+            refreshed = await self.async_refresh_battery_settings(force=True)
+            authoritative_refresh_observed |= refreshed
+            if (
+                refreshed
+                and coord.power_match_control_available
+                and coord.battery_power_match_enabled is target
+            ):
+                self.clear_battery_settings_write_pending()
+                coord.publish_runtime_state_update("power_match")
+                return
+            if attempt < 3:
+                await asyncio.sleep(0.75)
+
+        if not authoritative_refresh_observed:
+            state._battery_power_match_control = previous_control
+        self.clear_battery_settings_write_pending()
+        coord.publish_runtime_state_update("power_match")
+        self._raise_validation(
+            "power_match_toggle_not_applied",
+            message="PowerMatch toggle was not applied by Enphase.",
         )
 
     async def async_set_charge_from_grid_schedule_enabled(self, enabled: bool) -> None:

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -7042,6 +7042,23 @@ class EnphaseCoordinator(
         return begin is not None and end is not None
 
     @property
+    def power_match_control_available(self) -> bool:
+        if getattr(self, "_battery_has_encharge", None) is False:
+            return False
+        if self.battery_system_task is True:
+            return False
+        control = getattr(self, "_battery_power_match_control", None)
+        if not isinstance(control, BatteryControlCapability):
+            return False
+        if control.show is not True or control.enabled is None:
+            return False
+        if control.locked is True:
+            return False
+        owner = self.battery_user_is_owner
+        installer = self.battery_user_is_installer
+        return not (owner is False and installer is False)
+
+    @property
     def battery_charge_from_grid_enabled(self) -> bool | None:
         return getattr(self, "_battery_charge_from_grid", None)
 
@@ -7910,6 +7927,16 @@ class EnphaseCoordinator(
         return self._battery_control_to_dict(value)
 
     @property
+    def battery_power_match_control(self) -> dict[str, bool | None] | None:
+        value = getattr(self, "_battery_power_match_control", None)
+        return self._battery_control_to_dict(value)
+
+    @property
+    def battery_power_match_enabled(self) -> bool | None:
+        value = getattr(self, "_battery_power_match_control", None)
+        return self._battery_control_field(value, "enabled")
+
+    @property
     def battery_cfg_control_show(self) -> bool | None:
         value = getattr(self, "_battery_cfg_control", None)
         field = self._battery_control_field(value, "show")
@@ -8645,6 +8672,9 @@ class EnphaseCoordinator(
 
     async def async_set_charge_from_grid(self, enabled: bool) -> None:
         await self.battery_runtime.async_set_charge_from_grid(enabled)
+
+    async def async_set_power_match(self, enabled: bool) -> None:
+        await self.battery_runtime.async_set_power_match(enabled)
 
     async def async_set_charge_from_grid_schedule_enabled(self, enabled: bool) -> None:
         await self.battery_runtime.async_set_charge_from_grid_schedule_enabled(enabled)

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -562,6 +562,7 @@ class CoordinatorDiagnostics:
             "charge_from_grid_control_available": (
                 coord.charge_from_grid_control_available
             ),
+            "power_match_control_available": coord.power_match_control_available,
             "charge_from_grid_schedule_supported": (
                 coord.charge_from_grid_schedule_supported
             ),
@@ -773,6 +774,7 @@ class CoordinatorDiagnostics:
             "battery_dtg_control": coord.battery_dtg_control,
             "battery_cfg_control": coord.battery_cfg_control,
             "battery_rbd_control": coord.battery_rbd_control,
+            "battery_power_match_control": coord.battery_power_match_control,
             "battery_system_task": coord.battery_system_task,
             "battery_grid_mode": getattr(coord, "_battery_grid_mode", None),
             "battery_mode_display": coord.battery_mode_display,

--- a/custom_components/enphase_ev/icons.json
+++ b/custom_components/enphase_ev/icons.json
@@ -818,6 +818,9 @@
       },
       "storm_guard_evse_charge": {
         "default": "mdi:battery-charging-100"
+      },
+      "power_match": {
+        "default": "mdi:sine-wave"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -399,6 +399,7 @@ class BatteryState:
     _battery_cfg_control_force_schedule_supported: bool | None = None
     _battery_cfg_control: BatteryControlCapability | None = None
     _battery_rbd_control: BatteryControlCapability | None = None
+    _battery_power_match_control: BatteryControlCapability | None = None
     _battery_system_task: bool | None = None
     _battery_profile_evse_device: PayloadMap | None = None
     _battery_use_battery_for_self_consumption: bool | None = None

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -238,6 +238,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Charge from grid toggle was not applied by Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch setting is unavailable."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch toggle was not applied by Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Charge from grid schedule is unavailable."
     },
@@ -2239,6 +2245,9 @@
       },
       "charge_from_grid": {
         "name": "Charge Battery From Grid"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Charge From Grid Schedule"

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -251,6 +251,17 @@ def _charge_from_grid_schedule_retained(coord: EnphaseCoordinator) -> bool:
     return force_supported is not False
 
 
+def _power_match_retained(coord: EnphaseCoordinator) -> bool:
+    control = getattr(coord, "battery_power_match_control", None)
+    if not isinstance(control, dict):
+        return False
+    return (
+        control.get("show") is True
+        and isinstance(control.get("enabled"), bool)
+        and control.get("locked") is not True
+    )
+
+
 def _retained_site_switch_keys(
     coord: EnphaseCoordinator, entry: EnphaseConfigEntry | None = None
 ) -> set[str]:
@@ -270,6 +281,8 @@ def _retained_site_switch_keys(
             retained.add("savings_use_battery_after_peak")
         if _charge_from_grid_retained(coord):
             retained.add("charge_from_grid")
+        if _power_match_retained(coord):
+            retained.add("power_match")
         if _charge_from_grid_schedule_retained(coord):
             retained.add("charge_from_grid_schedule")
         if getattr(coord, "discharge_to_grid_schedule_available", None) is not False:
@@ -342,6 +355,17 @@ async def async_setup_entry(
         inventory_ready = bool(getattr(coord, "_devices_inventory_ready", False))
         site_entities: list[SwitchEntity] = []
         retain_site_entity_keys = _retained_site_switch_keys(coord, entry)
+        power_match_unique_id = f"{DOMAIN}_site_{coord.site_id}_power_match"
+        registered_power_match_entity_id = ent_reg.async_get_entity_id(
+            "switch", DOMAIN, power_match_unique_id
+        )
+        if (
+            isinstance(registered_power_match_entity_id, str)
+            and registered_power_match_entity_id
+            and _site_has_battery(coord)
+            and _type_available(coord, "encharge")
+        ):
+            retain_site_entity_keys.add("power_match")
         if (
             "storm_guard" in retain_site_entity_keys
             and "storm_guard" not in site_entity_keys
@@ -363,6 +387,12 @@ async def async_setup_entry(
             ):
                 site_entities.append(ChargeFromGridSwitch(coord))
                 site_entity_keys.add("charge_from_grid")
+            if (
+                "power_match" in retain_site_entity_keys
+                and "power_match" not in site_entity_keys
+            ):
+                site_entities.append(PowerMatchSwitch(coord))
+                site_entity_keys.add("power_match")
             if (
                 "charge_from_grid_schedule" in retain_site_entity_keys
                 and "charge_from_grid_schedule" not in site_entity_keys
@@ -412,6 +442,7 @@ async def async_setup_entry(
                     "storm_guard",
                     "savings_use_battery_after_peak",
                     "charge_from_grid",
+                    "power_match",
                     "charge_from_grid_schedule",
                     "discharge_to_grid_schedule",
                     "restrict_battery_discharge_schedule",
@@ -423,6 +454,7 @@ async def async_setup_entry(
                 {
                     "savings_use_battery_after_peak",
                     "charge_from_grid",
+                    "power_match",
                     "charge_from_grid_schedule",
                     "discharge_to_grid_schedule",
                     "restrict_battery_discharge_schedule",
@@ -447,6 +479,7 @@ async def async_setup_entry(
                 f"{DOMAIN}_site_{coord.site_id}_storm_guard",
                 f"{DOMAIN}_site_{coord.site_id}_savings_use_battery_after_peak",
                 f"{DOMAIN}_site_{coord.site_id}_charge_from_grid",
+                f"{DOMAIN}_site_{coord.site_id}_power_match",
                 f"{DOMAIN}_site_{coord.site_id}_charge_from_grid_schedule",
                 f"{DOMAIN}_site_{coord.site_id}_discharge_to_grid_schedule",
                 f"{DOMAIN}_site_{coord.site_id}_restrict_battery_discharge_schedule",
@@ -714,6 +747,50 @@ class ChargeFromGridSwitch(CoordinatorEntity, SwitchEntity):  # type: ignore[mis
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self._coord.async_set_charge_from_grid(False)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = _type_device_info(self._coord, "encharge")
+        if info is not None:
+            return info
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"type:{self._coord.site_id}:encharge")},
+            manufacturer="Enphase",
+        )
+
+
+class PowerMatchSwitch(CoordinatorEntity, SwitchEntity):  # type: ignore[misc]
+    _attr_has_entity_name = True
+    _attr_translation_key = "power_match"
+
+    def __init__(self, coord: EnphaseCoordinator) -> None:
+        super().__init__(coord)
+        self._coord = coord
+        self._attr_unique_id = f"{DOMAIN}_site_{coord.site_id}_power_match"
+
+    @property
+    def available(self) -> bool:
+        if not super().available:
+            return False
+        return (
+            _type_available(self._coord, "encharge")
+            and not _battery_write_access_explicitly_denied(self._coord)
+            and self._coord.power_match_control_available
+        )
+
+    @property
+    def is_on(self) -> bool:
+        return self._coord.battery_power_match_enabled is True
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        return battery_schedule_extra_state_attributes(self._coord)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self._coord.async_set_power_match(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self._coord.async_set_power_match(False)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Зареждането от превключване на мрежата не е приложено от Enphase."
     },
+    "power_match_unavailable": {
+      "message": "Настройката PowerMatch не е налична."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Превключването на PowerMatch не беше приложено от Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Таксуването от графика на мрежата не е налично."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Зареждане на батерията от мрежата"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "График за зареждане от мрежата"

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Enphase nepoužilo nabíjení z přepínače mřížky."
     },
+    "power_match_unavailable": {
+      "message": "Nastavení PowerMatch není k dispozici."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Přepnutí PowerMatch nebylo společností Enphase použito."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Poplatek ze sítě není k dispozici."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Nabíjet baterii ze sítě"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Plán nabíjení ze sítě"

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Charge from grid toggle blev ikke anvendt af Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch-indstillingen er ikke tilgængelig."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch-skiftet blev ikke anvendt af Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Opkrævning fra netplan er ikke tilgængelig."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Oplad batteri fra elnet"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Tidsplan for opladning fra elnet"

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Die Ladung durch Netzumschaltung wurde von Enphase nicht angewendet."
     },
+    "power_match_unavailable": {
+      "message": "Die PowerMatch-Einstellung ist nicht verfügbar."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Die PowerMatch-Umschaltung wurde von Enphase nicht angewendet."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Der Zeitplan für die Ladung aus dem Netz ist nicht verfügbar."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Batterie aus dem Netz laden"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Zeitplan für Laden aus dem Netz"

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Η εναλλαγή φόρτισης από το δίκτυο δεν εφαρμόστηκε από το Enphase."
     },
+    "power_match_unavailable": {
+      "message": "Η ρύθμιση PowerMatch δεν είναι διαθέσιμη."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Η εναλλαγή του PowerMatch δεν εφαρμόστηκε από την Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Το χρονοδιάγραμμα φόρτισης από το δίκτυο δεν είναι διαθέσιμο."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Φόρτιση μπαταρίας από το δίκτυο"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Πρόγραμμα φόρτισης από το δίκτυο"

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Charge from grid toggle was not applied by Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch setting is unavailable."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch toggle was not applied by Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Charge from grid schedule is unavailable."
     },
@@ -2239,6 +2245,9 @@
       },
       "charge_from_grid": {
         "name": "Charge Battery From Grid"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Charge From Grid Schedule"

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Charge from grid toggle was not applied by Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch setting is unavailable."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch toggle was not applied by Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Charge from grid schedule is unavailable."
     },
@@ -2239,6 +2245,9 @@
       },
       "charge_from_grid": {
         "name": "Charge Battery From Grid"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Charge From Grid Schedule"

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Charge from grid toggle was not applied by Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch setting is unavailable."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch toggle was not applied by Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Charge from grid schedule is unavailable."
     },
@@ -2239,6 +2245,9 @@
       },
       "charge_from_grid": {
         "name": "Charge Battery From Grid"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Charge From Grid Schedule"

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Charge from grid toggle was not applied by Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch setting is unavailable."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch toggle was not applied by Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Charge from grid schedule is unavailable."
     },
@@ -2239,6 +2245,9 @@
       },
       "charge_from_grid": {
         "name": "Charge Battery From Grid"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Charge From Grid Schedule"

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Charge from grid toggle was not applied by Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch setting is unavailable."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch toggle was not applied by Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Charge from grid schedule is unavailable."
     },
@@ -2239,6 +2245,9 @@
       },
       "charge_from_grid": {
         "name": "Charge Battery From Grid"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Charge From Grid Schedule"

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Charge from grid toggle was not applied by Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch setting is unavailable."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch toggle was not applied by Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Charge from grid schedule is unavailable."
     },
@@ -2239,6 +2245,9 @@
       },
       "charge_from_grid": {
         "name": "Charge Battery From Grid"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Charge From Grid Schedule"

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Enphase no aplicó el conmutador de carga desde la red."
     },
+    "power_match_unavailable": {
+      "message": "La configuración de PowerMatch no está disponible."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Enphase no aplicó el cambio de PowerMatch."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "El horario de carga desde la red no está disponible."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Cargar batería desde la red"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Horario de carga desde la red"

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Enphase ei rakendanud võrgust laadimise lülitit."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatchi seade pole saadaval."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Enphase ei rakendanud PowerMatchi lülitust."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Võrgust laadimise ajakava pole saadaval."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Laadi akut võrgust"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Võrgust laadimise ajakava"

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Enphase ei ottanut verkosta lataamisen kytkintä käyttöön."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch-asetus ei ole käytettävissä."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Enphase ei ottanut PowerMatch-kytkentää käyttöön."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Verkosta lataamisen aikataulu ei ole käytettävissä."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Lataa akkua sähköverkosta"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Sähköverkkolatauksen aikataulu"

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "L’activation ou la désactivation de la charge depuis le réseau n’a pas été appliquée par Enphase."
     },
+    "power_match_unavailable": {
+      "message": "Le réglage PowerMatch n’est pas disponible."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "La modification de PowerMatch n’a pas été appliquée par Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Le planning de charge depuis le réseau n’est pas disponible."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Recharger la batterie depuis le réseau"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Programme de recharge depuis le réseau"

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Az Enphase nem alkalmazta a hálózatról töltés kapcsolóállapotát."
     },
+    "power_match_unavailable": {
+      "message": "A PowerMatch beállítás nem érhető el."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Az Enphase nem alkalmazta a PowerMatch kapcsolását."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "A hálózatról töltési ütemezés nem érhető el."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Akkumulátor töltése hálózatról"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Hálózatról töltés ütemezése"

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Enphase non ha applicato l'attivazione o disattivazione della ricarica dalla rete."
     },
+    "power_match_unavailable": {
+      "message": "L'impostazione PowerMatch non è disponibile."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "L'attivazione di PowerMatch non è stata applicata da Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "La pianificazione di ricarica dalla rete non è disponibile."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Carica batteria dalla rete"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Programma carica da rete"

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Enphase nepritaikė įkrovimo iš tinklo perjungimo."
     },
+    "power_match_unavailable": {
+      "message": "„PowerMatch“ nustatymas nepasiekiamas."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "„Enphase“ nepritaikė „PowerMatch“ perjungimo."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Įkrovimo iš tinklo tvarkaraštis nepasiekiamas."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Įkrauti bateriją iš tinklo"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Įkrovimo iš tinklo tvarkaraštis"

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Enphase nepiemēroja uzlādes no tīkla slēdzi."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch iestatījums nav pieejams."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Enphase nepiemēroja PowerMatch pārslēgšanu."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Uzlādes no tīkla grafiks nav pieejams."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Uzlādēt akumulatoru no tīkla"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Uzlādes no tīkla grafiks"

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Bryteren for lading fra nettet ble ikke brukt av Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch-innstillingen er ikke tilgjengelig."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch-bryteren ble ikke aktivert av Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Planen for lading fra nettet er ikke tilgjengelig."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Lad batteri fra strømnettet"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Tidsplan for lading fra strømnettet"

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "De schakelaar Laden vanaf het net is niet toegepast door Enphase."
     },
+    "power_match_unavailable": {
+      "message": "De PowerMatch-instelling is niet beschikbaar."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "De PowerMatch-schakeling is niet toegepast door Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Het laden-vanaf-het-net-schema is niet beschikbaar."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Batterij laden vanaf net"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Laadschema vanaf net"

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Przełącznik ładowania z sieci nie został zastosowany przez Enphase."
     },
+    "power_match_unavailable": {
+      "message": "Ustawienie PowerMatch jest niedostępne."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Przełączenie PowerMatch nie zostało zastosowane przez Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Harmonogram ładowania z sieci jest niedostępny."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Ładowanie baterii z sieci"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Harmonogram ładowania z sieci"

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "A cobrança da alternância de rede não foi aplicada pela Enphase."
     },
+    "power_match_unavailable": {
+      "message": "A configuração do PowerMatch não está disponível."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "A alteração do PowerMatch não foi aplicada pela Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "A cobrança da programação da rede não está disponível."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Carregar bateria da rede"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Agenda de carga da rede"

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Încărcarea de la comutatorul de rețea nu a fost aplicată de Enphase."
     },
+    "power_match_unavailable": {
+      "message": "Setarea PowerMatch nu este disponibilă."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "Comutarea PowerMatch nu a fost aplicată de Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Încărcarea din programul rețelei nu este disponibilă."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Încarcă bateria din rețea"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Program de încărcare din rețea"

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -235,6 +235,12 @@
     "charge_from_grid_toggle_not_applied": {
       "message": "Charge from grid toggle applicerades inte av Enphase."
     },
+    "power_match_unavailable": {
+      "message": "PowerMatch-inställningen är inte tillgänglig."
+    },
+    "power_match_toggle_not_applied": {
+      "message": "PowerMatch-växlingen tillämpades inte av Enphase."
+    },
     "charge_from_grid_schedule_unavailable": {
       "message": "Debitering från nätschema är inte tillgänglig."
     },
@@ -2245,6 +2251,9 @@
       },
       "charge_from_grid": {
         "name": "Ladda batteriet från nätet"
+      },
+      "power_match": {
+        "name": "PowerMatch"
       },
       "charge_from_grid_schedule": {
         "name": "Schema för laddning från nätet"

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -6012,6 +6012,11 @@ Example response:
       "locked": false,
       "scheduleSupported": true
     },
+    "powerMatchControl": {
+      "show": true,
+      "enabled": false,
+      "locked": false
+    },
     "evseStormEnabled": false,
     "isIQGWScheduleSupported": true,
     "appTutorialUrl": "<tutorial_id>",
@@ -6268,6 +6273,15 @@ Example payloads observed:
 ```json
 { "rbdControl": { "enabled": false } }
 ```
+
+```json
+{ "powerMatchControl": { "enabled": true } }
+```
+
+PowerMatch implementation notes:
+- The runtime treats `batterySettings.data.powerMatchControl` as the sole capability and state source. The switch is offered only when `show=true`, `enabled` is Boolean, and `locked` is not `true`.
+- PowerMatch writes merge `powerMatchControl.enabled` into the latest allowlisted BatteryConfig settings payload so other control fields and unrelated settings are preserved.
+- The separate `/app-api/<site_id>/powermatch_details` route remains unused because captured evidence establishes only UI visibility/state flags, not writable backend semantics.
 
 ```json
 {

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -5637,6 +5637,12 @@ def test_battery_config_write_payload_helpers_cover_merge_and_base_fallbacks() -
         {
             "data": {
                 "dtgControl": {"enabled": False, "startTime": "00:00"},
+                "powerMatchControl": {
+                    "show": True,
+                    "enabled": False,
+                    "locked": False,
+                    "futureField": {"value": 1},
+                },
                 "devices": {"iqEvse": {"enabled": True}},
                 "ignored": 1,
             }
@@ -5644,6 +5650,12 @@ def test_battery_config_write_payload_helpers_cover_merge_and_base_fallbacks() -
     )
     assert client._battery_config_write_bases["battery_settings"] == {  # noqa: SLF001
         "dtgControl": {"enabled": False, "startTime": "00:00"},
+        "powerMatchControl": {
+            "show": True,
+            "enabled": False,
+            "locked": False,
+            "futureField": {"value": 1},
+        },
         "devices": {"iqEvse": {"enabled": True}},
     }
 
@@ -5657,9 +5669,19 @@ def test_battery_config_write_payload_helpers_cover_merge_and_base_fallbacks() -
     }
     assert client._battery_config_merged_write_payload(  # noqa: SLF001
         "battery_settings",
-        {"dtgControl": {"enabled": True}, "chargeFromGrid": True},
+        {
+            "dtgControl": {"enabled": True},
+            "powerMatchControl": {"enabled": True},
+            "chargeFromGrid": True,
+        },
     ) == {
         "dtgControl": {"enabled": True, "startTime": "00:00"},
+        "powerMatchControl": {
+            "show": True,
+            "enabled": True,
+            "locked": False,
+            "futureField": {"value": 1},
+        },
         "devices": {"iqEvse": {"enabled": True}},
         "chargeFromGrid": True,
     }
@@ -5679,6 +5701,12 @@ def test_battery_config_write_payload_helpers_cover_merge_and_base_fallbacks() -
         attempt,
     ) == {
         "dtgControl": {"enabled": True, "startTime": "00:00"},
+        "powerMatchControl": {
+            "show": True,
+            "enabled": False,
+            "locked": False,
+            "futureField": {"value": 1},
+        },
         "devices": {"iqEvse": {"enabled": True}},
     }
     assert (  # noqa: SLF001
@@ -6955,6 +6983,49 @@ async def test_set_battery_settings_compat_builds_merged_payload_without_devices
         "chargeFromGrid": True
     }
     assert client._battery_config_write_request.await_args.kwargs["params"] == {}
+    assert (
+        client._battery_config_write_request.await_args.kwargs["strip_devices"] is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_strips_devices_from_stateful_attempt() -> (
+    None
+):
+    client = _make_client()
+    client._remember_battery_config_write_base(  # noqa: SLF001
+        "battery_settings",
+        {
+            "data": {
+                "powerMatchControl": {"show": True, "enabled": False},
+                "devices": {"iqEvse": {"enabled": True}},
+            }
+        },
+    )
+    client._battery_config_write_attempts = MagicMock(  # noqa: SLF001
+        return_value=[
+            api._BatteryConfigWriteAttempt(  # noqa: SLF001
+                attempt_id="stateful",
+                auth_mode=api._BATTERY_CONFIG_VARIANT_PRIMARY,  # noqa: SLF001
+                merged_payload=True,
+            )
+        ]
+    )
+    client._acquire_xsrf_token = AsyncMock(return_value="token")  # noqa: SLF001
+    client._battery_config_attempt_headers = MagicMock(return_value={})  # noqa: SLF001
+    client._json = AsyncMock(return_value={"message": "success"})  # noqa: SLF001
+
+    await client._battery_config_write_request(  # noqa: SLF001
+        "PUT",
+        "https://example.test/batterySettings/SITE",
+        json_body={"powerMatchControl": {"enabled": True}},
+        endpoint_family="battery_settings",
+        write_intent="battery_settings_update",
+        strip_devices=True,
+    )
+
+    sent = client._json.await_args.kwargs["json"]  # noqa: SLF001
+    assert sent == {"powerMatchControl": {"show": True, "enabled": True}}
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -69,6 +69,10 @@ def test_parse_battery_settings_payload_maps_mode_and_controls(
                     "enabled": True,
                     "locked": False,
                 },
+                "powerMatchControl": {
+                    "show": True,
+                    "enabled": "true",
+                },
                 "devices": {
                     "iqEvse": {
                         "useBatteryFrSelfConsumption": True,
@@ -122,8 +126,82 @@ def test_parse_battery_settings_payload_maps_mode_and_controls(
         "force_schedule_supported": None,
         "force_schedule_opted": None,
     }
+    assert coord.battery_power_match_control == {
+        "show": True,
+        "enabled": True,
+        "locked": None,
+        "show_day_schedule": None,
+        "schedule_supported": None,
+        "force_schedule_supported": None,
+        "force_schedule_opted": None,
+    }
+    assert coord.battery_power_match_enabled is True
+    assert coord.power_match_control_available is True
     assert coord.battery_system_task is False
     assert coord.battery_use_battery_for_self_consumption is True
+
+
+def test_power_match_capability_requires_authoritative_usable_control(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+
+    runtime.parse_battery_settings_payload(
+        {"data": {"powerMatchControl": {"show": True, "enabled": False}}},
+        clear_missing_controls=True,
+    )
+    assert coord.battery_power_match_enabled is False
+    assert coord.power_match_control_available is True
+
+    runtime.parse_battery_settings_payload({"data": {"chargeFromGrid": True}})
+    assert coord.battery_power_match_enabled is False
+
+    runtime.parse_battery_settings_payload(
+        {"data": {"powerMatchControl": {"enabled": True}}}
+    )
+    assert coord.battery_power_match_enabled is True
+    assert coord.battery_power_match_control["show"] is True
+    assert coord.power_match_control_available is True
+
+    runtime.parse_battery_settings_payload(
+        {"data": {"powerMatchControl": {"show": False, "enabled": True}}},
+        clear_missing_controls=True,
+    )
+    assert coord.power_match_control_available is False
+
+    runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "powerMatchControl": {"show": True, "enabled": True, "locked": True}
+            }
+        },
+        clear_missing_controls=True,
+    )
+    assert coord.power_match_control_available is False
+
+    runtime.parse_battery_settings_payload(
+        {"data": {"powerMatchControl": {"show": True, "enabled": "unknown"}}},
+        clear_missing_controls=True,
+    )
+    assert coord.battery_power_match_enabled is None
+    assert coord.power_match_control_available is False
+
+    runtime.parse_battery_settings_payload(
+        {"data": {"powerMatchControl": 42}}, clear_missing_controls=True
+    )
+    assert coord.battery_power_match_control is None
+
+    runtime.parse_battery_settings_payload(
+        {"data": {"powerMatchControl": {"show": True, "enabled": True}}},
+        clear_missing_controls=True,
+    )
+    runtime.parse_battery_settings_payload(
+        {"data": {"chargeFromGrid": False}}, clear_missing_controls=True
+    )
+    assert coord.battery_power_match_control is None
 
 
 def test_dtg_and_rbd_control_enabled_are_distinct_from_schedule_enabled(
@@ -975,6 +1053,190 @@ async def test_set_charge_from_grid_disable_omits_disclaimer(
     coord.client.accept_battery_settings_disclaimer.assert_not_awaited()
     coord.client.validate_battery_schedule.assert_awaited_once_with("cfg")
     coord.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_set_power_match_uses_fresh_merged_settings_and_confirms(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.client.battery_settings_details = AsyncMock(
+        side_effect=[
+            {
+                "data": {
+                    "powerMatchControl": {"show": True, "enabled": False},
+                    "systemTask": False,
+                }
+            },
+            {
+                "data": {
+                    "powerMatchControl": {"show": True, "enabled": True},
+                    "systemTask": False,
+                }
+            },
+        ]
+    )
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.publish_runtime_state_update = MagicMock()
+
+    await coord.battery_runtime.async_set_power_match(True)
+
+    coord.client.set_battery_settings_compat.assert_awaited_once_with(
+        {"powerMatchControl": {"enabled": True}},
+        schedule_type="cfg",
+        include_source=True,
+        merged_payload=True,
+        strip_devices=True,
+    )
+    assert coord.client.battery_settings_details.await_count == 2
+    assert coord.battery_power_match_enabled is True
+    assert coord.battery_settings_write_pending is False
+    coord.async_request_refresh.assert_not_awaited()
+    coord.publish_runtime_state_update.assert_called_once_with("power_match")
+
+
+@pytest.mark.asyncio
+async def test_set_power_match_noops_when_fresh_state_matches(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = None  # noqa: SLF001
+    coord._battery_user_is_installer = None  # noqa: SLF001
+    coord.client.battery_settings_details = AsyncMock(
+        return_value={
+            "data": {
+                "powerMatchControl": {"show": True, "enabled": True},
+                "systemTask": False,
+            }
+        }
+    )
+    coord.client.battery_site_settings = AsyncMock(
+        return_value={"data": {"userDetails": {"isOwner": True, "isInstaller": False}}}
+    )
+    coord.client.set_battery_settings_compat = AsyncMock()
+    coord.publish_runtime_state_update = MagicMock()
+
+    await coord.battery_runtime.async_set_power_match(True)
+
+    coord.client.battery_site_settings.assert_awaited_once_with()
+    assert coord.battery_write_access_confirmed is True
+    coord.client.set_battery_settings_compat.assert_not_awaited()
+    coord.publish_runtime_state_update.assert_called_once_with("power_match")
+
+
+@pytest.mark.asyncio
+async def test_set_power_match_rejects_failed_or_unusable_preflight(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord.client.battery_settings_details = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with pytest.raises(ServiceValidationError, match="PowerMatch setting"):
+        await coord.battery_runtime.async_set_power_match(True)
+
+    coord.client.battery_settings_details = AsyncMock(
+        return_value={"data": {"powerMatchControl": {"show": False, "enabled": False}}}
+    )
+    with pytest.raises(ServiceValidationError, match="PowerMatch setting"):
+        await coord.battery_runtime.async_set_power_match(True)
+
+
+@pytest.mark.asyncio
+async def test_set_power_match_rejects_unconfirmed_server_state(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    stale = {
+        "data": {
+            "powerMatchControl": {"show": True, "enabled": False},
+            "systemTask": False,
+        }
+    }
+    coord.client.battery_settings_details = AsyncMock(return_value=stale)
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.publish_runtime_state_update = MagicMock()
+    sleep = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_runtime.asyncio.sleep", sleep
+    )
+
+    with pytest.raises(ServiceValidationError, match="was not applied"):
+        await coord.battery_runtime.async_set_power_match(True)
+
+    assert coord.client.battery_settings_details.await_count == 5
+    assert sleep.await_count == 3
+    assert coord.battery_power_match_enabled is False
+    assert coord.battery_settings_write_pending is False
+    coord.publish_runtime_state_update.assert_called_once_with("power_match")
+
+
+@pytest.mark.asyncio
+async def test_set_power_match_restores_authoritative_state_when_confirmation_fails(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord.client.battery_settings_details = AsyncMock(
+        side_effect=[
+            {
+                "data": {
+                    "powerMatchControl": {
+                        "show": True,
+                        "enabled": False,
+                        "locked": False,
+                    },
+                    "systemTask": False,
+                }
+            },
+            RuntimeError("confirmation unavailable"),
+            RuntimeError("confirmation unavailable"),
+            RuntimeError("confirmation unavailable"),
+            RuntimeError("confirmation unavailable"),
+        ]
+    )
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.publish_runtime_state_update = MagicMock()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_runtime.asyncio.sleep", AsyncMock()
+    )
+
+    with pytest.raises(ServiceValidationError, match="was not applied"):
+        await coord.battery_runtime.async_set_power_match(True)
+
+    assert coord.battery_power_match_enabled is False
+    assert coord.battery_power_match_control == {
+        "show": True,
+        "enabled": False,
+        "locked": False,
+        "show_day_schedule": None,
+        "schedule_supported": None,
+        "force_schedule_supported": None,
+        "force_schedule_opted": None,
+    }
+    assert coord.battery_settings_write_pending is False
+    coord.async_request_refresh.assert_not_awaited()
+    coord.publish_runtime_state_update.assert_called_once_with("power_match")
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -159,6 +159,7 @@ async def test_coordinator_public_runtime_commands_delegate(
     coord = coordinator_factory()
     battery_runtime = MagicMock()
     battery_runtime.async_set_charge_from_grid = AsyncMock()
+    battery_runtime.async_set_power_match = AsyncMock()
     battery_runtime.async_refresh_grid_control_check = AsyncMock()
     battery_runtime.async_refresh_storm_guard_profile = AsyncMock()
     battery_runtime.async_refresh_storm_alert = AsyncMock()
@@ -175,6 +176,7 @@ async def test_coordinator_public_runtime_commands_delegate(
     coord.inventory_runtime = inventory_runtime
 
     await coord.async_set_charge_from_grid(True)
+    await coord.async_set_power_match(False)
     await coord.battery_runtime.async_refresh_grid_control_check(force=True)
     await coord.async_refresh_storm_guard_profile(force=True)
     await coord.async_refresh_storm_alert(force=False)
@@ -188,6 +190,7 @@ async def test_coordinator_public_runtime_commands_delegate(
     await coord.async_ensure_system_dashboard_diagnostics()
 
     battery_runtime.async_set_charge_from_grid.assert_awaited_once_with(True)
+    battery_runtime.async_set_power_match.assert_awaited_once_with(False)
     battery_runtime.async_refresh_grid_control_check.assert_awaited_once_with(
         force=True
     )

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -306,6 +306,16 @@ class DummyCoordinator(SimpleNamespace):
             "force_schedule_supported": None,
             "force_schedule_opted": None,
         }
+        self.battery_power_match_control = {
+            "show": True,
+            "enabled": False,
+            "locked": False,
+            "show_day_schedule": None,
+            "schedule_supported": None,
+            "force_schedule_supported": None,
+            "force_schedule_opted": None,
+        }
+        self.power_match_control_available = True
         self.battery_system_task = False
         self._grid_control_check_payload = {
             "disableGridControl": False,
@@ -627,6 +637,8 @@ class DummyCoordinator(SimpleNamespace):
             "battery_dtg_control": self.battery_dtg_control,
             "battery_cfg_control": self.battery_cfg_control,
             "battery_rbd_control": self.battery_rbd_control,
+            "battery_power_match_control": self.battery_power_match_control,
+            "power_match_control_available": self.power_match_control_available,
             "battery_system_task": self.battery_system_task,
         }
 
@@ -895,6 +907,11 @@ async def test_config_entry_diagnostics_includes_coordinator(
         == 1
     )
     assert diag["coordinator"]["site_metrics"]["battery_cfg_control"]["locked"] is False
+    assert (
+        diag["coordinator"]["site_metrics"]["battery_power_match_control"]
+        == coord.battery_power_match_control
+    )
+    assert diag["coordinator"]["site_metrics"]["power_match_control_available"] is True
     assert diag["coordinator"]["site_metrics"]["battery_dtg_control"]["locked"] is True
     assert diag["coordinator"]["site_metrics"]["battery_system_task"] is False
     assert (

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -45,6 +45,8 @@ def _intentional_identical_translation(
 
     if path == "config.step.user.title" and value == "Enphase Energy":
         return True
+    if path == "entity.switch.power_match.name" and value == "PowerMatch":
+        return True
     if (
         locale == "fr"
         and value == "Notifications"
@@ -864,7 +866,10 @@ def test_battery_settings_entity_strings_exist_for_all_locales() -> None:
         "entity.sensor.battery_overall_status.state.unknown",
         "entity.number.battery_shutdown_level.name",
         "entity.switch.charge_from_grid.name",
+        "entity.switch.power_match.name",
         "entity.switch.charge_from_grid_schedule.name",
+        "exceptions.power_match_unavailable.message",
+        "exceptions.power_match_toggle_not_applied.message",
         "entity.time.charge_from_grid_start_time.name",
         "entity.time.charge_from_grid_end_time.name",
         "entity.calendar.backup_history.name",
@@ -875,6 +880,18 @@ def test_battery_settings_entity_strings_exist_for_all_locales() -> None:
         for path in paths:
             value = _at_path(data, path)
             assert value.strip(), f"{locale.name} missing value for {path}"
+
+    en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
+    exception_paths = [
+        "exceptions.power_match_unavailable.message",
+        "exceptions.power_match_toggle_not_applied.message",
+    ]
+    for locale in translations_dir.glob("*.json"):
+        if locale.name == "en.json" or locale.name.startswith("en-"):
+            continue
+        data = json.loads(locale.read_text(encoding="utf-8"))
+        for path in exception_paths:
+            assert _at_path(data, path) != _at_path(en_data, path)
 
 
 def test_tariff_entity_strings_exist_for_all_locales() -> None:

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -39,6 +39,7 @@ from custom_components.enphase_ev.switch import (
     DischargeToGridScheduleSwitch,
     EvseScheduleEditorDaySwitch,
     GreenBatterySwitch,
+    PowerMatchSwitch,
     RestrictBatteryDischargeScheduleSwitch,
     SavingsUseBatteryAfterPeakSwitch,
     StormGuardEvseSwitch,
@@ -618,6 +619,11 @@ async def test_async_setup_entry_keeps_cfg_switches_while_permission_unknown(
     coord._storm_evse_enabled = None  # noqa: SLF001
     coord._battery_charge_from_grid = True  # noqa: SLF001
     coord._battery_charge_from_grid_schedule_enabled = True  # noqa: SLF001
+    coord._battery_power_match_control = (  # noqa: SLF001
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": True, "enabled": False}
+        )
+    )
     coord._battery_charge_begin_time = 120  # noqa: SLF001
     coord._battery_charge_end_time = 300  # noqa: SLF001
     listener_callbacks = []
@@ -682,6 +688,11 @@ async def test_async_setup_entry_adds_supported_battery_site_switches_and_prunes
     coord._battery_charge_begin_time = 120  # noqa: SLF001
     coord._battery_charge_end_time = 300  # noqa: SLF001
     coord._battery_charge_from_grid_schedule_enabled = True  # noqa: SLF001
+    coord._battery_power_match_control = (  # noqa: SLF001
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": True, "enabled": False}
+        )
+    )
     coord._battery_dtg_control = (
         coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
             {"show": True, "showDaySchedule": True, "scheduleSupported": True}
@@ -725,6 +736,7 @@ async def test_async_setup_entry_adds_supported_battery_site_switches_and_prunes
 
     assert any(isinstance(entity, StormGuardSwitch) for entity in added)
     assert any(isinstance(entity, SavingsUseBatteryAfterPeakSwitch) for entity in added)
+    assert any(isinstance(entity, PowerMatchSwitch) for entity in added)
     assert any(isinstance(entity, DischargeToGridScheduleSwitch) for entity in added)
     assert any(
         isinstance(entity, RestrictBatteryDischargeScheduleSwitch) for entity in added
@@ -743,6 +755,7 @@ async def test_async_setup_entry_adds_supported_battery_site_switches_and_prunes
         not in active_unique_ids
     )
     assert f"enphase_ev_site_{coord.site_id}_charge_from_grid" not in active_unique_ids
+    assert f"enphase_ev_site_{coord.site_id}_power_match" not in active_unique_ids
 
 
 @pytest.mark.asyncio
@@ -755,6 +768,11 @@ async def test_async_setup_entry_keeps_loaded_site_switches_when_support_disprov
     coord._battery_user_is_owner = None  # noqa: SLF001
     coord._battery_user_is_installer = None  # noqa: SLF001
     coord._battery_show_storm_guard = True  # noqa: SLF001
+    coord._battery_power_match_control = (  # noqa: SLF001
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": True, "enabled": False}
+        )
+    )
     listener_callbacks = []
     original_add_listener = coord.async_add_listener
 
@@ -779,6 +797,7 @@ async def test_async_setup_entry_keeps_loaded_site_switches_when_support_disprov
     assert any(isinstance(entity, StormGuardSwitch) for entity in added)
     assert any(isinstance(entity, ChargeFromGridSwitch) for entity in added)
     assert any(isinstance(entity, ChargeFromGridScheduleSwitch) for entity in added)
+    assert any(isinstance(entity, PowerMatchSwitch) for entity in added)
 
     prune_spy.reset_mock()
     coord._battery_show_storm_guard = False  # noqa: SLF001
@@ -791,16 +810,21 @@ async def test_async_setup_entry_keeps_loaded_site_switches_when_support_disprov
             }
         )
     )
+    coord._battery_power_match_control = (  # noqa: SLF001
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": False, "enabled": False}
+        )
+    )
     listener_callbacks[0]()
 
     active_unique_ids = prune_spy.call_args_list[0].kwargs["active_unique_ids"]
     assert f"enphase_ev_site_{coord.site_id}_storm_guard" in active_unique_ids
     assert f"enphase_ev_site_{coord.site_id}_charge_from_grid" in active_unique_ids
+    assert f"enphase_ev_site_{coord.site_id}_power_match" in active_unique_ids
     assert (
         f"enphase_ev_site_{coord.site_id}_charge_from_grid_schedule"
         in active_unique_ids
     )
-
     added.clear()
     prune_spy.reset_mock()
     coord._battery_show_storm_guard = True  # noqa: SLF001
@@ -818,13 +842,54 @@ async def test_async_setup_entry_keeps_loaded_site_switches_when_support_disprov
     assert not any(isinstance(entity, StormGuardSwitch) for entity in added)
     assert not any(isinstance(entity, ChargeFromGridSwitch) for entity in added)
     assert not any(isinstance(entity, ChargeFromGridScheduleSwitch) for entity in added)
+    assert not any(isinstance(entity, PowerMatchSwitch) for entity in added)
     active_unique_ids = prune_spy.call_args_list[0].kwargs["active_unique_ids"]
     assert f"enphase_ev_site_{coord.site_id}_storm_guard" in active_unique_ids
     assert f"enphase_ev_site_{coord.site_id}_charge_from_grid" in active_unique_ids
+    assert f"enphase_ev_site_{coord.site_id}_power_match" in active_unique_ids
     assert (
         f"enphase_ev_site_{coord.site_id}_charge_from_grid_schedule"
         in active_unique_ids
     )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_retains_registered_power_match_while_unknown(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = None  # noqa: SLF001
+    coord._battery_user_is_installer = None  # noqa: SLF001
+    coord._battery_power_match_control = None  # noqa: SLF001
+    coord.inventory_view.has_type_for_entities = lambda type_key: type_key == "encharge"
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    ent_reg = er.async_get(hass)
+    unique_id = f"enphase_ev_site_{coord.site_id}_power_match"
+    registered = ent_reg.async_get_or_create(
+        "switch",
+        "enphase_ev",
+        unique_id,
+        config_entry=config_entry,
+    )
+    remove_spy = MagicMock(wraps=ent_reg.async_remove)
+    monkeypatch.setattr(ent_reg, "async_remove", remove_spy)
+    added = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    power_match = next(
+        entity for entity in added if isinstance(entity, PowerMatchSwitch)
+    )
+    assert power_match.available is False
+    assert ent_reg.async_get(registered.entity_id) is not None
+    remove_spy.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -2064,6 +2129,56 @@ def test_charge_from_grid_switch_exposes_schedule_attributes(
     assert attrs == {"write_pending": False, "write_age_seconds": None}
 
 
+def test_power_match_switch_availability_and_state(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._battery_power_match_control = (  # noqa: SLF001
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": True, "enabled": False}
+        )
+    )
+    switch = PowerMatchSwitch(coord)
+
+    assert switch.unique_id == f"enphase_ev_site_{coord.site_id}_power_match"
+    assert switch.available is True
+    assert switch.is_on is False
+    assert switch.extra_state_attributes == {
+        "write_pending": False,
+        "write_age_seconds": None,
+    }
+
+    coord._battery_system_task = True  # noqa: SLF001
+    assert switch.available is False
+    coord._battery_system_task = False  # noqa: SLF001
+
+    coord._battery_power_match_control = (  # noqa: SLF001
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": True, "enabled": True, "locked": True}
+        )
+    )
+    assert switch.is_on is True
+    assert switch.available is False
+
+    coord._battery_power_match_control = None  # noqa: SLF001
+    assert switch.is_on is False
+    assert switch.available is False
+
+
+@pytest.mark.asyncio
+async def test_power_match_switch_turn_on_off(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.async_set_power_match = AsyncMock()
+    switch = PowerMatchSwitch(coord)
+
+    await switch.async_turn_on()
+    coord.async_set_power_match.assert_awaited_once_with(True)
+
+    await switch.async_turn_off()
+    coord.async_set_power_match.assert_awaited_with(False)
+
+
 @pytest.mark.asyncio
 async def test_charge_from_grid_switch_turn_on_off(coordinator_factory) -> None:
     coord = coordinator_factory()
@@ -2436,6 +2551,9 @@ def test_site_switch_device_info_fallbacks(coordinator_factory) -> None:
     assert ChargeFromGridSwitch(coord).device_info["identifiers"] == {
         ("enphase_ev", f"type:{coord.site_id}:encharge")
     }
+    assert PowerMatchSwitch(coord).device_info["identifiers"] == {
+        ("enphase_ev", f"type:{coord.site_id}:encharge")
+    }
     assert ChargeFromGridScheduleSwitch(coord).device_info["identifiers"] == {
         ("enphase_ev", f"type:{coord.site_id}:encharge")
     }
@@ -2453,12 +2571,14 @@ def test_site_switch_device_info_prefers_type_info_and_storm_guard_envoy_gate(
             expected_encharge,
             expected_encharge,
             expected_encharge,
+            expected_encharge,
         ]
     )
 
     assert StormGuardSwitch(coord).device_info is expected_envoy
     assert SavingsUseBatteryAfterPeakSwitch(coord).device_info is expected_encharge
     assert ChargeFromGridSwitch(coord).device_info is expected_encharge
+    assert PowerMatchSwitch(coord).device_info is expected_encharge
     assert ChargeFromGridScheduleSwitch(coord).device_info is expected_encharge
 
     coord.inventory_view.type_device_info = lambda _type_key: None
@@ -2483,6 +2603,7 @@ def test_charge_from_grid_switches_unavailable_when_coordinator_unavailable(
 
     assert ChargeFromGridSwitch(coord).available is False
     assert ChargeFromGridScheduleSwitch(coord).available is False
+    assert PowerMatchSwitch(coord).available is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Add a capability-gated Home Assistant switch for Enphase PowerMatch using the existing cloud BatteryConfig API.

The switch is created only when an authoritative battery-settings response advertises a visible, unlocked `powerMatchControl` block with a Boolean state. Writes preserve the latest allowlisted server settings, omit `devices`, use the existing compatibility/authentication paths, and require authoritative confirmation before completing.

This also adds normalized diagnostics, localized strings, documentation, API notes, and regression coverage for parsing, write safety, confirmation, and entity lifecycle behavior.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [x] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/state_models.py custom_components/enphase_ev/switch.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_service_translations.py tests/components/enphase_ev/test_switch_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/state_models.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/switch.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

- Translation tests: 43 passed
- Enphase integration suite: 3,807 passed
- Full repository suite: 3,939 passed
- Targeted coverage: 100% across all touched Python modules
- Manual Home Assistant runtime verification: the configured IQ Battery site did not advertise PowerMatch, and no switch was created, confirming capability gating

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

PowerMatch remains cloud-only and does not use Envoy-local APIs or the ambiguous `/powermatch_details` UI-flags endpoint.
