### PR TITLE
Expose DTG control-only windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Exposed the discharge-to-grid switch and configured window for IQ Battery sites
+  that use the `dtgControl` window without per-day schedule rows. (#810)
 
 ### 🔧 Improvements
 - Scoped device-registry synchronization, cleanup, and service routing to the

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -7131,16 +7131,22 @@ class EnphaseCoordinator(
         start_minutes: object,
         end_minutes: object,
         schedule_status: object = None,
+        allow_control_window: bool = False,
     ) -> bool:
         if self._battery_schedule_control_available(control):
             show_day_schedule = self._battery_control_field(
                 control, "show_day_schedule"
             )
-            if show_day_schedule is False:
-                return False
             schedule_supported = self._battery_control_field(
                 control, "schedule_supported"
             )
+            if show_day_schedule is False:
+                return (
+                    allow_control_window
+                    and schedule_supported is True
+                    and start_minutes is not None
+                    and end_minutes is not None
+                )
             if schedule_supported is not None:
                 return schedule_supported
         elif isinstance(schedule_status, str) and schedule_status.strip():
@@ -7162,16 +7168,18 @@ class EnphaseCoordinator(
         schedule_id: object,
         start_minutes: object,
         end_minutes: object,
+        allow_control_window: bool = False,
     ) -> bool:
         if not self._battery_schedule_supported(
             control,
             schedule_id=schedule_id,
             start_minutes=start_minutes,
             end_minutes=end_minutes,
+            allow_control_window=allow_control_window,
         ):
             return False
         return (
-            schedule_id is not None
+            (schedule_id is not None or allow_control_window)
             and start_minutes is not None
             and end_minutes is not None
         )
@@ -7219,23 +7227,36 @@ class EnphaseCoordinator(
         age = self.battery_settings_write_age_seconds
         return age is not None and age < FAST_TOGGLE_POLL_HOLD_S
 
+    def _battery_dtg_effective_window(self) -> tuple[int | None, int | None]:
+        start_minutes = getattr(self, "_battery_dtg_begin_time", None)
+        if start_minutes is None:
+            start_minutes = getattr(self, "_battery_dtg_control_begin_time", None)
+        end_minutes = getattr(self, "_battery_dtg_end_time", None)
+        if end_minutes is None:
+            end_minutes = getattr(self, "_battery_dtg_control_end_time", None)
+        return start_minutes, end_minutes
+
     @property
     def discharge_to_grid_schedule_supported(self) -> bool:
+        start_minutes, end_minutes = self._battery_dtg_effective_window()
         return self._battery_schedule_supported(
             getattr(self, "_battery_dtg_control", None),
             schedule_id=getattr(self, "_battery_dtg_schedule_id", None),
-            start_minutes=getattr(self, "_battery_dtg_begin_time", None),
-            end_minutes=getattr(self, "_battery_dtg_end_time", None),
+            start_minutes=start_minutes,
+            end_minutes=end_minutes,
             schedule_status=getattr(self, "_battery_dtg_schedule_status", None),
+            allow_control_window=True,
         )
 
     @property
     def discharge_to_grid_schedule_available(self) -> bool:
+        start_minutes, end_minutes = self._battery_dtg_effective_window()
         return self._battery_schedule_available(
             getattr(self, "_battery_dtg_control", None),
             schedule_id=getattr(self, "_battery_dtg_schedule_id", None),
-            start_minutes=getattr(self, "_battery_dtg_begin_time", None),
-            end_minutes=getattr(self, "_battery_dtg_end_time", None),
+            start_minutes=start_minutes,
+            end_minutes=end_minutes,
+            allow_control_window=True,
         )
 
     def _battery_schedule_effective_enabled(self, schedule_type: str) -> bool | None:
@@ -7282,16 +7303,12 @@ class EnphaseCoordinator(
 
     @property
     def battery_discharge_to_grid_start_time(self) -> dt_time | None:
-        minutes = getattr(self, "_battery_dtg_begin_time", None)
-        if minutes is None:
-            minutes = getattr(self, "_battery_dtg_control_begin_time", None)
+        minutes, _ = self._battery_dtg_effective_window()
         return self._minutes_of_day_to_time(minutes)
 
     @property
     def battery_discharge_to_grid_end_time(self) -> dt_time | None:
-        minutes = getattr(self, "_battery_dtg_end_time", None)
-        if minutes is None:
-            minutes = getattr(self, "_battery_dtg_control_end_time", None)
+        _, minutes = self._battery_dtg_effective_window()
         return self._minutes_of_day_to_time(minutes)
 
     @property

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -693,6 +693,40 @@ def test_battery_schedule_support_helpers_cover_false_paths(
     assert coord.discharge_to_grid_schedule_available is False
 
 
+def test_dtg_control_window_without_day_schedule_is_available(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+
+    coord.battery_runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "batteryGridMode": "ExportOnly",
+                "dtgControl": {
+                    "show": True,
+                    "showDaySchedule": False,
+                    "enabled": True,
+                    "locked": False,
+                    "scheduleSupported": True,
+                    "startTime": 1020,
+                    "endTime": 1379,
+                },
+            }
+        }
+    )
+
+    assert coord._battery_dtg_schedule_id is None  # noqa: SLF001
+    assert coord._battery_dtg_begin_time is None  # noqa: SLF001
+    assert coord._battery_dtg_end_time is None  # noqa: SLF001
+    assert coord.discharge_to_grid_schedule_supported is True
+    assert coord.discharge_to_grid_schedule_available is True
+    assert coord.battery_discharge_to_grid_schedule_enabled is True
+    assert coord.battery_discharge_to_grid_start_time == dt_time(17, 0)
+    assert coord.battery_discharge_to_grid_end_time == dt_time(22, 59)
+
+
 def test_rbd_time_properties_fall_back_to_control_window(coordinator_factory) -> None:
     coord = coordinator_factory()
     coord._battery_rbd_control_begin_time = 60  # noqa: SLF001
@@ -3956,6 +3990,53 @@ async def test_dtg_schedule_enabled_without_schedule_uses_battery_settings_toggl
     assert coord._battery_dtg_end_time is None  # noqa: SLF001
     assert coord.battery_discharge_to_grid_start_time == dt_time(19, 0)
     assert coord.battery_discharge_to_grid_end_time == dt_time(22, 0)
+
+
+@pytest.mark.asyncio
+async def test_dtg_control_window_without_day_schedule_uses_battery_settings_toggle(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord.battery_runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "dtgControl": {
+                    "show": True,
+                    "showDaySchedule": False,
+                    "enabled": True,
+                    "locked": False,
+                    "scheduleSupported": True,
+                    "startTime": 1020,
+                    "endTime": 1379,
+                }
+            }
+        }
+    )
+    coord.client.set_battery_settings = AsyncMock(return_value={})
+    coord.battery_runtime._async_verify_schedule_family_toggle_applied = (
+        AsyncMock()
+    )  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+
+    await coord.async_set_discharge_to_grid_schedule_enabled(False)
+
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": False,
+                "show": True,
+                "locked": False,
+                "showDaySchedule": False,
+                "scheduleSupported": True,
+                "startTime": 1020,
+                "endTime": 1379,
+            }
+        },
+        schedule_type="dtg",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -693,14 +693,21 @@ async def test_async_setup_entry_adds_supported_battery_site_switches_and_prunes
             {"show": True, "enabled": False}
         )
     )
-    coord._battery_dtg_control = (
-        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
-            {"show": True, "showDaySchedule": True, "scheduleSupported": True}
-        )
+    coord.battery_runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "dtgControl": {
+                    "show": True,
+                    "showDaySchedule": False,
+                    "enabled": True,
+                    "locked": False,
+                    "scheduleSupported": True,
+                    "startTime": 1020,
+                    "endTime": 1379,
+                }
+            }
+        }
     )
-    coord._battery_dtg_schedule_id = "sched-dtg"  # noqa: SLF001
-    coord._battery_dtg_begin_time = 1080  # noqa: SLF001
-    coord._battery_dtg_end_time = 1380  # noqa: SLF001
     coord._battery_rbd_control = (
         coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
             {"show": True, "showDaySchedule": True, "scheduleSupported": True}
@@ -2309,6 +2316,36 @@ def test_discharge_to_grid_schedule_switch_availability(coordinator_factory) -> 
 
     assert sw.available is True
     assert sw.is_on is True
+
+
+def test_discharge_to_grid_control_window_switch_availability(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord.battery_runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "dtgControl": {
+                    "show": True,
+                    "showDaySchedule": False,
+                    "enabled": True,
+                    "locked": False,
+                    "scheduleSupported": True,
+                    "startTime": 1020,
+                    "endTime": 1379,
+                }
+            }
+        }
+    )
+
+    sw = DischargeToGridScheduleSwitch(coord)
+
+    assert sw.available is True
+    assert sw.is_on is True
+    assert sw.extra_state_attributes["start_time"] == "17:00"
+    assert sw.extra_state_attributes["end_time"] == "22:59"
 
 
 def test_discharge_to_grid_schedule_switch_exposes_schedule_attributes(


### PR DESCRIPTION
## Summary

- Expose the existing discharge-to-grid switch when Battery Settings supplies a
  valid `dtgControl` window but `/schedules` has no per-day rows.
- Resolve DTG availability from the effective row-or-control window while keeping
  the control-window exception scoped to DTG.
- Cover the reported payload shape through coordinator, entity setup, switch
  attributes, and Battery Settings toggle tests.

The previous availability gate rejected `showDaySchedule: false` before consulting
`scheduleSupported` and required a schedule row ID even though the DTG control
window and enablement were already parsed. This left active DTG configuration
invisible in Home Assistant.

Fixes #810.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_switch_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_switch_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Post-rebase targeted validation:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_switch_module.py && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && pytest -q tests/components/enphase_ev/test_battery_runtime_settings.py::test_dtg_control_window_without_day_schedule_is_available tests/components/enphase_ev/test_battery_runtime_settings.py::test_dtg_control_window_without_day_schedule_uses_battery_settings_toggle tests/components/enphase_ev/test_switch_module.py::test_async_setup_entry_adds_supported_battery_site_switches_and_prunes_types tests/components/enphase_ev/test_switch_module.py::test_discharge_to_grid_control_window_switch_availability"
```

Results: 3,961 passed and 2 skipped in the complete suite; coordinator targeted
coverage remained at 100%.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The regression payload uses `dtgControl.enabled`, `startTime`, and `endTime` with
`showDaySchedule: false`, `scheduleSupported: true`, and an empty DTG schedule-row
list. No translation, manifest, diagnostics payload, or repair behavior changed.
