### PR TITLE
Confirm pending battery profiles from live state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to this project will be documented in this file.
 - Add capability-gated PowerMatch cloud control for supported IQ Battery sites
 
 ### 🐛 Bug fixes
-- None
+- Confirmed pending IQ Battery profile changes when either the configured profile
+  or live hardware profile matches, preventing false long-running repair issues
+  when Enlighten leaves the configured profile stale. (#799)
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -528,6 +528,21 @@ class BatteryRuntime:
         if not self._pending_requires_authoritative_confirmation():
             return True
         state = self.battery_state
+        pending_profile = getattr(state, "_battery_pending_profile", None)
+        pending_requested_at = getattr(state, "_battery_pending_requested_at", None)
+        live_sample_utc = getattr(state, "_battery_live_profile_sample_utc", None)
+        if (
+            pending_profile
+            and getattr(state, "_battery_live_profile", None) == pending_profile
+            and isinstance(pending_requested_at, datetime)
+            and isinstance(live_sample_utc, datetime)
+            and pending_requested_at.tzinfo is not None
+            and live_sample_utc.tzinfo is not None
+            and live_sample_utc >= pending_requested_at
+        ):
+            return True
+        if getattr(state, "_battery_profile", None) != pending_profile:
+            return False
         pending_requested_mono = getattr(state, "_battery_pending_requested_mono", None)
         authoritative_seen_mono = getattr(
             state, "_battery_profile_authoritative_seen_mono", None
@@ -898,10 +913,9 @@ class BatteryRuntime:
         pending_profile = getattr(state, "_battery_pending_profile", None)
         if not pending_profile:
             return False
-        effective_profile = getattr(state, "_battery_profile", None)
-        if effective_profile is None:
-            effective_profile = getattr(state, "_battery_live_profile", None)
-        if effective_profile != pending_profile:
+        configured_profile = getattr(state, "_battery_profile", None)
+        live_profile = getattr(state, "_battery_live_profile", None)
+        if pending_profile not in (configured_profile, live_profile):
             return False
         if not getattr(state, "_battery_pending_require_exact_settings", True):
             return True

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -86,12 +86,15 @@ def test_battery_runtime_optimistic_profile_guard_branches(
     assert runtime._profile_authoritative_read_is_fresh() is False  # noqa: SLF001
 
     coord._battery_pending_authoritative_confirmation_required = True  # noqa: SLF001
+    coord._battery_pending_profile = "backup_only"  # noqa: SLF001
+    coord._battery_profile = "backup_only"  # noqa: SLF001
     coord._battery_pending_requested_mono = BadSeen()  # noqa: SLF001
     coord._battery_profile_authoritative_seen_mono = time.monotonic()  # noqa: SLF001
     assert (  # noqa: SLF001
         runtime._pending_authoritative_confirmation_received() is False
     )
     coord._battery_pending_authoritative_confirmation_required = False  # noqa: SLF001
+    coord._battery_pending_profile = None  # noqa: SLF001
 
     runtime.set_battery_optimistic_profile("backup_only", 100, None)
     runtime._note_authoritative_profile_read("backup_only")  # noqa: SLF001
@@ -605,6 +608,64 @@ def test_backend_pending_false_clears_when_effective_state_matches(
 
     assert coord.battery_profile_pending is False
     assert coord._battery_backend_profile_update_pending is None  # noqa: SLF001
+
+
+def test_fresh_live_profile_sample_clears_pending_with_stale_configured_profile(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    runtime.set_battery_pending(
+        profile="backup_only",
+        reserve=100,
+        sub_type=None,
+        require_exact_settings=False,
+    )
+
+    runtime.parse_battery_status_payload(
+        {
+            "storages": [
+                {
+                    "id": "123",
+                    "battery_mode": "Full Backup",
+                    "current_charge": "75%",
+                }
+            ]
+        }
+    )
+
+    assert coord.battery_profile_pending is False
+    assert coord.battery_profile == "backup_only"
+    assert coord._battery_backend_profile_update_pending is None  # noqa: SLF001
+
+
+def test_stale_live_profile_sample_does_not_confirm_pending(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    runtime.set_battery_pending(
+        profile="backup_only",
+        reserve=100,
+        sub_type=None,
+        require_exact_settings=False,
+    )
+    requested_at = coord._battery_pending_requested_at  # noqa: SLF001
+    assert requested_at is not None
+    coord._battery_live_profile = "backup_only"  # noqa: SLF001
+    coord._battery_live_profile_sample_utc = requested_at - timedelta(  # noqa: SLF001
+        seconds=1
+    )
+    coord._battery_profile_authoritative_seen_mono = (  # noqa: SLF001
+        coord._battery_pending_requested_mono + 1
+    )
+
+    runtime.sync_backend_battery_profile_pending(False)
+
+    assert coord.battery_profile_pending is True
+    assert coord._battery_backend_profile_update_pending is False  # noqa: SLF001
 
 
 def test_backend_pending_false_keeps_pending_when_age_unavailable(

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -1450,6 +1450,7 @@ def test_battery_status_payload_tracks_live_profile_without_clearing_pending(
     coord._battery_pending_profile = "backup_only"  # noqa: SLF001
     coord._battery_pending_reserve = 100  # noqa: SLF001
     coord._battery_pending_require_exact_settings = False  # noqa: SLF001
+    coord._battery_pending_authoritative_confirmation_required = True  # noqa: SLF001
 
     coord.battery_runtime.parse_battery_status_payload(
         {
@@ -1511,7 +1512,7 @@ def test_battery_status_payload_clears_pending_when_no_profile_endpoint_value(
     assert coord.battery_effective_profile == "backup_only"
 
 
-def test_configured_profile_confirms_pending_with_stale_live_profile(
+def test_either_configured_or_live_profile_confirms_pending(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -1526,7 +1527,7 @@ def test_configured_profile_confirms_pending_with_stale_live_profile(
 
     coord._battery_profile = "backup_only"  # noqa: SLF001
     coord._battery_live_profile = "self-consumption"  # noqa: SLF001
-    assert coord._effective_profile_matches_pending() is False  # noqa: SLF001
+    assert coord._effective_profile_matches_pending() is True  # noqa: SLF001
 
 
 def test_configured_profile_wins_over_stale_live_profile(


### PR DESCRIPTION
## Summary

- Accept a fresh live IQ Battery profile as authoritative confirmation of a pending profile write when Enlighten's configured profile remains stale.
- Require the live sample to be at or after the pending request so cached live state cannot confirm a new write.
- Add regression coverage for both fresh and stale live samples while preserving configured-profile confirmation safeguards.

Fixes #799.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_coordinator_battery_profile.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc "git config --global --add safe.directory /workspace && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

- Integration suite: 3,809 passed.
- Full suite: 3,941 passed.
- Targeted `battery_runtime.py` coverage: 100%.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation changes are not required for this bug fix.
- [x] Translations are not affected.
- [x] I ran targeted coverage for the touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The regression tests model a stale configured profile alongside both fresh and stale live hardware-profile samples. No diagnostics or screenshots are required.
