### PR TITLE
Preserve ignored repair state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Kept optional HEMS authentication diagnostics out of unrelated repair issues,
   preventing battery and other repairs from presenting irrelevant HEMS failures.
   (#799)
+- Preserved ignored repair state when transient issues clear and recur. (#799)
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -62,8 +62,12 @@ class CoordinatorDiagnostics:
         if not self.degraded_service_repair_issues_enabled:
             self.clear_degraded_service_repair_issues()
 
-    def _delete_issue(self, issue_id: str) -> None:
+    def _delete_issue(self, issue_id: str, *, preserve_ignored: bool = False) -> None:
         coord = self.coordinator
+        if preserve_ignored:
+            issue = ir.async_get(coord.hass).async_get_issue(DOMAIN, issue_id)
+            if issue is not None and issue.dismissed_version is not None:
+                return
         ir.async_delete_issue(coord.hass, DOMAIN, issue_id)
 
     def _entry_issue_suffix(self) -> str | None:
@@ -84,11 +88,27 @@ class CoordinatorDiagnostics:
             return issue_id
         return f"{issue_id}_{suffix}"
 
-    def _delete_reported_issue(self, issue_id: str) -> None:
+    def _delete_reported_issue(
+        self, issue_id: str, *, preserve_ignored: bool = False
+    ) -> None:
         registry_issue_id = self._repair_issue_id(issue_id)
-        self._delete_issue(registry_issue_id)
+        self._delete_issue(
+            registry_issue_id,
+            preserve_ignored=preserve_ignored,
+        )
         if registry_issue_id != issue_id:
-            self._delete_issue(issue_id)
+            self._delete_issue(issue_id, preserve_ignored=preserve_ignored)
+
+    def _reported_issue_is_active(self, issue_id: str) -> bool:
+        registry_issue_id = self._repair_issue_id(issue_id)
+        issue_registry = ir.async_get(self.coordinator.hass)
+        issue = issue_registry.async_get_issue(DOMAIN, registry_issue_id)
+        if issue is not None and issue.active:
+            return True
+        if registry_issue_id == issue_id:
+            return False
+        legacy_issue = issue_registry.async_get_issue(DOMAIN, issue_id)
+        return legacy_issue is not None and legacy_issue.active
 
     def clear_legacy_degraded_service_repair_issues(self) -> None:
         """Clear pre-scoped degraded-service repair issues after upgrade."""
@@ -149,9 +169,11 @@ class CoordinatorDiagnostics:
 
     def _clear_reported_issue(self, flag_attr: str, issue_id: str) -> None:
         coord = self.coordinator
-        if not getattr(coord, flag_attr, False):
+        if not getattr(coord, flag_attr, False) and not self._reported_issue_is_active(
+            issue_id
+        ):
             return
-        self._delete_reported_issue(issue_id)
+        self._delete_reported_issue(issue_id, preserve_ignored=True)
         setattr(coord, flag_attr, False)
 
     @property

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2216,6 +2216,69 @@ async def test_http_error_issue(hass, monkeypatch):
     assert any(issue_id == ISSUE_CLOUD_ERRORS for _, issue_id in deleted)
 
 
+def test_ignored_battery_profile_issue_survives_clear_and_recurrence(
+    hass, monkeypatch
+) -> None:
+    from homeassistant.helpers import issue_registry as ir
+
+    from custom_components.enphase_ev.const import (
+        BATTERY_PROFILE_PENDING_TIMEOUT_S,
+        ISSUE_BATTERY_PROFILE_PENDING,
+    )
+    from custom_components.enphase_ev.coordinator_diagnostics import (
+        CoordinatorDiagnostics,
+    )
+
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._battery_pending_profile = "cost_savings"  # noqa: SLF001
+    coord._battery_pending_requested_at = datetime.now(
+        timezone.utc
+    ) - timedelta(  # noqa: SLF001
+        seconds=BATTERY_PROFILE_PENDING_TIMEOUT_S + 30
+    )
+
+    coord._sync_battery_profile_pending_issue()  # noqa: SLF001
+
+    issue_registry = ir.async_get(hass)
+    issue = issue_registry.async_get_issue(DOMAIN, ISSUE_BATTERY_PROFILE_PENDING)
+    assert issue is not None
+    ir.async_ignore_issue(hass, DOMAIN, ISSUE_BATTERY_PROFILE_PENDING, True)
+    ignored_version = issue_registry.async_get_issue(
+        DOMAIN, ISSUE_BATTERY_PROFILE_PENDING
+    ).dismissed_version
+    assert ignored_version is not None
+
+    coord._battery_pending_requested_at = datetime.now(timezone.utc)  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue()  # noqa: SLF001
+
+    preserved = issue_registry.async_get_issue(DOMAIN, ISSUE_BATTERY_PROFILE_PENDING)
+    assert preserved is not None
+    assert preserved.dismissed_version == ignored_version
+    assert coord._battery_profile_issue_reported is False  # noqa: SLF001
+
+    coord._battery_pending_requested_at = datetime.now(
+        timezone.utc
+    ) - timedelta(  # noqa: SLF001
+        seconds=BATTERY_PROFILE_PENDING_TIMEOUT_S + 30
+    )
+    coord._sync_battery_profile_pending_issue()  # noqa: SLF001
+    recurring = issue_registry.async_get_issue(DOMAIN, ISSUE_BATTERY_PROFILE_PENDING)
+    assert recurring is not None
+    assert recurring.dismissed_version == ignored_version
+    assert coord._battery_profile_issue_reported is True  # noqa: SLF001
+
+    coord._battery_pending_requested_at = datetime.now(timezone.utc)  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue()  # noqa: SLF001
+    assert coord._battery_profile_issue_reported is False  # noqa: SLF001
+
+    coord.diagnostics = CoordinatorDiagnostics(coord)
+    ir.async_ignore_issue(hass, DOMAIN, ISSUE_BATTERY_PROFILE_PENDING, False)
+    coord._sync_battery_profile_pending_issue()  # noqa: SLF001
+
+    assert issue_registry.async_get_issue(DOMAIN, ISSUE_BATTERY_PROFILE_PENDING) is None
+    assert coord._battery_profile_issue_reported is False  # noqa: SLF001
+
+
 @pytest.mark.asyncio
 async def test_network_issue_includes_metrics(hass, monkeypatch):
     from homeassistant.helpers.update_coordinator import UpdateFailed


### PR DESCRIPTION
## Summary

- Preserve Home Assistant's ignored state when a transient Enphase repair clears.
- Keep coordinator report flags aligned with the current condition while deriving retained repair state from the issue registry.
- Delete a resolved repair if the user later unignores it, including after coordinator diagnostics is reconstructed.
- Add regression coverage for clear, recurrence, reconstruction, unignore, and final cleanup.

The root cause was `_clear_reported_issue()` deleting the issue-registry entry that owns Home Assistant's `dismissed_version`. A later recurrence therefore created a fresh, unignored repair. The fix keeps ignored entries in the registry while the condition is clear and consults registry activity during cleanup instead of relying on process-local state.

Fixes #799.

## Related Issues

- #800
- #801

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator_diagnostics.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
task_git_common=$(git rev-parse --git-common-dir) && docker compose -f devtools/docker/docker-compose.yml run --rm -v "$task_git_common:$task_git_common" ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator_diagnostics.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

- Integration tests: 3,810 passed.
- Repository-wide tests: 3,942 passed.
- Service translation tests: 43 passed.
- `coordinator_diagnostics.py`: 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed. (Not applicable; no documented behavior or options changed.)
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (No strings changed; translation tests pass.)
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The regression test uses Home Assistant's real issue registry. It confirms that ignored repairs remain dismissed across clear and recurrence, report flags reset when the condition clears, and cleanup still works after `CoordinatorDiagnostics` is reconstructed.
