### PR TITLE
Isolate HEMS authentication repair context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 - Confirmed pending IQ Battery profile changes when either the configured profile
   or live hardware profile matches, preventing false long-running repair issues
   when Enlighten leaves the configured profile stale. (#799)
+- Kept optional HEMS authentication diagnostics out of unrelated repair issues,
+  preventing battery and other repairs from presenting irrelevant HEMS failures.
+  (#799)
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -96,6 +96,28 @@ class CoordinatorDiagnostics:
         for issue_id in _DEGRADED_SERVICE_REPAIR_ISSUE_IDS:
             self._delete_issue(issue_id)
 
+    @staticmethod
+    def _repair_issue_metrics(
+        issue_id: str, metrics: dict[str, object]
+    ) -> dict[str, object]:
+        """Return diagnostic context relevant to a specific repair issue."""
+
+        if issue_id == ISSUE_HEMS_AUTH_DEGRADED:
+            return metrics
+        filtered = {
+            key: value
+            for key, value in metrics.items()
+            if not key.startswith("hems_auth_")
+        }
+        if filtered.get("last_error") == "hems_auth_degraded":
+            filtered.pop("last_error")
+        degraded_services = filtered.get("degraded_services")
+        if isinstance(degraded_services, list):
+            filtered["degraded_services"] = [
+                service for service in degraded_services if service != "hems_auth"
+            ]
+        return filtered
+
     def _create_site_metrics_issue(
         self,
         issue_id: str,
@@ -105,7 +127,8 @@ class CoordinatorDiagnostics:
     ) -> None:
         coord = self.coordinator
         registry_issue_id = self._repair_issue_id(issue_id)
-        metrics, base_placeholders = self.issue_context()
+        metrics = self._repair_issue_metrics(issue_id, self.collect_site_metrics())
+        base_placeholders = self.issue_translation_placeholders(metrics)
         # Repair issues store the current diagnostic snapshot so users can share
         # actionable context without enabling debug logging first.
         issue_placeholders = dict(base_placeholders)

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -4689,6 +4689,10 @@ def test_hems_auth_circuit_is_coordinator_backed(
     first_issue = mock_issue_registry.created[-1]
     assert first_issue[1] == "hems_auth_degraded"
     assert first_issue[2]["translation_placeholders"]["failure_count"] == "1"
+    issue_metrics = first_issue[2]["data"]["site_metrics"]
+    assert issue_metrics["hems_auth_failure_count"] == 1
+    assert issue_metrics["hems_auth_last_endpoint"] == "hems_devices"
+    assert "hems_auth" in issue_metrics["degraded_services"]
 
     assert coord._note_hems_auth_failure(  # noqa: SLF001
         coord_mod.Unauthorized(),

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -280,6 +280,17 @@ def test_pending_profile_timeout_issue_lifecycle(
     ) - timedelta(  # noqa: SLF001
         seconds=BATTERY_PROFILE_PENDING_TIMEOUT_S + 30
     )
+    coord._hems_auth_failure_count = 25  # noqa: SLF001
+    coord._hems_auth_last_endpoint = "hems_consumption_lifetime"  # noqa: SLF001
+    coord._hems_auth_last_status = 200  # noqa: SLF001
+    coord._hems_auth_last_reason = "login_wall"  # noqa: SLF001
+    coord._hems_auth_backoff_until = time.monotonic() + 3600  # noqa: SLF001
+    coord._hems_auth_backoff_ends_utc = datetime.now(
+        timezone.utc
+    ) + timedelta(  # noqa: SLF001
+        hours=1
+    )
+    coord._last_error = "hems_auth_degraded"  # noqa: SLF001
 
     coord._sync_battery_profile_pending_issue()  # noqa: SLF001
 
@@ -287,7 +298,14 @@ def test_pending_profile_timeout_issue_lifecycle(
     domain, issue_id, payload = mock_issue_registry.created[-1]
     assert domain == DOMAIN
     assert issue_id == ISSUE_BATTERY_PROFILE_PENDING
-    assert payload["translation_placeholders"]["pending_timeout_minutes"] == "15"
+    placeholders = payload["translation_placeholders"]
+    assert placeholders["pending_timeout_minutes"] == "15"
+    assert not {key for key in placeholders if key.startswith("hems_")}
+    assert {"failure_count", "reason"}.isdisjoint(placeholders)
+    metrics = payload["data"]["site_metrics"]
+    assert not {key for key in metrics if key.startswith("hems_auth_")}
+    assert metrics.get("last_error") != "hems_auth_degraded"
+    assert "hems_auth" not in metrics["degraded_services"]
 
     coord._battery_pending_requested_at = datetime.now(timezone.utc)  # noqa: SLF001
     coord._sync_battery_profile_pending_issue()  # noqa: SLF001


### PR DESCRIPTION
## Summary

- Filter HEMS authentication metrics and aliases out of unrelated repair issues.
- Preserve the full authentication context on the dedicated HEMS degraded repair.
- Add regression coverage for both the filtered battery repair and dedicated HEMS repair paths.

This fixes the remaining repair-context concern discussed in #799. The root cause was that every repair issue received the complete site diagnostic snapshot, allowing optional HEMS authentication failures to appear in unrelated battery and service repairs.

## Related Issues

- #799

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator_diagnostics.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_battery_profile.py"
task_git_common=$(git rev-parse --git-common-dir) && docker compose -f devtools/docker/docker-compose.yml run --rm -v "$task_git_common:$task_git_common" ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator_diagnostics.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

- Integration tests: 3,809 passed.
- Repository-wide tests: 3,941 passed.
- `coordinator_diagnostics.py`: 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed. (Not applicable; no documented behavior or options changed.)
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (Not applicable; no strings changed.)
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The dedicated `hems_auth_degraded` repair retains all HEMS authentication diagnostics. Other repairs omit `hems_auth_*` metrics, HEMS-derived generic placeholders, the HEMS degraded-service marker, and a HEMS-only `last_error`.
