### PR TITLE
Modernize device registry access for Home Assistant 2026.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🔧 Improvements
-- None
+- Scoped device-registry synchronization, cleanup, and service routing to the
+  owning config entry for compatibility with Home Assistant 2026.8's per-entry
+  device identifiers.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -41,6 +41,11 @@ from .device_info_helpers import (
     _normalize_evse_model_name as _normalize_evse_model_name,
     async_prime_integration_version,
 )
+from .device_registry_compat import (
+    device_belongs_to_config_entry,
+    get_device_by_identifier,
+    via_device_kwargs,
+)
 from .device_types import (
     is_dry_contact_type_key,
     normalize_type_key,
@@ -460,7 +465,7 @@ def _sync_type_devices(
         kwargs["serial_number"] = serial_number
         kwargs["model_id"] = model_id
         kwargs["sw_version"] = sw_version
-        existing = dev_reg.async_get_device(identifiers={ident})
+        existing = get_device_by_identifier(dev_reg, ident, entry.entry_id)
         changes: list[str] = []
         if existing is None:
             changes.append("new_device")
@@ -533,8 +538,10 @@ def _sync_charger_devices(
             "manufacturer": "Enphase",
             "name": dev_name,
             "serial_number": str(sn),
-            "via_device": None,
         }
+        kwargs.update(
+            via_device_kwargs(dev_reg, via_device_id=None, legacy_via_device=None)
+        )
         model_name_raw = d.get("model_name")
         model_display = _compose_charger_model_display(
             display_name,
@@ -551,7 +558,7 @@ def _sync_charger_devices(
             kwargs["sw_version"] = str(sw)
 
         changes: list[str] = []
-        existing = dev_reg.async_get_device(identifiers={(DOMAIN, sn)})
+        existing = get_device_by_identifier(dev_reg, (DOMAIN, sn), entry.entry_id)
         if existing is None:
             changes.append("new_device")
         else:
@@ -732,8 +739,7 @@ def _remove_empty_inactive_serial_devices(
     entry_id = getattr(entry, "entry_id", None)
     removed = 0
     for device in iter_device_registry_entries(dev_reg):
-        config_entries = getattr(device, "config_entries", None)
-        if config_entries is not None and entry_id not in config_entries:
+        if not device_belongs_to_config_entry(device, entry_id):
             continue
         identifiers = getattr(device, "identifiers", None)
         if not identifiers:
@@ -1218,7 +1224,7 @@ def _migrate_legacy_gateway_type_devices(
         DOMAIN,
         f"type:{site_id_text}:envoy",
     )
-    gateway_device = dev_reg.async_get_device(identifiers={gateway_ident})
+    gateway_device = get_device_by_identifier(dev_reg, gateway_ident, entry.entry_id)
     if gateway_device is None:
         return
     gateway_device_id = getattr(gateway_device, "id", None)
@@ -1301,14 +1307,13 @@ def _migrate_legacy_gateway_type_devices(
 
     for type_key in _LEGACY_GATEWAY_TYPE_KEYS:
         legacy_ident = (DOMAIN, f"type:{site_id_text}:{type_key}")
-        legacy_device = dev_reg.async_get_device(identifiers={legacy_ident})
+        legacy_device = get_device_by_identifier(dev_reg, legacy_ident, entry.entry_id)
         if legacy_device is None:
             continue
         _move_device_to_gateway(legacy_device, type_key)
 
     for legacy_device in iter_device_registry_entries(dev_reg):
-        config_entries = getattr(legacy_device, "config_entries", None)
-        if config_entries is not None and entry_id not in config_entries:
+        if not device_belongs_to_config_entry(legacy_device, entry_id):
             continue
         identifiers = getattr(legacy_device, "identifiers", None)
         if not identifiers:
@@ -1365,18 +1370,19 @@ def _remove_legacy_site_device(
         DOMAIN,
         f"type:{site_id_text}:envoy",
     )
-    gateway_device = dev_reg.async_get_device(identifiers={gateway_ident})
+    gateway_device = get_device_by_identifier(dev_reg, gateway_ident, entry.entry_id)
     if gateway_device is not None:
         gateway_device_id = getattr(gateway_device, "id", None)
 
     legacy_site_ident = (DOMAIN, f"site:{site_id_text}")
-    legacy_site_device = dev_reg.async_get_device(identifiers={legacy_site_ident})
+    legacy_site_device = get_device_by_identifier(
+        dev_reg, legacy_site_ident, entry.entry_id
+    )
     if legacy_site_device is None:
         return
     if not _is_legacy_site_device(legacy_site_device, legacy_site_ident):
         return
-    config_entries = getattr(legacy_site_device, "config_entries", None)
-    if config_entries is not None and entry_id not in config_entries:
+    if not device_belongs_to_config_entry(legacy_site_device, entry_id):
         return
     legacy_site_device_id = getattr(legacy_site_device, "id", None)
     if legacy_site_device_id is None:
@@ -1514,7 +1520,7 @@ def _remove_evse_type_device_and_entities(
         return
 
     evse_ident = (DOMAIN, f"type:{site_id_text}:iqevse")
-    evse_device = dev_reg.async_get_device(identifiers={evse_ident})
+    evse_device = get_device_by_identifier(dev_reg, evse_ident, entry.entry_id)
     if evse_device is None:
         return
     evse_device_id = getattr(evse_device, "id", None)

--- a/custom_components/enphase_ev/device_registry_compat.py
+++ b/custom_components/enphase_ev/device_registry_compat.py
@@ -1,0 +1,85 @@
+"""Compatibility helpers for Home Assistant device registry API transitions."""
+
+from __future__ import annotations
+
+from typing import cast
+
+from homeassistant.helpers import device_registry as dr
+
+
+def get_device_by_identifier(
+    device_registry: dr.DeviceRegistry,
+    identifier: tuple[str, str],
+    config_entry_id: str,
+) -> dr.DeviceEntry | None:
+    """Return the device matching an identifier for one config entry."""
+
+    scoped_lookup = getattr(device_registry, "async_get_device_by_identifier", None)
+    if callable(scoped_lookup):
+        return cast(dr.DeviceEntry | None, scoped_lookup(identifier, config_entry_id))
+    return device_registry.async_get_device(identifiers={identifier})
+
+
+def device_config_entry_ids(
+    device: object,
+    *,
+    device_registry: dr.DeviceRegistry | None = None,
+) -> tuple[str, ...]:
+    """Return owning entry IDs, including legacy composite devices."""
+
+    device_id = getattr(device, "id", None)
+    get_composite_splits = (
+        getattr(
+            device_registry,
+            "async_get_devices_for_composite_device_id",
+            None,
+        )
+        if device_registry is not None
+        else None
+    )
+    if device_id is not None and callable(get_composite_splits):
+        split_devices = get_composite_splits(device_id)
+        if split_devices:
+            return tuple(
+                dict.fromkeys(
+                    str(split_device.config_entry_id) for split_device in split_devices
+                )
+            )
+
+    config_entry_id = getattr(device, "config_entry_id", None)
+    if config_entry_id is not None:
+        return (str(config_entry_id),)
+
+    # Home Assistant before 2026.8 only exposes config_entries. Composite
+    # devices on newer versions are handled above through their real splits.
+    return _legacy_config_entry_ids(device)
+
+
+def _legacy_config_entry_ids(device: object) -> tuple[str, ...]:
+    """Return plural owners from old HA or a synthesized composite device."""
+
+    config_entries = getattr(device, "config_entries", None)
+    if not config_entries:
+        return ()
+    return tuple(str(entry_id) for entry_id in config_entries)
+
+
+def device_belongs_to_config_entry(device: object, config_entry_id: object) -> bool:
+    """Return whether a device belongs to the specified config entry."""
+
+    if config_entry_id is None:
+        return False
+    return str(config_entry_id) in device_config_entry_ids(device)
+
+
+def via_device_kwargs(
+    device_registry: dr.DeviceRegistry,
+    *,
+    via_device_id: str | None,
+    legacy_via_device: tuple[str, str] | None,
+) -> dict[str, object]:
+    """Return the supported parent-device keyword for this HA version."""
+
+    if callable(getattr(device_registry, "async_get_device_by_identifier", None)):
+        return {"via_device_id": via_device_id}
+    return {"via_device": legacy_via_device}

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -37,6 +37,7 @@ from .const import (
     ISSUE_TOO_MANY_ACTIVE_SESSIONS,
 )
 from .device_types import parse_type_identifier
+from .device_registry_compat import device_config_entry_ids
 from .log_redaction import redact_site_id
 from .parsing_helpers import coerce_optional_bool
 from .grid_profile_runtime import SUPPORT_DENIED, GridProfileRuntime
@@ -168,20 +169,15 @@ def async_setup_services(
         data = coord.data if isinstance(getattr(coord, "data", None), dict) else {}
         return bool(not serials and not data and sn)
 
-    def _device_config_entry_ids(device: dr.DeviceEntry) -> list[str]:
-        entry_ids: list[str] = []
-        config_entries = getattr(device, "config_entries", None)
-        if config_entries:
-            entry_ids.extend(str(entry_id) for entry_id in config_entries)
-        config_entry_id = getattr(device, "config_entry_id", None)
-        if config_entry_id:
-            entry_ids.append(str(config_entry_id))
-        return list(dict.fromkeys(entry_ids))
+    def _device_config_entry_ids(
+        dev_reg: dr.DeviceRegistry, device: dr.DeviceEntry
+    ) -> list[str]:
+        return list(device_config_entry_ids(device, device_registry=dev_reg))
 
     def _config_entry_ids_for_device(
         dev_reg: dr.DeviceRegistry, dev: dr.DeviceEntry
     ) -> list[str]:
-        entry_ids = _device_config_entry_ids(dev)
+        entry_ids = _device_config_entry_ids(dev_reg, dev)
         if entry_ids:
             return entry_ids
         via = dev.via_device_id
@@ -190,7 +186,7 @@ def async_setup_services(
         parent = dev_reg.async_get(via)
         if not parent:
             return []
-        return _device_config_entry_ids(parent)
+        return _device_config_entry_ids(dev_reg, parent)
 
     async def _resolve_device_routing_context(
         device_id: str,

--- a/tests/components/enphase_ev/test_device_registry_compat.py
+++ b/tests/components/enphase_ev/test_device_registry_compat.py
@@ -1,0 +1,107 @@
+"""Tests for device registry compatibility helpers."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from custom_components.enphase_ev.device_registry_compat import (
+    device_belongs_to_config_entry,
+    device_config_entry_ids,
+    get_device_by_identifier,
+    via_device_kwargs,
+)
+
+
+def test_scoped_identifier_lookup_uses_modern_registry_api() -> None:
+    """Modern Home Assistant lookups include the owning config entry."""
+
+    device = SimpleNamespace(id="owned-device")
+    scoped_lookup = Mock(return_value=device)
+    registry = SimpleNamespace(async_get_device_by_identifier=scoped_lookup)
+
+    assert (
+        get_device_by_identifier(registry, ("enphase_ev", "shared"), "entry-a")
+        is device
+    )
+    scoped_lookup.assert_called_once_with(("enphase_ev", "shared"), "entry-a")
+
+
+def test_scoped_identifier_lookup_falls_back_for_old_home_assistant() -> None:
+    """The advertised minimum HA version keeps using its legacy lookup."""
+
+    device = SimpleNamespace(id="legacy-device")
+    legacy_lookup = Mock(return_value=device)
+    registry = SimpleNamespace(async_get_device=legacy_lookup)
+
+    assert (
+        get_device_by_identifier(registry, ("enphase_ev", "serial"), "entry-a")
+        is device
+    )
+    legacy_lookup.assert_called_once_with(identifiers={("enphase_ev", "serial")})
+
+
+def test_device_config_entry_ids_support_modern_legacy_and_composite_devices() -> None:
+    """Ordinary devices use one owner while legacy composites retain all owners."""
+
+    assert device_config_entry_ids(SimpleNamespace(config_entry_id="entry-a")) == (
+        "entry-a",
+    )
+    assert set(
+        device_config_entry_ids(
+            SimpleNamespace(
+                config_entry_id=None,
+                config_entries={"entry-a", "entry-b"},
+            )
+        )
+    ) == {"entry-a", "entry-b"}
+    assert device_config_entry_ids(SimpleNamespace(config_entry_id=None)) == ()
+    composite = SimpleNamespace(
+        id="old-composite-id",
+        config_entry_id="primary-entry",
+        config_entries={"entry-a", "entry-b"},
+    )
+    composite_registry = SimpleNamespace(
+        async_get_devices_for_composite_device_id=lambda device_id: (
+            [
+                SimpleNamespace(config_entry_id="entry-a"),
+                SimpleNamespace(config_entry_id="entry-b"),
+            ]
+            if device_id == composite.id
+            else []
+        )
+    )
+    assert set(
+        device_config_entry_ids(composite, device_registry=composite_registry)
+    ) == {"entry-a", "entry-b"}
+    ordinary_registry = SimpleNamespace(
+        async_get_devices_for_composite_device_id=lambda _device_id: []
+    )
+    assert device_config_entry_ids(
+        SimpleNamespace(id="ordinary", config_entry_id="entry-a"),
+        device_registry=ordinary_registry,
+    ) == ("entry-a",)
+    assert device_belongs_to_config_entry(
+        SimpleNamespace(config_entry_id="entry-a"), "entry-a"
+    )
+    assert not device_belongs_to_config_entry(
+        SimpleNamespace(config_entry_id="entry-a"), "entry-b"
+    )
+    assert not device_belongs_to_config_entry(
+        SimpleNamespace(config_entry_id="entry-a"), None
+    )
+
+
+def test_via_device_kwargs_follow_available_registry_api() -> None:
+    """Parent linkage uses via_device_id only when Home Assistant supports it."""
+
+    modern_registry = SimpleNamespace(async_get_device_by_identifier=Mock())
+    assert via_device_kwargs(
+        modern_registry,
+        via_device_id="parent-id",
+        legacy_via_device=("enphase_ev", "parent-serial"),
+    ) == {"via_device_id": "parent-id"}
+
+    assert via_device_kwargs(
+        SimpleNamespace(),
+        via_device_id="parent-id",
+        legacy_via_device=("enphase_ev", "parent-serial"),
+    ) == {"via_device": ("enphase_ev", "parent-serial")}

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -41,6 +41,7 @@ from custom_components.enphase_ev import (
     _registry_type_metadata_signature,
     _remove_retired_grid_profile_device_entities,
     _remove_evse_type_device_and_entities,
+    _remove_empty_inactive_serial_devices,
     _remove_legacy_inventory_entities,
     _remove_legacy_site_device,
     _startup_migration_version,
@@ -3386,6 +3387,144 @@ class _FakeDeviceRegistry:
             if device.id == device_id:
                 del self._devices[ident]
                 break
+
+
+class _ScopedFakeDeviceRegistry:
+    """Model the per-config-entry identifier uniqueness introduced in HA 2026.8."""
+
+    def __init__(self) -> None:
+        self.devices: dict[str, _FakeDevice] = {}
+        self._by_owner_and_identifier: dict[
+            tuple[str, tuple[str, str]], _FakeDevice
+        ] = {}
+
+    def async_get_device_by_identifier(self, identifier, config_entry_id):
+        return self._by_owner_and_identifier.get((config_entry_id, identifier))
+
+    def async_get_or_create(self, **kwargs):
+        identifier = next(iter(kwargs["identifiers"]))
+        config_entry_id = kwargs["config_entry_id"]
+        key = (config_entry_id, identifier)
+        device = self._by_owner_and_identifier.get(key)
+        if device is None:
+            device = _FakeDevice(
+                id=f"{config_entry_id}-{len(self.devices) + 1}",
+                config_entry_id=config_entry_id,
+                identifiers={identifier},
+                manufacturer=None,
+                name=None,
+                model=None,
+                model_id=None,
+                serial_number=None,
+                hw_version=None,
+                sw_version=None,
+                via_device_id=None,
+            )
+            self._by_owner_and_identifier[key] = device
+            self.devices[device.id] = device
+        for field in (
+            "name",
+            "manufacturer",
+            "model",
+            "model_id",
+            "serial_number",
+            "hw_version",
+            "sw_version",
+            "via_device_id",
+        ):
+            if field in kwargs:
+                setattr(device, field, kwargs[field])
+        return device
+
+    def async_remove_device(self, device_id):
+        device = self.devices.pop(device_id)
+        identifier = next(iter(device.identifiers))
+        self._by_owner_and_identifier.pop((device.config_entry_id, identifier))
+
+
+def test_sync_type_devices_scopes_duplicate_identifier_to_config_entry(
+    config_entry,
+) -> None:
+    """Registry synchronization must not update another entry's matching device."""
+
+    registry = _ScopedFakeDeviceRegistry()
+    identifier = (DOMAIN, "type:shared-site:envoy")
+    other_entry = SimpleNamespace(entry_id="other-entry")
+
+    def _coordinator(name: str):
+        return _with_inventory_view(
+            SimpleNamespace(
+                iter_type_keys=lambda: ["envoy"],
+                type_identifier=lambda _key: identifier,
+                type_label=lambda _key: "Gateway",
+                type_device_name=lambda _key: name,
+                type_device_model=lambda _key: "IQ Gateway",
+            )
+        )
+
+    _sync_type_devices(
+        other_entry, _coordinator("Other Gateway"), registry, "shared-site"
+    )
+    _sync_type_devices(
+        config_entry, _coordinator("Owned Gateway"), registry, "shared-site"
+    )
+
+    other_device = registry.async_get_device_by_identifier(
+        identifier, other_entry.entry_id
+    )
+    owned_device = registry.async_get_device_by_identifier(
+        identifier, config_entry.entry_id
+    )
+    assert other_device is not None
+    assert owned_device is not None
+    assert other_device.id != owned_device.id
+    assert other_device.name == "Other Gateway"
+    assert owned_device.name == "Owned Gateway"
+
+
+def test_inactive_device_cleanup_only_removes_owned_duplicate(
+    hass: HomeAssistant, config_entry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cleanup ignores another entry's device with the same identifier."""
+
+    registry = _ScopedFakeDeviceRegistry()
+    identifier = (DOMAIN, "SHARED-INACTIVE")
+    for entry_id in ("other-entry", config_entry.entry_id):
+        registry.async_get_or_create(
+            config_entry_id=entry_id,
+            identifiers={identifier},
+            manufacturer="Enphase",
+            name=f"Charger {entry_id}",
+        )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er.async_get",
+        lambda _hass: SimpleNamespace(entities={}),
+    )
+    monkeypatch.setattr(
+        enphase_init,
+        "active_serial_registry_identifiers",
+        lambda _coord: {
+            "charger": set(),
+            "battery": set(),
+            "ac_battery": set(),
+            "inverter": set(),
+        },
+    )
+    coord = SimpleNamespace(_devices_inventory_ready=True)
+
+    assert (
+        _remove_empty_inactive_serial_devices(
+            hass, config_entry, coord, registry, "shared-site"
+        )
+        == 1
+    )
+    assert (
+        registry.async_get_device_by_identifier(identifier, "other-entry") is not None
+    )
+    assert (
+        registry.async_get_device_by_identifier(identifier, config_entry.entry_id)
+        is None
+    )
 
 
 def test_sync_type_devices_skips_invalid_and_updates_existing(config_entry) -> None:

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -761,6 +761,133 @@ async def test_services_route_evse_targets_to_owning_entry_with_site_only_entry(
 
 
 @pytest.mark.asyncio
+async def test_services_route_duplicate_serial_to_device_config_entry(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A device owner disambiguates a serial exposed by multiple entries."""
+
+    handlers = _register_service_handlers(hass, monkeypatch)
+    serial = "SHARED-EVSE"
+    first_coord = _fake_service_coordinator(site_id="shared-site", serials={serial})
+    second_coord = _fake_service_coordinator(site_id="shared-site", serials={serial})
+    first_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "shared-site"},
+        title="First shared site",
+        unique_id="first-shared-site",
+    )
+    second_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "shared-site"},
+        title="Second shared site",
+        unique_id="second-shared-site",
+    )
+    for entry, coord in (
+        (first_entry, first_coord),
+        (second_entry, second_coord),
+    ):
+        entry.add_to_hass(hass)
+        entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    device = SimpleNamespace(
+        id="second-device",
+        identifiers={(DOMAIN, serial)},
+        config_entry_id=second_entry.entry_id,
+        via_device_id=None,
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.dr.async_get",
+        lambda _hass: SimpleNamespace(
+            async_get=lambda device_id: device if device_id == device.id else None
+        ),
+    )
+
+    await handlers[(DOMAIN, "start_charging")](
+        SimpleNamespace(
+            data={
+                "device_id": [device.id],
+                "charging_level": 24,
+                "connector_id": 1,
+            }
+        )
+    )
+
+    second_coord.async_start_charging.assert_awaited_once_with(
+        serial, requested_amps=24, connector_id=1
+    )
+    first_coord.async_start_charging.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_services_route_composite_device_through_split_owners(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pre-migration composite target checks each real split owner."""
+
+    handlers = _register_service_handlers(hass, monkeypatch)
+    serial = "COMPOSITE-EVSE"
+    first_coord = _fake_service_coordinator(
+        site_id="first-site", serials={"OTHER-EVSE"}
+    )
+    second_coord = _fake_service_coordinator(site_id="second-site", serials={serial})
+    first_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "first-site"},
+        title="First composite owner",
+        unique_id="first-composite-owner",
+    )
+    second_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "second-site"},
+        title="Second composite owner",
+        unique_id="second-composite-owner",
+    )
+    for entry, coord in (
+        (first_entry, first_coord),
+        (second_entry, second_coord),
+    ):
+        entry.add_to_hass(hass)
+        entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    composite = SimpleNamespace(
+        id="old-composite-device-id",
+        identifiers={(DOMAIN, serial)},
+        config_entry_id=first_entry.entry_id,
+        config_entries={first_entry.entry_id, second_entry.entry_id},
+        via_device_id=None,
+    )
+    split_devices = [
+        SimpleNamespace(config_entry_id=first_entry.entry_id),
+        SimpleNamespace(config_entry_id=second_entry.entry_id),
+    ]
+    registry = SimpleNamespace(
+        async_get=lambda device_id: (composite if device_id == composite.id else None),
+        async_get_devices_for_composite_device_id=lambda device_id: (
+            split_devices if device_id == composite.id else []
+        ),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.dr.async_get",
+        lambda _hass: registry,
+    )
+
+    await handlers[(DOMAIN, "start_charging")](
+        SimpleNamespace(
+            data={
+                "device_id": [composite.id],
+                "charging_level": 18,
+                "connector_id": 2,
+            }
+        )
+    )
+
+    second_coord.async_start_charging.assert_awaited_once_with(
+        serial, requested_amps=18, connector_id=2
+    )
+    first_coord.async_start_charging.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_targeted_services_raise_without_target_or_owner(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Scope Enphase device-registry lookups to the owning config entry on Home Assistant 2026.8 and newer.
- Preserve Home Assistant 2026.6 compatibility through contained registry helpers.
- Route legacy composite device targets through their public split-device owners and prevent cross-entry cleanup.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Executed in the pinned `docker-ha-dev` image:

```bash
ruff check .
black --check custom_components/enphase_ev/__init__.py custom_components/enphase_ev/services.py custom_components/enphase_ev/device_registry_compat.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_services.py tests/components/enphase_ev/test_device_registry_compat.py
python -m pre_commit run --all-files
python scripts/validate_quality_scale.py
python scripts/validate_quality_scale.py --validate-remote-brands
python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log
mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev
COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase
COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q
COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/services.py,custom_components/enphase_ev/device_registry_compat.py --fail-under=100
pytest -q
```

Results:

- 3,824 integration tests passed.
- 3,956 repository tests passed.
- All three touched production modules reported 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed. (Not applicable; no user configuration changed.)
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (No translation changes.)
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The compatibility helpers prefer the Home Assistant 2026.8 scoped APIs and only use plural config-entry ownership or unscoped identifier lookup on older supported Home Assistant releases. Synthesized composite IDs are resolved using `async_get_devices_for_composite_device_id`, without private registry state.
