### PR TITLE
Fix delayed battery and microinverter entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v4.1.1 - 2026-07-29
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Refreshed per-battery charge, status, health, and cycle-count entities after
+  delayed battery warmup instead of retaining a cached unavailable snapshot.
+- Published delayed per-microinverter telemetry capability changes and reduced
+  paginated dashboard response sizes so power entities load and update reliably
+  without accepting a truncated first page as complete telemetry or discarding
+  completed device readings when another inverter is unresolved.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `4.1.1`.
+
 ## v4.1.0 - 2026-07-29
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -108,6 +108,11 @@ INVERTER_PARAMETER_ALIASES: dict[str, str] = {
 }
 INVERTER_PARAMETER_REQUEST_TIMEOUT_S = 15.0
 INVERTER_PARAMETER_BATCH_CONCURRENCY = 2
+INVERTER_PARAMETER_MIN_PAGE_SIZE = 50
+INVERTER_PARAMETER_MAX_PAGE_SIZE = 500
+INVERTER_PARAMETER_MAX_PAGES = (
+    INVERTER_PARAMETER_MAX_PAGE_SIZE // INVERTER_PARAMETER_MIN_PAGE_SIZE
+)
 
 
 @dataclass(frozen=True)
@@ -119,6 +124,16 @@ class CoordinatorTopologySnapshot:
     active_type_keys: tuple[str, ...]
     gateway_iq_router_keys: tuple[str, ...]
     inventory_ready: bool
+    inverter_telemetry_serials: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class InverterParameterFetchResult:
+    """Per-parameter readings plus the serials they can update authoritatively."""
+
+    readings: dict[str, tuple[object, object | None]]
+    authoritative_serials: frozenset[str]
+    error: Exception | None = None
 
 
 class InventoryRuntime:
@@ -681,6 +696,7 @@ class InventoryRuntime:
             "battery_count": len(snapshot.battery_serials),
             "ac_battery_count": len(snapshot.ac_battery_serials),
             "inverter_count": len(snapshot.inverter_serials),
+            "inverter_telemetry_count": len(snapshot.inverter_telemetry_serials),
             "active_type_keys": list(snapshot.active_type_keys),
             "gateway_iq_router_count": len(snapshot.gateway_iq_router_keys),
             "site_energy_channels": sorted(
@@ -801,18 +817,24 @@ class InventoryRuntime:
             for key in (self._router_record_key(record) for record in router_records)
             if key
         )
+        inverter_serials = tuple(self.iter_inverter_serials())
         return CoordinatorTopologySnapshot(
             charger_serials=tuple(self.iter_serials()),
             battery_serials=tuple(self.iter_battery_serials()),
             ac_battery_serials=tuple(
                 getattr(self.coordinator, "iter_ac_battery_serials", lambda: [])()
             ),
-            inverter_serials=tuple(self.iter_inverter_serials()),
+            inverter_serials=inverter_serials,
             active_type_keys=tuple(self.iter_type_keys()),
             gateway_iq_router_keys=router_keys,
             inventory_ready=bool(
                 getattr(self, "_devices_inventory_ready", False)
                 or getattr(self, "_hems_inventory_ready", False)
+            ),
+            inverter_telemetry_serials=tuple(
+                serial
+                for serial in inverter_serials
+                if bool((self.inverter_data(serial) or {}).get("telemetry"))
             ),
         )
 
@@ -3023,6 +3045,151 @@ class InventoryRuntime:
         )
 
     @staticmethod
+    def _inverter_parameter_has_more_pages(
+        payload: dict[str, object], current_page: int
+    ) -> bool | None:
+        """Return explicit paging state, or ``None`` when the payload omits it."""
+
+        metadata_records: list[Mapping[str, object]] = []
+        for key in ("pagination", "paging", "meta"):
+            metadata = payload.get(key)
+            if isinstance(metadata, dict):
+                metadata_records.append(metadata)
+        metadata_records.append(payload)
+
+        def _positive_int(value: object) -> int | None:
+            if isinstance(value, int) and not isinstance(value, bool):
+                return value if value > 0 else None
+            if isinstance(value, str) and value.strip().isdigit():
+                parsed = int(value.strip())
+                return parsed if parsed > 0 else None
+            return None
+
+        def _first_positive_int(
+            metadata: Mapping[str, object], keys: tuple[str, ...]
+        ) -> int | None:
+            for key in keys:
+                parsed = _positive_int(metadata.get(key))
+                if parsed is not None:
+                    return parsed
+            return None
+
+        for metadata in metadata_records:
+            for key in ("has_next", "has_next_page", "hasNext", "hasNextPage"):
+                has_next = metadata.get(key)
+                if isinstance(has_next, bool):
+                    return has_next
+            for key in ("next_page", "nextPage"):
+                if key not in metadata:
+                    continue
+                next_page = metadata.get(key)
+                if next_page in (None, False, ""):
+                    return False
+                parsed_next_page = _positive_int(next_page)
+                if parsed_next_page is not None:
+                    return parsed_next_page > current_page
+            for key in (
+                "total_pages",
+                "totalPages",
+                "last_page",
+                "lastPage",
+                "page_count",
+                "pageCount",
+            ):
+                total_pages = _positive_int(metadata.get(key))
+                if total_pages is not None:
+                    return current_page < total_pages
+            total = _first_positive_int(
+                metadata,
+                (
+                    "total",
+                    "total_count",
+                    "totalCount",
+                    "total_records",
+                    "totalRecords",
+                ),
+            )
+            per_page = _first_positive_int(
+                metadata,
+                ("per_page", "perPage", "page_size", "pageSize"),
+            )
+            response_page = _first_positive_int(
+                metadata,
+                ("page", "current_page", "currentPage"),
+            )
+            if total is not None and per_page is not None:
+                page = response_page or current_page
+                return page * per_page < total
+        return None
+
+    async def _async_fetch_complete_inverter_parameter(
+        self,
+        fetcher: Callable[..., Awaitable[object]],
+        serials: list[str],
+        parameter_id: str,
+        *,
+        per_page: int,
+    ) -> InverterParameterFetchResult:
+        """Fetch pages without discarding readings resolved before a failure."""
+
+        requested_serials = set(serials)
+        readings: dict[str, tuple[object, object | None]] = {}
+        deadline = time.monotonic() + INVERTER_PARAMETER_REQUEST_TIMEOUT_S
+        for page in range(1, INVERTER_PARAMETER_MAX_PAGES + 1):
+            try:
+                async with asyncio.timeout(max(0.0, deadline - time.monotonic())):
+                    payload = await fetcher(
+                        serials,
+                        parameter_id,
+                        per_page=per_page,
+                        page=page,
+                    )
+            except Exception as err:  # noqa: BLE001 - retain completed serials
+                if not readings:
+                    raise
+                return InverterParameterFetchResult(
+                    readings,
+                    frozenset(readings),
+                    err,
+                )
+            if not self._inverter_parameter_payload_is_valid(payload):
+                return InverterParameterFetchResult(
+                    readings,
+                    frozenset(readings),
+                    ValueError(
+                        f"Dashboard parameter response was invalid for {parameter_id}"
+                    ),
+                )
+            assert isinstance(payload, dict)
+            raw_rows = payload.get("intervals")
+            if not isinstance(raw_rows, list):
+                raw_rows = payload.get("data")
+            assert isinstance(raw_rows, list)
+            for serial, reading in self._inverter_parameter_rows(
+                payload, parameter_id
+            ).items():
+                if serial in requested_serials:
+                    # Pages are newest-first, so retain the first reading seen.
+                    readings.setdefault(serial, reading)
+            has_more_pages = self._inverter_parameter_has_more_pages(payload, page)
+            if (
+                requested_serials.issubset(readings)
+                or has_more_pages is False
+                or (has_more_pages is None and not raw_rows)
+            ):
+                return InverterParameterFetchResult(
+                    readings,
+                    frozenset(requested_serials),
+                )
+        return InverterParameterFetchResult(
+            readings,
+            frozenset(readings),
+            ValueError(
+                f"Dashboard parameter pagination limit reached for {parameter_id}"
+            ),
+        )
+
+    @staticmethod
     def _inverter_parameter_snapshot_has_values(snapshot: object) -> bool:
         """Return whether a telemetry snapshot contains at least one reading."""
 
@@ -3035,10 +3202,14 @@ class InventoryRuntime:
         cls,
         telemetry_by_serial: dict[str, dict[str, object]],
         canonical: str,
+        *,
+        serials: frozenset[str] | None = None,
     ) -> None:
         """Remove one canonical reading and its metadata from every inverter."""
 
         for serial, snapshot in list(telemetry_by_serial.items()):
+            if serials is not None and serial not in serials:
+                continue
             snapshot.pop(canonical, None)
             for metadata_key in ("parameter_ids", "sampled_at"):
                 metadata = snapshot.get(metadata_key)
@@ -3073,40 +3244,61 @@ class InventoryRuntime:
         telemetry_family = "inverter_parameter_telemetry"
         telemetry_health = coord._endpoint_family_state(telemetry_family)
         freshness_raw = getattr(self, "_inverter_parameter_success_mono", None)
-        freshness_items = (
-            freshness_raw.items() if isinstance(freshness_raw, dict) else ()
-        )
-        freshness_by_parameter = {
-            str(key): float(value)
-            for key, value in freshness_items
-            if isinstance(key, str) and isinstance(value, (int, float))
-        }
+        freshness_by_serial: dict[str, dict[str, float]] = {}
+        if isinstance(freshness_raw, dict):
+            for key, value in freshness_raw.items():
+                if isinstance(key, str) and isinstance(value, dict):
+                    parsed_freshness = {
+                        str(canonical): float(timestamp)
+                        for canonical, timestamp in value.items()
+                        if isinstance(canonical, str)
+                        and isinstance(timestamp, (int, float))
+                    }
+                    if key in cached_by_serial and parsed_freshness:
+                        freshness_by_serial[key] = parsed_freshness
+                    continue
+                # Accept the pre-4.1.1 parameter-wide shape during a live reload.
+                if isinstance(key, str) and isinstance(value, (int, float)):
+                    for serial, snapshot in cached_by_serial.items():
+                        if key in snapshot:
+                            freshness_by_serial.setdefault(serial, {})[key] = float(
+                                value
+                            )
         policy = coord._endpoint_family_policy(telemetry_family)
         stale_after_s = policy.stale_after_s if policy is not None else None
         now_mono = time.monotonic()
-        cached_canonicals = {
-            key
-            for snapshot in cached_by_serial.values()
-            for key in snapshot
-            if key not in {"parameter_ids", "sampled_at"}
+        cached_pairs = {
+            (serial, canonical)
+            for serial, snapshot in cached_by_serial.items()
+            for canonical in snapshot
+            if canonical not in {"parameter_ids", "sampled_at"}
         }
-        stale_canonicals: set[str] = set()
+        stale_pairs: set[tuple[str, str]] = set()
         if isinstance(stale_after_s, (int, float)) and stale_after_s > 0:
-            for canonical in cached_canonicals:
-                last_success = freshness_by_parameter.get(
+            for serial, canonical in cached_pairs:
+                last_success = freshness_by_serial.get(serial, {}).get(
                     canonical,
                     telemetry_health.last_success_mono,
                 )
                 if last_success is not None and now_mono - last_success > float(
                     stale_after_s
                 ):
-                    stale_canonicals.add(canonical)
-                    self._remove_inverter_parameter(cached_by_serial, canonical)
-                    freshness_by_parameter.pop(canonical, None)
-        if stale_canonicals:
+                    stale_pairs.add((serial, canonical))
+            for serial, canonical in stale_pairs:
+                self._remove_inverter_parameter(
+                    cached_by_serial,
+                    canonical,
+                    serials=frozenset({serial}),
+                )
+                freshness_for_serial = freshness_by_serial.get(serial)
+                if freshness_for_serial is not None:
+                    freshness_for_serial.pop(canonical, None)
+                    if not freshness_for_serial:
+                        freshness_by_serial.pop(serial, None)
+        if stale_pairs:
             self._update_shared_state(
                 _inverter_parameter_telemetry=cached_by_serial,
-                _inverter_parameter_success_mono=freshness_by_parameter,
+                _inverter_parameter_success_mono=freshness_by_serial,
             )
             if isinstance(telemetry_health.degraded, bool):
                 telemetry_health.degraded = True
@@ -3204,78 +3396,97 @@ class InventoryRuntime:
             return cached_by_serial
 
         typed_parameter_fetcher = cast(
-            Callable[[list[str], str], Awaitable[object]], parameter_fetcher
+            Callable[..., Awaitable[object]], parameter_fetcher
+        )
+        # Keep each response small enough for high-rate power queries, but follow
+        # explicit paging metadata (or an empty metadata-free page) until every
+        # requested inverter is resolved. This avoids treating a truncated first
+        # page as an authoritative parameter snapshot.
+        parameter_page_size = min(
+            INVERTER_PARAMETER_MAX_PAGE_SIZE,
+            max(INVERTER_PARAMETER_MIN_PAGE_SIZE, len(serials) * 2),
         )
         results = await self._async_run_bounded_optional_batch(
             [
-                partial(typed_parameter_fetcher, serials, parameter_id)
+                partial(
+                    self._async_fetch_complete_inverter_parameter,
+                    typed_parameter_fetcher,
+                    serials,
+                    parameter_id,
+                    per_page=parameter_page_size,
+                )
                 for parameter_id in parameter_ids
-            ]
+            ],
+            timeout_s=None,
         )
-        valid_payload_count = 0
+        successful_parameter_count = 0
+        updated_parameter_count = 0
         first_error: Exception | None = None
         telemetry_by_serial = {
             serial: value
             for serial, value in cached_by_serial.items()
             if serial in serials
         }
-        cached_canonicals = {
-            key
-            for snapshot in telemetry_by_serial.values()
-            for key in snapshot
-            if key not in {"parameter_ids", "sampled_at"}
-        }
-        failed_canonicals: set[str] = set()
+        retained_cached_pairs = set(cached_pairs - stale_pairs)
+        failed_pairs: set[tuple[str, str]] = set()
         for parameter_id, result in zip(parameter_ids, results, strict=True):
             canonical = INVERTER_PARAMETER_ALIASES[parameter_id.lower()]
             if isinstance(result, Exception):
                 first_error = first_error or result
-                failed_canonicals.add(canonical)
+                failed_pairs.update((serial, canonical) for serial in serials)
                 continue
-            if not self._inverter_parameter_payload_is_valid(result):
-                first_error = first_error or ValueError(
-                    f"Dashboard parameter response was invalid for {parameter_id}"
+            assert isinstance(result, InverterParameterFetchResult)
+            if result.error is None:
+                successful_parameter_count += 1
+            else:
+                first_error = first_error or result.error
+                failed_pairs.update(
+                    (serial, canonical)
+                    for serial in set(serials) - result.authoritative_serials
                 )
-                failed_canonicals.add(canonical)
-                continue
-            assert isinstance(result, dict)
-            valid_payload_count += 1
-            freshness_by_parameter[canonical] = now_mono
-            self._remove_inverter_parameter(telemetry_by_serial, canonical)
-            for serial, (value, sampled_at) in self._inverter_parameter_rows(
-                result, parameter_id
-            ).items():
-                if serial not in serials:
-                    continue
+            if result.authoritative_serials:
+                updated_parameter_count += 1
+            for serial in result.authoritative_serials:
+                retained_cached_pairs.discard((serial, canonical))
+                freshness_for_serial = freshness_by_serial.get(serial)
+                if freshness_for_serial is not None:
+                    freshness_for_serial.pop(canonical, None)
+                    if not freshness_for_serial:
+                        freshness_by_serial.pop(serial, None)
+            self._remove_inverter_parameter(
+                telemetry_by_serial,
+                canonical,
+                serials=result.authoritative_serials,
+            )
+            for serial, (value, sampled_at) in result.readings.items():
                 snapshot = telemetry_by_serial.setdefault(serial, {})
                 snapshot[canonical] = value
                 snapshot.setdefault("parameter_ids", {})[canonical] = parameter_id
+                freshness_by_serial.setdefault(serial, {})[canonical] = now_mono
                 if sampled_at is not None:
                     snapshot.setdefault("sampled_at", {})[canonical] = sampled_at
-        if valid_payload_count:
+        if updated_parameter_count:
             self._update_shared_state(
                 _inverter_parameter_telemetry=telemetry_by_serial,
-                _inverter_parameter_success_mono=freshness_by_parameter,
+                _inverter_parameter_success_mono=freshness_by_serial,
             )
         useful_telemetry = any(
             self._inverter_parameter_snapshot_has_values(snapshot)
             for snapshot in telemetry_by_serial.values()
         )
-        current_canonicals = {
-            key
-            for snapshot in telemetry_by_serial.values()
-            for key in snapshot
-            if key not in {"parameter_ids", "sampled_at"}
+        current_pairs = {
+            (serial, canonical)
+            for serial, snapshot in telemetry_by_serial.items()
+            for canonical in snapshot
+            if canonical not in {"parameter_ids", "sampled_at"}
         }
-        using_cached_data = bool(
-            failed_canonicals & cached_canonicals & current_canonicals
-        )
-        failed_cache_stale = bool(failed_canonicals & stale_canonicals)
-        if valid_payload_count == len(parameter_ids):
+        using_cached_data = bool(retained_cached_pairs & current_pairs & failed_pairs)
+        failed_cache_stale = bool(failed_pairs & stale_pairs)
+        if successful_parameter_count == len(parameter_ids):
             coord._note_endpoint_family_success(telemetry_family)
             telemetry_health.degraded = False
             telemetry_health.partial_success = False
-            telemetry_health.successful_items = valid_payload_count
+            telemetry_health.successful_items = successful_parameter_count
             telemetry_health.total_items = len(parameter_ids)
             telemetry_health.using_cached_data = False
             telemetry_health.cache_stale = False
@@ -3289,7 +3500,7 @@ class InventoryRuntime:
             identifiers=serials,
             max_length=160,
         )
-        if valid_payload_count:
+        if updated_parameter_count:
             coord._note_endpoint_family_success(telemetry_family)
             telemetry_health.last_error = safe_batch_error
             telemetry_health.degraded = bool(failed_cache_stale or not useful_telemetry)
@@ -3308,17 +3519,17 @@ class InventoryRuntime:
                 or telemetry_health.consecutive_failures >= failure_threshold
             )
             telemetry_health.partial_success = False
-        telemetry_health.successful_items = valid_payload_count
+        telemetry_health.successful_items = successful_parameter_count
         telemetry_health.total_items = len(parameter_ids)
         telemetry_health.using_cached_data = using_cached_data
         telemetry_health.cache_stale = failed_cache_stale
-        return telemetry_by_serial if valid_payload_count else cached_by_serial
+        return telemetry_by_serial if updated_parameter_count else cached_by_serial
 
     @staticmethod
     async def _async_run_bounded_optional_batch(
         factories: list[Callable[[], Awaitable[object]]],
         *,
-        timeout_s: float = INVERTER_PARAMETER_REQUEST_TIMEOUT_S,
+        timeout_s: float | None = INVERTER_PARAMETER_REQUEST_TIMEOUT_S,
         concurrency: int = INVERTER_PARAMETER_BATCH_CONCURRENCY,
     ) -> list[object]:
         """Run optional requests with bounded concurrency and per-request timeout."""
@@ -3328,6 +3539,8 @@ class InventoryRuntime:
         async def _run(factory: Callable[[], Awaitable[object]]) -> object:
             try:
                 async with semaphore:
+                    if timeout_s is None:
+                        return await factory()
                     async with asyncio.timeout(max(0.0, timeout_s)):
                         return await factory()
             except Exception as err:  # noqa: BLE001 - preserve partial optional data
@@ -3368,6 +3581,7 @@ class InventoryRuntime:
             )
             self._merge_microinverter_type_bucket()
             self._merge_heatpump_type_bucket()
+            self._refresh_cached_topology()
             return
 
         fetch_inventory = getattr(self.client, "inverters_inventory", None)
@@ -3815,6 +4029,7 @@ class InventoryRuntime:
         )
         self._merge_microinverter_type_bucket()
         self._merge_heatpump_type_bucket()
+        self._refresh_cached_topology()
 
     def inverters_refresh_due(self, *, force: bool = False) -> bool:
         coord = self.coordinator

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "4.1.0"
+  "version": "4.1.1"
 }

--- a/custom_components/enphase_ev/sensor_battery.py
+++ b/custom_components/enphase_ev/sensor_battery.py
@@ -79,7 +79,7 @@ class BatterySensorModel:
     coordinator: EnphaseCoordinator
     serial: str
     ac_battery: bool = False
-    _cache_token: tuple[int, int] | None = field(default=None, init=False)
+    _cache_sources: tuple[object, object] | None = field(default=None, init=False)
     _cache: BatteryStorageSnapshot | None = field(default=None, init=False)
 
     def snapshot(self) -> BatteryStorageSnapshot | None:
@@ -92,8 +92,12 @@ class BatterySensorModel:
             None,
         )
         cacheable = coordinator_data is not None or family_data is not None
-        token = (id(coordinator_data), id(family_data))
-        if cacheable and token == self._cache_token:
+        if (
+            cacheable
+            and self._cache_sources is not None
+            and coordinator_data is self._cache_sources[0]
+            and family_data is self._cache_sources[1]
+        ):
             return self._cache
 
         if self.ac_battery:
@@ -105,7 +109,10 @@ class BatterySensorModel:
             cast(BatteryStorageSnapshot, payload) if isinstance(payload, dict) else None
         )
         if cacheable:
-            self._cache_token = token
+            # Retain the source objects themselves. Caching only their integer IDs
+            # lets CPython reuse both IDs when empty startup maps are replaced,
+            # which can preserve a cached missing snapshot after warmup completes.
+            self._cache_sources = (coordinator_data, family_data)
             self._cache = snapshot
         return snapshot
 

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -231,7 +231,9 @@ class InventoryState:
     _inverter_parameter_ids: list[str] = field(default_factory=list)
     _inverter_parameter_columns: list[str] = field(default_factory=list)
     _inverter_parameter_telemetry: PayloadMapByKey = field(default_factory=dict)
-    _inverter_parameter_success_mono: dict[str, float] = field(default_factory=dict)
+    _inverter_parameter_success_mono: dict[str, dict[str, float]] = field(
+        default_factory=dict
+    )
 
 
 @dataclass(slots=True)

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -2013,24 +2013,29 @@ Returns `columns[]` metadata including `name`, `header`, `attribute_name`, visib
 
 ### 2.9.4.b.3 Bulk Device Parameter Readings
 ```
-GET /service/system_dashboard/api_internal/cs/sites/<site_id>/data/parameter-view?serial_numbers=<csv>&per_page=500&page=1&range=today&parameter_id=<id>&start_date=&end_date=&sort_by_date=desc
+GET /service/system_dashboard/api_internal/cs/sites/<site_id>/data/parameter-view?serial_numbers=<csv>&per_page=<n>&page=<page>&range=today&parameter_id=<id>&start_date=&end_date=&sort_by_date=desc
 ```
 Returns paginated device readings for one parameter. The response includes
 `intervals[]`, per-device `columns[]`, paging fields, and range metadata. The
 integration passes every active microinverter serial in one CSV request per
 supported parameter, uses the site master-data catalog to avoid unsupported
 probes, and runs up to two parameter requests concurrently with an independent
-15-second timeout per request. Supported values are normalized to power, AC/DC
+15-second timeout per parameter. It requests at least 50 rows per page and follows
+up to 10 pages until every requested inverter has a reading, explicit paging
+metadata reports the final page, or an empty metadata-free page proves exhaustion.
+When the safety limit or a later-page failure leaves some devices unresolved,
+fresh readings already collected are published while only unresolved devices keep
+their bounded cached values. Supported values are normalized to power, AC/DC
 voltage/current, AC frequency, temperature, signal strength, and firmware when
 advertised and present.
 
-Successful parameters retain independent freshness timestamps. Partial batches
-remain healthy while they publish useful telemetry and any reused parameter values
-are younger than 30 minutes. A batch is degraded when it has no usable current or
-cached result, when a reused parameter becomes stale, or after three consecutive
-full-batch failures. Sanitized failure reasons and UTC retry times remain visible
-through the Service Status diagnostic attributes even while a fresh-cache retry is
-classified as healthy.
+Each device/parameter reading retains an independent freshness timestamp. Partial
+batches remain healthy while they publish useful telemetry and any reused device
+values are younger than 30 minutes. A batch is degraded when it has no usable
+current or cached result, when a reused reading becomes stale, or after three
+consecutive full-batch failures. Sanitized failure reasons and UTC retry times
+remain visible through the Service Status diagnostic attributes even while a
+fresh-cache retry is classified as healthy.
 
 ### 2.9.4.c System Dashboard Devices Table
 ```

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -83,6 +83,7 @@ def test_inventory_runtime_helper_paths(coordinator_factory) -> None:
         "battery_count": 0,
         "ac_battery_count": 0,
         "inverter_count": 0,
+        "inverter_telemetry_count": 0,
         "active_type_keys": [],
         "gateway_iq_router_count": 0,
         "site_energy_channels": [],
@@ -1376,7 +1377,9 @@ async def test_inventory_runtime_bulk_parameter_telemetry(coordinator_factory) -
         return_value={"columns": [{"attribute_name": "reading_1"}]}
     )
 
-    async def _parameter_view(_serials, parameter_id):
+    async def _parameter_view(_serials, parameter_id, *, per_page, page):
+        assert per_page == 50
+        assert page == 1
         if parameter_id == "power":
             return {
                 "intervals": [{"timestamp": "2026-07-11T01:00:00Z", "reading_1": 212}],
@@ -1420,7 +1423,14 @@ async def test_inventory_runtime_bulk_parameter_telemetry(coordinator_factory) -
         "temperature": 41.5,
     }
     assert coord._inverter_parameter_columns == ["reading_1"]  # noqa: SLF001
+    assert coord.inventory_runtime.topology_snapshot().inverter_telemetry_serials == (
+        "INV-A",
+    )
     assert coord.client.system_dashboard_parameter_view.await_count == 3
+    assert all(
+        call.kwargs["per_page"] == 50
+        for call in coord.client.system_dashboard_parameter_view.await_args_list
+    )
 
     for family in (
         "inverter_dashboard_inventory",
@@ -1433,6 +1443,140 @@ async def test_inventory_runtime_bulk_parameter_telemetry(coordinator_factory) -
 
     await runtime._async_refresh_inverters()  # noqa: SLF001
     assert coord.client.system_dashboard_parameter_view.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_parameter_telemetry_follows_pagination(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    runtime._set_shared_state_attr("_inverter_parameter_ids", ["power"])  # noqa: SLF001
+    monkeypatch.setattr(
+        coord,
+        "_endpoint_family_should_run",
+        lambda family, **_kwargs: family == "inverter_parameter_telemetry",
+    )
+
+    async def _parameter_view(_serials, _parameter_id, *, per_page, page):
+        assert per_page == 50
+        if page == 1:
+            return {
+                "intervals": [{"serial_number": "INV-A", "value": 250}],
+                "pagination": {"page": 1, "total_pages": 2},
+            }
+        assert page == 2
+        return {
+            "data": [{"serial_number": "INV-B", "value": 175}],
+            "pagination": {"page": 2, "total_pages": 2},
+        }
+
+    coord.client.system_dashboard_parameter_view = AsyncMock(
+        side_effect=_parameter_view
+    )
+
+    result = await runtime._async_refresh_inverter_parameter_telemetry(  # noqa: SLF001
+        ["INV-A", "INV-B"]
+    )
+
+    assert result == {
+        "INV-A": {"power": 250.0, "parameter_ids": {"power": "power"}},
+        "INV-B": {"power": 175.0, "parameter_ids": {"power": "power"}},
+    }
+    assert [
+        call.kwargs["page"]
+        for call in coord.client.system_dashboard_parameter_view.await_args_list
+    ] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_parameter_pagination_limit_is_not_authoritative(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    current_time = [1_000.0]
+    monkeypatch.setattr(
+        inventory_runtime_mod,
+        "time",
+        SimpleNamespace(monotonic=lambda: current_time[0]),
+    )
+    runtime._update_shared_state(  # noqa: SLF001
+        _inverter_parameter_ids=["power"],
+        _inverter_parameter_telemetry={
+            "INV-A": {
+                "power": 100.0,
+                "parameter_ids": {"power": "power"},
+            },
+            "INV-B": {
+                "power": 200.0,
+                "parameter_ids": {"power": "power"},
+            },
+        },
+        _inverter_parameter_success_mono={
+            "INV-A": {"power": 0.0},
+            "INV-B": {"power": 0.0},
+        },
+    )
+    monkeypatch.setattr(
+        coord,
+        "_endpoint_family_should_run",
+        lambda family, **_kwargs: family == "inverter_parameter_telemetry",
+    )
+    coord.client.system_dashboard_parameter_view = AsyncMock(
+        return_value={
+            "intervals": [
+                {"serial_number": "INV-A", "value": 275 - index} for index in range(50)
+            ]
+        }
+    )
+    monkeypatch.setattr(inventory_runtime_mod, "INVERTER_PARAMETER_MAX_PAGES", 1)
+
+    result = await runtime._async_refresh_inverter_parameter_telemetry(  # noqa: SLF001
+        ["INV-A", "INV-B"]
+    )
+
+    assert result == {
+        "INV-A": {"power": 275.0, "parameter_ids": {"power": "power"}},
+        "INV-B": {"power": 200.0, "parameter_ids": {"power": "power"}},
+    }
+    assert coord._inverter_parameter_success_mono == {  # noqa: SLF001
+        "INV-A": {"power": 1_000.0},
+        "INV-B": {"power": 0.0},
+    }
+    health = coord._endpoint_family_state(  # noqa: SLF001
+        "inverter_parameter_telemetry"
+    )
+    assert health.partial_success is True
+    assert health.successful_items == 0
+    assert health.total_items == 1
+    assert health.using_cached_data is True
+    assert health.last_error == "Dashboard parameter pagination limit reached for power"
+
+    current_time[0] = 1_901.0
+    monkeypatch.setattr(coord, "_endpoint_family_should_run", lambda *_args: False)
+    assert await runtime._async_refresh_inverter_parameter_telemetry(  # noqa: SLF001
+        ["INV-A", "INV-B"]
+    ) == {"INV-A": {"power": 275.0, "parameter_ids": {"power": "power"}}}
+    assert coord._inverter_parameter_success_mono == {  # noqa: SLF001
+        "INV-A": {"power": 1_000.0}
+    }
+
+    current_time[0] = 2_000.0
+    monkeypatch.setattr(
+        coord,
+        "_endpoint_family_should_run",
+        lambda family, **_kwargs: family == "inverter_parameter_telemetry",
+    )
+    await runtime._async_refresh_inverter_parameter_telemetry(  # noqa: SLF001
+        ["INV-A", "INV-B"]
+    )
+    assert (
+        coord._endpoint_family_state(  # noqa: SLF001
+            "inverter_parameter_telemetry"
+        ).using_cached_data
+        is False
+    )
 
 
 @pytest.mark.asyncio
@@ -1742,6 +1886,54 @@ def test_inventory_runtime_parameter_row_shapes_and_invalid_values() -> None:
         "firmware",
     ) == {"INV-C": ("firmware-v1", None)}
     assert parser({"intervals": "bad"}, "power") == {}
+
+
+def test_inventory_runtime_parameter_paging_metadata() -> None:
+    has_more = InventoryRuntime._inverter_parameter_has_more_pages
+
+    assert has_more({"has_next": True}, 1) is True
+    assert has_more({"next_page": None}, 1) is False
+    assert has_more({"nextPage": "2"}, 1) is True
+    assert has_more({"total": "3", "per_page": "2", "page": "1"}, 1) is True
+    assert (
+        has_more(
+            {
+                "total": "16",
+                "per_page": "50",
+                "pagination": {"page": 1, "total_pages": 2},
+            },
+            1,
+        )
+        is True
+    )
+    assert has_more({}, 1) is None
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_parameter_later_page_failure_retains_readings(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory().inventory_runtime
+    fetcher = AsyncMock(
+        side_effect=[
+            {
+                "intervals": [{"serial_number": "INV-A", "value": 250}],
+                "has_next": True,
+            },
+            TimeoutError("later page timed out"),
+        ]
+    )
+
+    result = await runtime._async_fetch_complete_inverter_parameter(  # noqa: SLF001
+        fetcher,
+        ["INV-A", "INV-B"],
+        "power",
+        per_page=50,
+    )
+
+    assert result.readings == {"INV-A": (250.0, None)}
+    assert result.authoritative_serials == frozenset({"INV-A"})
+    assert isinstance(result.error, TimeoutError)
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -321,6 +321,90 @@ def test_per_update_device_snapshots_are_reused(coordinator_factory) -> None:
     assert inverter.native_value == 1
 
 
+def test_battery_snapshot_cache_retains_source_identity(
+    coordinator_factory, monkeypatch
+) -> None:
+    """A replaced warmup map must not alias a cached missing snapshot."""
+
+    from custom_components.enphase_ev import sensor_battery
+    from custom_components.enphase_ev.sensor import EnphaseBatteryStorageChargeSensor
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._battery_storage_data = {}  # noqa: SLF001
+    entity = EnphaseBatteryStorageChargeSensor(coord, "BAT-1")
+
+    # Reproduce the old integer-ID cache collision deterministically. The fixed
+    # model compares retained source objects by identity and does not call id().
+    monkeypatch.setattr(sensor_battery, "id", lambda _value: 1, raising=False)
+    assert entity.native_value is None
+
+    coord._battery_storage_data = {  # noqa: SLF001
+        "BAT-1": {"serial_number": "BAT-1", "current_charge_pct": 42}
+    }
+    coord.data = dict(coord.data)
+
+    assert entity.available is True
+    assert entity.native_value == 42
+
+
+@pytest.mark.asyncio
+async def test_inverter_power_entity_is_added_after_delayed_telemetry(
+    hass, config_entry, coordinator_factory
+) -> None:
+    """A warmup telemetry capability change must load its registered entity."""
+
+    from custom_components.enphase_ev.sensor import (
+        EnphaseInverterTelemetrySensor,
+        async_setup_entry,
+    )
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._inverters_inventory_payload = {}  # noqa: SLF001
+    coord.inventory_runtime._set_shared_state_attr(  # noqa: SLF001
+        "_inverter_data",
+        {"INV-A": {"serial_number": "INV-A", "telemetry": {}}},
+    )
+    coord.inventory_runtime._set_shared_state_attr(  # noqa: SLF001
+        "_inverter_order", ["INV-A"]
+    )
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "microinverter": {
+                "type_key": "microinverter",
+                "type_label": "Microinverters",
+                "count": 1,
+                "devices": [{"serial_number": "INV-A"}],
+            }
+        },
+        ["microinverter"],
+    )
+    coord.inventory_runtime._refresh_cached_topology()  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    added: list[Any] = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    assert not any(
+        isinstance(entity, EnphaseInverterTelemetrySensor) for entity in added
+    )
+
+    coord.inventory_runtime._set_shared_state_attr(  # noqa: SLF001
+        "_inverter_data",
+        {"INV-A": {"serial_number": "INV-A", "telemetry": {"power": 234.5}}},
+    )
+    coord.inventory_runtime._refresh_cached_topology()  # noqa: SLF001
+
+    power_entity = next(
+        entity for entity in added if isinstance(entity, EnphaseInverterTelemetrySensor)
+    )
+    assert power_entity.native_value == 234.5
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("support_state", ["unknown", "activation_unavailable"])
 async def test_async_setup_preserves_grid_profile_registry_during_startup_probe(


### PR DESCRIPTION
## Summary

Fixes battery health, cycle-count, status, and charge entities that could remain unavailable after delayed startup data arrived. It also makes delayed microinverter telemetry capabilities trigger entity discovery and follows paginated dashboard telemetry without treating a truncated page as authoritative.

The battery issue was caused by caching transient source object IDs, which CPython could reuse after warmup maps were replaced. The inverter issue combined a topology cache that did not include telemetry capability with first-page-only parameter handling.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/sensor_battery.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/inventory_runtime.py,custom_components/enphase_ev/sensor_battery.py,custom_components/enphase_ev/state_models.py --fail-under=100"
```

Results:

- Full repository: 3,948 passed.
- Integration package: 3,816 passed.
- Service translations: 43 passed.
- Touched Python modules: 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The supplied Home Assistant diagnostics showed two IQ Battery devices with populated health and cycle-count data and a microinverter fleet whose power entities remained unavailable. This change preserves fresh partial telemetry during pagination failures and expires unresolved per-device cache entries independently.
