### PR TITLE
Add Home Assistant 2026.8 compatibility validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,12 @@ on:
     paths:
       - 'custom_components/**'
       - 'tests/components/enphase_ev/**'
+      - 'tests/compatibility/**'
       - '.pre-commit-config.yaml'
       - '.ruff.toml'
+      - 'devtools/docker/requirements-ha-2026.8.txt'
+      - 'devtools/docker/Dockerfile'
+      - 'devtools/docker/docker-compose.yml'
       - '.github/workflows/tests.yml'
       - '.github/workflows/ci.yml'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,11 +5,15 @@ on:
     paths:
       - 'custom_components/**'
       - 'tests/components/enphase_ev/**'
+      - 'tests/compatibility/**'
       - '.pre-commit-config.yaml'
       - '.ruff.toml'
       - '.strict-typing'
       - 'devtools/docker/requirements-dev.txt'
       - 'devtools/docker/requirements-min-ha.txt'
+      - 'devtools/docker/requirements-ha-2026.8.txt'
+      - 'devtools/docker/Dockerfile'
+      - 'devtools/docker/docker-compose.yml'
       - 'quality_scale.yaml'
       - 'scripts/importtime_profile.py'
       - 'scripts/validate_quality_scale.py'
@@ -168,6 +172,38 @@ jobs:
           tests/components/enphase_ev/test_device_action.py
           tests/components/enphase_ev/test_device_trigger.py
           tests/components/enphase_ev/test_schedule_sync.py
+
+  homeassistant-2026-8:
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            devtools/docker/requirements-ha-2026.8.txt
+            .github/workflows/tests.yml
+      - name: Install Home Assistant 2026.8 test deps
+        run: |
+          # The current plugin release pins 2026.8.0b3. Install its compatible
+          # dependency stack, then overlay the beta under test without deps.
+          python -m pip install --upgrade pip
+          pip install --upgrade --pre -r devtools/docker/requirements-ha-2026.8.txt
+          pip install --upgrade --pre --no-deps "homeassistant==2026.8.0b4"
+          python -c "from homeassistant.const import __version__; assert __version__ == '2026.8.0b4', __version__; print(f'Home Assistant {__version__}')"
+      - name: Run Home Assistant 2026.8 compatibility tests
+        run: >
+          pytest -q --asyncio-mode=auto
+          tests/compatibility/test_ha_2026_8_device_registry.py
+          tests/components/enphase_ev/test_init_module.py::test_async_setup_entry_updates_existing_device
+          tests/components/enphase_ev/test_init_module.py::test_remove_legacy_site_device_preserves_real_devices_with_site_identifier
+          tests/components/enphase_ev/test_init_module.py::test_remove_legacy_site_device_removes_empty_device_without_gateway
+          tests/components/enphase_ev/test_services.py::test_services_route_evse_targets_to_owning_entry_with_site_only_entry
 
   pytest:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,12 @@ Include the integration version, Home Assistant version, affected entity IDs, de
    docker compose -f devtools/docker/docker-compose.yml build ha-dev
    ```
 4. **Develop and test** your changes inside `ha-dev`.
+   To reproduce the forward-compatibility lane against the pinned Home Assistant
+   2026.8 beta, run:
+   ```bash
+   docker compose -f devtools/docker/docker-compose.yml build ha-2026-8
+   docker compose -f devtools/docker/docker-compose.yml run --rm ha-2026-8 bash -lc "pytest -q tests/compatibility/test_ha_2026_8_device_registry.py tests/components/enphase_ev/test_init_module.py::test_async_setup_entry_updates_existing_device tests/components/enphase_ev/test_init_module.py::test_remove_legacy_site_device_preserves_real_devices_with_site_identifier tests/components/enphase_ev/test_init_module.py::test_remove_legacy_site_device_removes_empty_device_without_gateway tests/components/enphase_ev/test_services.py::test_services_route_evse_targets_to_owning_entry_with_site_only_entry"
+   ```
 5. **Start `ha-runtime` when you need a real Home Assistant UI for manual verification**:
    ```bash
    mkdir -p .ha-config

--- a/devtools/docker/Dockerfile
+++ b/devtools/docker/Dockerfile
@@ -32,10 +32,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /workspace
 
-COPY devtools/docker/requirements-dev.txt requirements-dev.txt
+ARG REQUIREMENTS_FILE=requirements-dev.txt
+ARG HOME_ASSISTANT_VERSION=""
+
+COPY devtools/docker/requirements*.txt /tmp/enphase-ev-requirements/
 
 RUN python -m pip install --upgrade pip && \
-    pip install --no-cache-dir -r requirements-dev.txt
+    pip install --no-cache-dir \
+        -r "/tmp/enphase-ev-requirements/${REQUIREMENTS_FILE}" && \
+    if [ -n "${HOME_ASSISTANT_VERSION}" ]; then \
+        pip install --no-cache-dir --no-deps \
+            "homeassistant==${HOME_ASSISTANT_VERSION}"; \
+    fi
 
 # Allow git operations (e.g. pre-commit) inside the mounted workspace.
 RUN git config --global --add safe.directory /workspace

--- a/devtools/docker/docker-compose.yml
+++ b/devtools/docker/docker-compose.yml
@@ -11,6 +11,22 @@ services:
       - PYTHONDONTWRITEBYTECODE=1
       - PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
 
+  ha-2026-8:
+    build:
+      context: ../..
+      dockerfile: devtools/docker/Dockerfile
+      args:
+        REQUIREMENTS_FILE: requirements-ha-2026.8.txt
+        HOME_ASSISTANT_VERSION: 2026.8.0b4
+    volumes:
+      - ../..:/workspace:delegated
+    working_dir: /workspace
+    command: sleep infinity
+    environment:
+      - PYTHONDONTWRITEBYTECODE=1
+      - PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
+      - PYTEST_ASYNCIO_MODE=auto
+
   ha-runtime:
     image: ghcr.io/home-assistant/home-assistant:stable
     restart: unless-stopped

--- a/devtools/docker/requirements-ha-2026.8.txt
+++ b/devtools/docker/requirements-ha-2026.8.txt
@@ -1,0 +1,7 @@
+# Dependencies for the Home Assistant 2026.8 forward-compatibility lane.
+#
+# This plugin release supplies the test dependencies for Home Assistant
+# 2026.8.0b3. Docker and CI then overlay 2026.8.0b4 without dependencies so the
+# tested Home Assistant version remains authoritative while the compatible
+# plugin stack is retained.
+pytest-homeassistant-custom-component==0.13.351

--- a/tests/compatibility/test_ha_2026_8_device_registry.py
+++ b/tests/compatibility/test_ha_2026_8_device_registry.py
@@ -1,0 +1,72 @@
+"""Compatibility contract tests for Home Assistant 2026.8 device registry APIs."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+DOMAIN = "enphase_ev"
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(dr.DeviceRegistry, "async_get_device_by_identifier"),
+    reason="Home Assistant 2026.8 device registry API is unavailable",
+)
+
+
+def test_config_entry_scoped_device_identifiers(hass: HomeAssistant) -> None:
+    """The same identifier resolves independently for separate config entries."""
+    first_entry = MockConfigEntry(domain=DOMAIN, unique_id="first-site")
+    second_entry = MockConfigEntry(domain=DOMAIN, unique_id="second-site")
+    first_entry.add_to_hass(hass)
+    second_entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    shared_identifier = (DOMAIN, "shared-serial")
+
+    first_device = registry.async_get_or_create(
+        config_entry_id=first_entry.entry_id,
+        identifiers={shared_identifier},
+        name="First charger",
+    )
+    second_device = registry.async_get_or_create(
+        config_entry_id=second_entry.entry_id,
+        identifiers={shared_identifier},
+        name="Second charger",
+    )
+
+    assert first_device.id != second_device.id
+    assert first_device.config_entry_id == first_entry.entry_id
+    assert second_device.config_entry_id == second_entry.entry_id
+    assert (
+        registry.async_get_device_by_identifier(shared_identifier, first_entry.entry_id)
+        == first_device
+    )
+    assert (
+        registry.async_get_device_by_identifier(
+            shared_identifier, second_entry.entry_id
+        )
+        == second_device
+    )
+
+
+def test_via_device_id_links_scoped_devices(hass: HomeAssistant) -> None:
+    """The 2026.8 via_device_id keyword links a child to its exact parent."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="site")
+    entry.add_to_hass(hass)
+    registry = dr.async_get(hass)
+    parent = registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "site:site")},
+        name="Site",
+    )
+
+    child = registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "charger")},
+        name="Charger",
+        via_device_id=parent.id,
+    )
+
+    assert child.via_device_id == parent.id


### PR DESCRIPTION
## Summary

- Add a reproducible Home Assistant 2026.8.0b4 forward-compatibility CI lane while retaining the existing 2026.6 minimum-version lane.
- Add device-registry contract coverage for per-config-entry identifiers and `via_device_id`.
- Provide a matching local Docker Compose service and contributor command.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (CI validation)

## Testing

Stable pinned development image:

```bash
ruff check .
black --check tests/compatibility/test_ha_2026_8_device_registry.py
python -m pre_commit run --all-files
python scripts/validate_quality_scale.py
python scripts/validate_quality_scale.py --validate-remote-brands
python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log
mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev
pytest -q
docker compose -f devtools/docker/docker-compose.yml config --quiet
```

Home Assistant 2026.8 beta lane:

```bash
pytest -q --asyncio-mode=auto tests/compatibility/test_ha_2026_8_device_registry.py tests/components/enphase_ev/test_init_module.py::test_async_setup_entry_updates_existing_device tests/components/enphase_ev/test_init_module.py::test_remove_legacy_site_device_preserves_real_devices_with_site_identifier tests/components/enphase_ev/test_init_module.py::test_remove_legacy_site_device_removes_empty_device_without_gateway tests/components/enphase_ev/test_services.py::test_services_route_evse_targets_to_owning_entry_with_site_only_entry
```

Results:

- Stable suite: 3,948 passed, 2 expected compatibility skips.
- Home Assistant 2026.8.0b4 lane: 6 passed.
- Ruff, Black, pre-commit, strict mypy, quality-scale, remote-brands, import-time, Compose configuration, and workflow YAML validation passed.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes. (Not applicable; CI-only behavior.)
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (No translation changes.)
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage. (No production Python modules changed.)
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The beta dependency stack uses `pytest-homeassistant-custom-component==0.13.351`, then overlays Home Assistant 2026.8.0b4 without dependency resolution because the plugin currently pins beta 3. The exact b4 lane passed locally. A full local Compose image rebuild was blocked by shared Docker Desktop storage exhaustion; the GitHub Actions lane installs the same stack directly and does not depend on that local image build.
