### PR TITLE
Use typed percentage units on Home Assistant 2026.7+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - Scoped device-registry synchronization, cleanup, and service routing to the
   owning config entry for compatibility with Home Assistant 2026.8's per-entry
   device identifiers.
+- Used Home Assistant's typed percentage unit on 2026.7 and newer while retaining
+  compatibility with the minimum supported Home Assistant 2026.6 release.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
+from homeassistant import const as ha_const
 from homeassistant.components.number import NumberEntity, NumberMode
-from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent, UnitOfEnergy
+from homeassistant.const import UnitOfElectricCurrent, UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback as ha_callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -32,6 +33,17 @@ PARALLEL_UPDATES = 0
 
 _CallbackT = TypeVar("_CallbackT", bound=Callable[..., object])
 callback = cast(Callable[[_CallbackT], _CallbackT], ha_callback)
+
+
+def _percentage_unit(constants: object) -> str:
+    """Return the current percentage unit with pre-2026.7 compatibility."""
+    unit_of_ratio = getattr(constants, "UnitOfRatio", None)
+    if unit_of_ratio is not None:
+        return cast(str, unit_of_ratio.PERCENTAGE)
+    return cast(str, getattr(constants, "PERCENTAGE"))
+
+
+_PERCENTAGE_UNIT = _percentage_unit(ha_const)
 
 
 def _site_has_battery(coord: EnphaseCoordinator) -> bool:
@@ -611,7 +623,7 @@ class _BatteryScheduleEditorLimitNumber(BatteryScheduleEditorEntity, NumberEntit
     _attr_native_min_value = 5.0
     _attr_native_max_value = 100.0
     _attr_native_step = 1.0
-    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_native_unit_of_measurement = _PERCENTAGE_UNIT
     _attr_mode = NumberMode.SLIDER
 
     def __init__(

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from enum import StrEnum
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant import const as ha_const
 
 from custom_components.enphase_ev.battery_schedule_editor import (
     BatteryScheduleEditorManager,
@@ -128,6 +130,34 @@ def test_number_battery_write_access_confirmed_falls_back_to_roles() -> None:
     coord.battery_user_is_installer = False
     coord.battery_write_access_confirmed = True
     assert number_mod._battery_write_access_confirmed(coord) is True
+
+
+def test_percentage_unit_prefers_unit_of_ratio_without_legacy_access() -> None:
+    from custom_components.enphase_ev import number as number_mod
+
+    class FakeUnitOfRatio(StrEnum):
+        PERCENTAGE = "%"
+
+    class ModernConstants:
+        UnitOfRatio = FakeUnitOfRatio
+
+        @property
+        def PERCENTAGE(self) -> str:
+            raise AssertionError("legacy PERCENTAGE must not be accessed")
+
+    assert number_mod._percentage_unit(ModernConstants()) is FakeUnitOfRatio.PERCENTAGE
+
+    runtime_unit_of_ratio = getattr(ha_const, "UnitOfRatio", None)
+    if runtime_unit_of_ratio is not None:
+        assert number_mod._PERCENTAGE_UNIT is runtime_unit_of_ratio.PERCENTAGE
+    else:
+        assert number_mod._PERCENTAGE_UNIT == ha_const.PERCENTAGE
+
+
+def test_percentage_unit_falls_back_for_home_assistant_2026_6() -> None:
+    from custom_components.enphase_ev import number as number_mod
+
+    assert number_mod._percentage_unit(SimpleNamespace(PERCENTAGE="%")) == "%"
 
 
 def test_retained_site_number_unique_ids_follow_scheduler_state() -> None:


### PR DESCRIPTION
## Summary

- Replace percentage unit usage with `UnitOfRatio.PERCENTAGE` on Home Assistant 2026.7 and newer.
- Retain compatibility with the minimum supported Home Assistant 2026.6 release.
- Cover both the typed-unit and legacy fallback paths.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Executed in the pinned `docker-ha-dev` image:

```bash
ruff check .
black --check custom_components/enphase_ev/number.py tests/components/enphase_ev/test_number_module.py
python -m pre_commit run --all-files
python scripts/validate_quality_scale.py
python scripts/validate_quality_scale.py --validate-remote-brands
python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log
mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev
COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase
COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q
COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/number.py --fail-under=100
pytest -q
```

Minimum-version validation:

```bash
pip install -r devtools/docker/requirements-min-ha.txt
pip install --no-deps pytest-homeassistant-custom-component==0.13.340
pytest -q tests/components/enphase_ev/test_number_module.py -k percentage_unit
```

Results:

- Home Assistant 2026.6 resolver tests: 2 passed.
- 3,818 integration tests passed.
- 3,950 repository tests passed.
- `number.py` reported 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed. (Not applicable.)
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (No translation changes.)
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The legacy `PERCENTAGE` attribute is only read when `UnitOfRatio` is unavailable, avoiding deprecated unit access on newer Home Assistant releases.
