### PR TITLE
Include battery and generator energy in grid export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug fixes
 - Exposed the discharge-to-grid switch and configured window for IQ Battery sites
   that use the `dtgControl` window without per-day schedule rows. (#810)
+- Included battery-to-grid and generator-to-grid energy in the Site Grid Export
+  sensor so discharge-to-grid sites report their full export while preserving
+  existing Energy Dashboard statistics continuity. (#809)
 
 ### 🔧 Improvements
 - Scoped device-registry synchronization, cleanup, and service routing to the

--- a/custom_components/enphase_ev/api_parsers.py
+++ b/custom_components/enphase_ev/api_parsers.py
@@ -314,6 +314,7 @@ def normalize_lifetime_energy_payload(payload: object) -> PayloadMap | None:
         "consumption",
         "solar_home",
         "solar_grid",
+        "generator_grid",
         "grid_home",
         "import",
         "export",

--- a/custom_components/enphase_ev/energy.py
+++ b/custom_components/enphase_ev/energy.py
@@ -53,6 +53,7 @@ class SiteEnergyFlow:
     source_unit: str = UnitOfPower.WATT
     last_reset_at: str | None = None
     interval_minutes: float | None = None
+    legacy_offset_kwh: float = 0.0
 
 
 class EnergyManager:
@@ -514,6 +515,7 @@ class EnergyManager:
             bucket_count: int,
             *,
             allow_zero: bool = False,
+            legacy_offset_wh: float = 0.0,
         ) -> None:
             if bucket_count <= 0 or total_wh < 0:
                 return
@@ -546,6 +548,7 @@ class EnergyManager:
                 source_unit=source_unit,
                 last_reset_at=last_reset,
                 interval_minutes=interval_minutes,
+                legacy_offset_kwh=round(legacy_offset_wh / 1000.0, 3),
             )
             if last_reset:
                 self._site_energy_last_reset[flow] = last_reset
@@ -672,11 +675,31 @@ class EnergyManager:
                 allow_zero=True,
             )
 
-        # Grid export
-        exp_total, exp_count = self._sum_energy_buckets(
-            payload.get("solar_grid"), interval_hours
-        )
-        _store("grid_export", exp_total, ["solar_grid"], exp_count)
+        # Grid export (all energy delivered through the site meter).
+        exp_total = 0.0
+        exp_count = 0
+        exp_fields: list[str] = []
+        legacy_offset_wh = 0.0
+        for field in ("solar_grid", "battery_grid", "generator_grid"):
+            field_total, field_count = self._sum_energy_buckets(
+                payload.get(field), interval_hours
+            )
+            if field_count <= 0:
+                continue
+            exp_total += field_total
+            exp_count = max(exp_count, field_count)
+            exp_fields.append(field)
+            if field in ("battery_grid", "generator_grid"):
+                legacy_offset_wh += field_total
+        if exp_fields:
+            _store(
+                "grid_export",
+                exp_total,
+                exp_fields,
+                exp_count,
+                allow_zero=True,
+                legacy_offset_wh=legacy_offset_wh,
+            )
 
         # Battery charge (into battery)
         charge_total, charge_count = self._sum_energy_buckets(

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.components.sensor import (
     RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
+    SensorExtraStoredData,
     SensorStateClass,
 )
 from homeassistant.const import (
@@ -178,7 +179,7 @@ SITE_SERVICE_STATUS_STATES: tuple[str, ...] = ("ok", "degraded", "unknown")
 CURRENT_POWER_CACHE_TTL_MULTIPLIER = 2
 SITE_LIFETIME_FLOW_BUCKET_LENGTH_KEYS: dict[str, tuple[str, ...]] = {
     "grid_import": ("import", "grid_home", "grid_battery"),
-    "grid_export": ("solar_grid",),
+    "grid_export": ("solar_grid", "battery_grid", "generator_grid"),
     "battery_charge": ("charge", "solar_battery", "grid_battery"),
     "battery_discharge": ("discharge", "battery_home", "battery_grid"),
 }
@@ -1369,6 +1370,59 @@ class _LastSessionRestoreData(ExtraStoredData):  # type: ignore[misc]
             _as_float(data.get("last_session_end")),
             str(session_key) if session_key is not None else None,
             _as_int(data.get("last_duration_min")),
+        )
+
+
+@dataclass
+class _SiteEnergyRestoreData(SensorExtraStoredData):  # type: ignore[misc]
+    """Persist sensor state and site-energy composition migration state."""
+
+    composition_offset_kwh: float
+    composition_offset_reset_at: str | None
+    composition_source_start_date: str | None
+    composition_migration_checked: bool
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            **super().as_dict(),
+            "composition_offset_kwh": self.composition_offset_kwh,
+            "composition_offset_reset_at": self.composition_offset_reset_at,
+            "composition_source_start_date": self.composition_source_start_date,
+            "composition_migration_checked": self.composition_migration_checked,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> "_SiteEnergyRestoreData":
+        if not isinstance(data, dict):
+            return cls(None, None, 0.0, None, None, False)
+        sensor_restore = SensorExtraStoredData.from_dict(data)
+        try:
+            offset = float(data.get("composition_offset_kwh", 0.0))
+        except (TypeError, ValueError):
+            offset = 0.0
+        if not math.isfinite(offset) or offset < 0:
+            offset = 0.0
+        reset_at = data.get("composition_offset_reset_at")
+        start_date = data.get("composition_source_start_date")
+        return cls(
+            native_value=(
+                sensor_restore.native_value if sensor_restore is not None else None
+            ),
+            native_unit_of_measurement=(
+                sensor_restore.native_unit_of_measurement
+                if sensor_restore is not None
+                else None
+            ),
+            composition_offset_kwh=offset,
+            composition_offset_reset_at=(
+                reset_at if isinstance(reset_at, str) else None
+            ),
+            composition_source_start_date=(
+                start_date if isinstance(start_date, str) else None
+            ),
+            composition_migration_checked=(
+                data.get("composition_migration_checked") is True
+            ),
         )
 
 
@@ -4598,6 +4652,10 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):  # type: ignore[m
         self._attr_unique_id = f"{DOMAIN}_site_{coord.site_id}_{flow_key}"
         self._restored_value: float | None = None
         self._restored_reset_at: str | None = None
+        self._composition_offset_kwh = 0.0
+        self._composition_offset_reset_at: str | None = None
+        self._composition_source_start_date: str | None = None
+        self._composition_migration_checked = flow_key != "grid_export"
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -4617,9 +4675,34 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):  # type: ignore[m
         except Exception:  # noqa: BLE001
             last_state = None
         if last_state is not None:
-            reset_attr = (last_state.attributes or {}).get("last_reset_at")
+            attributes = last_state.attributes or {}
+            reset_attr = attributes.get("last_reset_at")
             if isinstance(reset_attr, str):
                 self._restored_reset_at = reset_attr
+        last_extra = await self.async_get_last_extra_data()
+        composition_restore = _SiteEnergyRestoreData.from_dict(
+            last_extra.as_dict() if last_extra is not None else None
+        )
+        if (
+            self._flow_key == "grid_export"
+            and composition_restore.composition_migration_checked
+        ):
+            self._composition_offset_kwh = composition_restore.composition_offset_kwh
+            self._composition_offset_reset_at = (
+                composition_restore.composition_offset_reset_at
+            )
+            self._composition_source_start_date = (
+                composition_restore.composition_source_start_date
+            )
+            self._composition_migration_checked = True
+
+    @staticmethod
+    def _coerce_nonnegative_float(value: object) -> float | None:
+        try:
+            numeric = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+        return numeric if math.isfinite(numeric) and numeric >= 0 else None
 
     def _flow_data(self) -> dict[str, object]:
         energy = getattr(self._coord, "energy", None)
@@ -4640,6 +4723,7 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):  # type: ignore[m
                 "source_unit": entry.source_unit,
                 "last_reset_at": entry.last_reset_at,
                 "interval_minutes": entry.interval_minutes,
+                "legacy_offset_kwh": entry.legacy_offset_kwh,
             }
         if isinstance(entry, dict):
             return entry
@@ -4654,6 +4738,53 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):  # type: ignore[m
             return float(val)  # type: ignore[arg-type]
         except Exception:  # noqa: BLE001
             return None
+
+    def _ensure_composition_migration(self) -> None:
+        """Preserve total-increasing continuity across export composition changes."""
+
+        data = self._flow_data()
+        current_value = self._coerce_nonnegative_float(data.get("value_kwh"))
+        reset_at = data.get("last_reset_at")
+        current_reset_at = reset_at if isinstance(reset_at, str) else None
+        start_date = data.get("start_date")
+        current_start_date = start_date if isinstance(start_date, str) else None
+        if self._composition_migration_checked:
+            reset_marker_changed = (
+                current_reset_at is not None
+                and current_reset_at != self._composition_offset_reset_at
+            )
+            source_start_changed = (
+                current_start_date is not None
+                and self._composition_source_start_date is not None
+                and current_start_date != self._composition_source_start_date
+            )
+            offset_exceeds_total = (
+                current_value is not None
+                and current_value < self._composition_offset_kwh
+            )
+            if reset_marker_changed or source_start_changed or offset_exceeds_total:
+                self._composition_offset_kwh = 0.0
+                self._composition_offset_reset_at = current_reset_at
+                self._composition_source_start_date = current_start_date
+            return
+        if current_value is None:
+            return
+        if self._restored_value is not None:
+            legacy_offset = self._coerce_nonnegative_float(
+                data.get("legacy_offset_kwh")
+            )
+            if legacy_offset is not None:
+                legacy_value = max(current_value - legacy_offset, 0.0)
+                restored_to_legacy = abs(self._restored_value - legacy_value)
+                restored_to_composite = abs(self._restored_value - current_value)
+                # A takeover can restore a total from another integration. Only
+                # remove the newly added channels when the prior value actually
+                # tracks the legacy solar-only composition.
+                if restored_to_legacy <= restored_to_composite:
+                    self._composition_offset_kwh = legacy_offset
+        self._composition_offset_reset_at = current_reset_at
+        self._composition_source_start_date = current_start_date
+        self._composition_migration_checked = True
 
     @property
     def available(self) -> bool:
@@ -4683,14 +4814,30 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):  # type: ignore[m
     def native_value(self) -> Any:
         current = self._current_value()
         if current is not None:
-            return round(current, 2)
+            self._ensure_composition_migration()
+            return round(max(current - self._composition_offset_kwh, 0.0), 2)
         if self._restored_value is None:
             return None
         return round(self._restored_value, 2)
 
     @property
+    def extra_restore_state_data(self) -> ExtraStoredData | None:
+        if self._flow_key != "grid_export":
+            return super().extra_restore_state_data
+        sensor_restore = super().extra_restore_state_data
+        return _SiteEnergyRestoreData(
+            native_value=sensor_restore.native_value,
+            native_unit_of_measurement=sensor_restore.native_unit_of_measurement,
+            composition_offset_kwh=self._composition_offset_kwh,
+            composition_offset_reset_at=self._composition_offset_reset_at,
+            composition_source_start_date=self._composition_source_start_date,
+            composition_migration_checked=self._composition_migration_checked,
+        )
+
+    @property
     def extra_state_attributes(self) -> Any:
         data = self._flow_data()
+        self._ensure_composition_migration()
         attrs: dict[str, object] = {}
         last_report_raw = data.get("last_report_date")
         parsed_sample_ts = _EnphaseSiteLifetimePowerSensor._parse_sample_timestamp(

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -7415,6 +7415,7 @@ async def test_lifetime_energy_normalization() -> None:
                         "production": [1000, "2000", None, -5],
                         "import": ["", "30"],
                         "grid_home": [15],
+                        "generator_grid": ["12.5"],
                         "update_pending": False,
                         "start_date": "2024-01-01",
                         "last_report_date": "1700000000",
@@ -7432,6 +7433,7 @@ async def test_lifetime_energy_normalization() -> None:
     assert payload["production"] == [1000.0, 2000.0, None, -5.0]
     assert payload["import"] == [None, 30.0]
     assert payload["grid_home"] == [15.0]
+    assert payload["generator_grid"] == [12.5]
     assert payload["update_pending"] is False
     assert payload["start_date"] == "2024-01-01"
     assert payload["last_report_date"] == "1700000000"

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from homeassistant.const import UnitOfPower
+from homeassistant.const import UnitOfEnergy, UnitOfPower
 
 from custom_components.enphase_ev import energy as energy_mod
 from custom_components.enphase_ev.api import SiteEnergyUnavailable
@@ -20,6 +20,7 @@ from custom_components.enphase_ev.sensor import (
     EnphaseBatteryPowerSensor,
     EnphaseGridPowerSensor,
     EnphaseSiteEnergySensor,
+    _SiteEnergyRestoreData,
     _SiteLifetimePowerRestoreData,
     _lifetime_energy_delta,
 )
@@ -32,6 +33,7 @@ def test_site_energy_aggregation_with_fallbacks(coordinator_factory) -> None:
         "consumption": [1500, 500],
         "solar_home": [400, 100],
         "solar_grid": [600, None],
+        "generator_grid": [25],
         "grid_battery": [50],
         "battery_grid": [100],
         "charge": None,
@@ -62,7 +64,12 @@ def test_site_energy_aggregation_with_fallbacks(coordinator_factory) -> None:
         "grid_battery",
     ]
     assert flows["grid_import"].value_kwh == pytest.approx(1.4)
-    assert flows["grid_export"].fields_used == ["solar_grid"]
+    assert flows["grid_export"].fields_used == [
+        "solar_grid",
+        "battery_grid",
+        "generator_grid",
+    ]
+    assert flows["grid_export"].value_kwh == pytest.approx(0.725)
     assert flows["battery_charge"].bucket_count == 1
     assert flows["battery_charge"].value_kwh == pytest.approx(0.15)
     assert flows["battery_discharge"].value_kwh == pytest.approx(0.25)
@@ -81,6 +88,39 @@ def test_site_energy_refresh_due_respects_backoff(
     monkeypatch.setattr(energy_mod.time, "monotonic", lambda: 100.0)
 
     assert manager.site_energy_refresh_due() is False
+
+
+def test_site_energy_grid_export_includes_battery_discharge_to_grid(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    payload = {
+        "solar_grid": [0, 0],
+        "battery_grid": [8000, 8180],
+        "interval_minutes": 60,
+    }
+
+    flows, _meta = coord.energy._aggregate_site_energy(payload)  # noqa: SLF001
+
+    assert flows["grid_export"].value_kwh == pytest.approx(16.18)
+    assert flows["grid_export"].fields_used == ["solar_grid", "battery_grid"]
+    assert flows["grid_export"].legacy_offset_kwh == pytest.approx(16.18)
+
+
+def test_site_energy_grid_export_preserves_zero_channels(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    payload = {
+        "solar_grid": [0, 0],
+        "battery_grid": [0, 0],
+        "interval_minutes": 60,
+    }
+
+    flows, _meta = coord.energy._aggregate_site_energy(payload)  # noqa: SLF001
+
+    assert flows["grid_export"].value_kwh == 0.0
+    assert flows["grid_export"].bucket_count == 2
+    assert flows["grid_export"].fields_used == ["solar_grid", "battery_grid"]
+    assert flows["grid_export"].legacy_offset_kwh == 0.0
 
 
 def test_site_energy_refresh_due_skips_when_cache_is_fresh(
@@ -1381,7 +1421,7 @@ def test_site_grid_power_sensor_stays_available_at_zero_when_channel_known(
     coord = coordinator_factory()
     coord.energy.site_energy = {}
     coord.energy._site_energy_meta = {  # noqa: SLF001
-        "bucket_lengths": {"solar_grid": 12},
+        "bucket_lengths": {"battery_grid": 12},
         "last_report_date": datetime(2024, 1, 2, tzinfo=timezone.utc),
     }
     sensor = EnphaseGridPowerSensor(coord)
@@ -1502,6 +1542,7 @@ async def test_site_lifetime_power_sensor_restores_and_handles_resets(
         }
 
     sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=None)
     await sensor.async_added_to_hass()
     assert sensor.available is False
 
@@ -3110,7 +3151,15 @@ async def test_site_energy_sensor_restoration(monkeypatch, hass, coordinator_fac
     sensor2.hass = hass
     sensor2.async_get_last_sensor_data = AsyncMock(return_value=None)
     sensor2.async_get_last_state = AsyncMock(side_effect=RuntimeError("boom"))
+    sensor2.async_get_last_extra_data = AsyncMock(return_value=None)
     await sensor2.async_added_to_hass()
+    assert sensor2.native_value is None
+    assert "composition_offset_kwh" not in sensor2.extra_state_attributes
+    assert sensor2.extra_restore_state_data is not None
+    assert (
+        sensor2.extra_restore_state_data.as_dict()["composition_migration_checked"]
+        is False
+    )
 
     class BadLastData:
         @property
@@ -3123,6 +3172,7 @@ async def test_site_energy_sensor_restoration(monkeypatch, hass, coordinator_fac
     sensor3.hass = hass
     sensor3.async_get_last_sensor_data = AsyncMock(return_value=BadLastData())
     sensor3.async_get_last_state = AsyncMock(return_value=None)
+    sensor3.async_get_last_extra_data = AsyncMock(return_value=None)
     await sensor3.async_added_to_hass()
     sensor3._restored_value = 1.5
     assert sensor3.available is True
@@ -3146,6 +3196,7 @@ async def test_site_energy_sensor_restoration(monkeypatch, hass, coordinator_fac
         "source_unit": UnitOfPower.WATT,
         "last_reset_at": None,
         "interval_minutes": None,
+        "legacy_offset_kwh": 0.0,
     }
 
     class BadStr:
@@ -3157,6 +3208,401 @@ async def test_site_energy_sensor_restoration(monkeypatch, hass, coordinator_fac
     }
     attrs = sensor3.extra_state_attributes
     assert "last_report_date" not in attrs
+
+
+@pytest.mark.asyncio
+async def test_grid_export_sensor_preserves_statistics_across_composition_migration(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord.energy.site_energy = {
+        "grid_export": SiteEnergyFlow(
+            value_kwh=26.105,
+            bucket_count=2,
+            fields_used=["solar_grid", "battery_grid"],
+            start_date="2023-08-10",
+            last_report_date=datetime(2026, 8, 2, tzinfo=timezone.utc),
+            update_pending=False,
+            source_unit="Wh",
+            interval_minutes=60,
+            legacy_offset_kwh=16.18,
+        )
+    }
+    sensor = EnphaseSiteEnergySensor(
+        coord, "grid_export", "site_grid_export", "Grid Export"
+    )
+    sensor.hass = hass
+
+    class LastData:
+        native_value = 9.9
+
+    class LastState:
+        attributes = {}
+
+    sensor.async_get_last_sensor_data = AsyncMock(return_value=LastData())
+    sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=None)
+    await sensor.async_added_to_hass()
+
+    assert sensor.native_value == pytest.approx(9.93)
+    restore_data = sensor.extra_restore_state_data
+    assert restore_data is not None
+    assert restore_data.as_dict()["composition_offset_kwh"] == pytest.approx(16.18)
+
+    coord.energy.site_energy["grid_export"] = SiteEnergyFlow(
+        value_kwh=26.28,
+        bucket_count=2,
+        fields_used=["solar_grid", "battery_grid"],
+        start_date="2023-08-10",
+        last_report_date=datetime(2026, 8, 2, 1, tzinfo=timezone.utc),
+        update_pending=False,
+        source_unit="Wh",
+        interval_minutes=60,
+        legacy_offset_kwh=16.255,
+    )
+
+    assert sensor.native_value == pytest.approx(10.1)
+    restore_data = sensor.extra_restore_state_data
+    assert restore_data is not None
+    assert restore_data.as_dict()["composition_offset_kwh"] == pytest.approx(16.18)
+
+    coord.energy.site_energy["grid_export"] = SiteEnergyFlow(
+        value_kwh=1.0,
+        bucket_count=2,
+        fields_used=["solar_grid", "battery_grid"],
+        start_date="2026-08-03",
+        last_report_date=datetime(2026, 8, 3, tzinfo=timezone.utc),
+        update_pending=False,
+        source_unit="Wh",
+        last_reset_at="2026-08-03T00:00:00+00:00",
+        interval_minutes=60,
+        legacy_offset_kwh=0.7,
+    )
+
+    assert sensor.native_value == pytest.approx(1.0)
+    restore_data = sensor.extra_restore_state_data
+    assert restore_data is not None
+    assert restore_data.as_dict()["composition_offset_kwh"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_grid_export_sensor_restores_composition_offset(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord.energy.site_energy = {
+        "grid_export": SiteEnergyFlow(
+            value_kwh=26.28,
+            bucket_count=2,
+            fields_used=["solar_grid", "battery_grid"],
+            start_date="2023-08-10",
+            last_report_date=datetime(2026, 8, 2, 1, tzinfo=timezone.utc),
+            update_pending=False,
+            source_unit="Wh",
+            interval_minutes=60,
+            legacy_offset_kwh=16.255,
+        )
+    }
+    sensor = EnphaseSiteEnergySensor(
+        coord, "grid_export", "site_grid_export", "Grid Export"
+    )
+    sensor.hass = hass
+
+    class LastData:
+        native_value = 10.1
+
+    class LastState:
+        attributes = {}
+
+    class LastExtra:
+        def as_dict(self):
+            return {
+                "composition_offset_kwh": "16.18",
+                "composition_offset_reset_at": None,
+                "composition_source_start_date": "2023-08-10",
+                "composition_migration_checked": True,
+            }
+
+    sensor.async_get_last_sensor_data = AsyncMock(return_value=LastData())
+    sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=LastExtra())
+    await sensor.async_added_to_hass()
+
+    assert sensor.native_value == pytest.approx(10.1)
+    restore_data = sensor.extra_restore_state_data
+    assert restore_data is not None
+    assert restore_data.as_dict()["composition_offset_kwh"] == pytest.approx(16.18)
+
+
+@pytest.mark.asyncio
+async def test_grid_export_sensor_does_not_offset_migrated_composite_history(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord.energy.site_energy = {
+        "grid_export": SiteEnergyFlow(
+            value_kwh=26.105,
+            bucket_count=2,
+            fields_used=["solar_grid", "battery_grid"],
+            start_date="2023-08-10",
+            last_report_date=datetime(2026, 8, 2, tzinfo=timezone.utc),
+            update_pending=False,
+            source_unit="Wh",
+            interval_minutes=60,
+            legacy_offset_kwh=16.18,
+        )
+    }
+    sensor = EnphaseSiteEnergySensor(
+        coord, "grid_export", "site_grid_export", "Grid Export"
+    )
+    sensor.hass = hass
+
+    class LastData:
+        native_value = 26.0
+
+    class LastState:
+        attributes = {}
+
+    sensor.async_get_last_sensor_data = AsyncMock(return_value=LastData())
+    sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=None)
+    await sensor.async_added_to_hass()
+
+    assert sensor.native_value == pytest.approx(26.11)
+    restore_data = sensor.extra_restore_state_data
+    assert restore_data is not None
+    assert restore_data.as_dict()["composition_offset_kwh"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_grid_export_sensor_clears_offset_after_offline_lifetime_reset(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord.energy.site_energy = {
+        "grid_export": SiteEnergyFlow(
+            value_kwh=1.0,
+            bucket_count=2,
+            fields_used=["solar_grid", "battery_grid"],
+            start_date="2026-08-03",
+            last_report_date=datetime(2026, 8, 3, tzinfo=timezone.utc),
+            update_pending=False,
+            source_unit="Wh",
+            interval_minutes=60,
+            legacy_offset_kwh=0.7,
+        )
+    }
+    sensor = EnphaseSiteEnergySensor(
+        coord, "grid_export", "site_grid_export", "Grid Export"
+    )
+    sensor.hass = hass
+
+    class LastData:
+        native_value = 10.1
+
+    class LastState:
+        attributes = {}
+
+    class LastExtra:
+        def as_dict(self):
+            return {
+                "composition_offset_kwh": 16.18,
+                "composition_offset_reset_at": None,
+                "composition_source_start_date": "2023-08-10",
+                "composition_migration_checked": True,
+            }
+
+    sensor.async_get_last_sensor_data = AsyncMock(return_value=LastData())
+    sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=LastExtra())
+    await sensor.async_added_to_hass()
+
+    assert sensor.native_value == pytest.approx(1.0)
+    restore_data = sensor.extra_restore_state_data
+    assert restore_data is not None
+    assert restore_data.as_dict() == {
+        "native_value": 1.0,
+        "native_unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
+        "composition_offset_kwh": 0.0,
+        "composition_offset_reset_at": None,
+        "composition_source_start_date": "2026-08-03",
+        "composition_migration_checked": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_new_grid_export_sensor_uses_full_composite_total(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord.energy.site_energy = {
+        "grid_export": SiteEnergyFlow(
+            value_kwh=26.105,
+            bucket_count=2,
+            fields_used=["solar_grid", "battery_grid"],
+            start_date="2023-08-10",
+            last_report_date=datetime(2026, 8, 2, tzinfo=timezone.utc),
+            update_pending=False,
+            source_unit="Wh",
+            interval_minutes=60,
+            legacy_offset_kwh=16.18,
+        )
+    }
+    sensor = EnphaseSiteEnergySensor(
+        coord, "grid_export", "site_grid_export", "Grid Export"
+    )
+    sensor.hass = hass
+    sensor.async_get_last_sensor_data = AsyncMock(return_value=None)
+    sensor.async_get_last_state = AsyncMock(return_value=None)
+    sensor.async_get_last_extra_data = AsyncMock(return_value=None)
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.native_value == pytest.approx(26.11)
+    restore_data = sensor.extra_restore_state_data
+    assert restore_data is not None
+    assert restore_data.as_dict() == {
+        "native_value": 26.11,
+        "native_unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
+        "composition_offset_kwh": 0.0,
+        "composition_offset_reset_at": None,
+        "composition_source_start_date": "2023-08-10",
+        "composition_migration_checked": True,
+    }
+    assert "composition_offset_kwh" not in sensor.extra_state_attributes
+    assert sensor._coerce_nonnegative_float("bad") is None  # noqa: SLF001
+    assert sensor._coerce_nonnegative_float(-1) is None  # noqa: SLF001
+    assert sensor._coerce_nonnegative_float(float("inf")) is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_grid_export_zero_channels_finalize_migration_before_first_export(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    zero_flows, _meta = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {"solar_grid": [0, 0], "battery_grid": [0, 0]}
+    )
+    coord.energy.site_energy = zero_flows
+    sensor = EnphaseSiteEnergySensor(
+        coord, "grid_export", "site_grid_export", "Grid Export"
+    )
+    sensor.hass = hass
+
+    class LastData:
+        native_value = 5.0
+
+    class LastState:
+        attributes = {}
+
+    sensor.async_get_last_sensor_data = AsyncMock(return_value=LastData())
+    sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=None)
+    await sensor.async_added_to_hass()
+
+    assert sensor.native_value == 0.0
+    restore_data = sensor.extra_restore_state_data
+    assert restore_data is not None
+    assert restore_data.as_dict()["composition_migration_checked"] is True
+
+    export_flows, _meta = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {"solar_grid": [0, 0], "battery_grid": [8000, 8180]}
+    )
+    coord.energy.site_energy = export_flows
+
+    assert sensor.native_value == pytest.approx(16.18)
+
+
+@pytest.mark.asyncio
+async def test_site_energy_sensor_restore_data_round_trip(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    source = EnphaseSiteEnergySensor(
+        coord, "grid_export", "site_grid_export", "Grid Export"
+    )
+    source.hass = hass
+    source._restored_value = 10.1  # noqa: SLF001
+    source._composition_offset_kwh = 16.18  # noqa: SLF001
+    source._composition_source_start_date = "2023-08-10"  # noqa: SLF001
+    source._composition_migration_checked = True  # noqa: SLF001
+
+    stored = source.extra_restore_state_data
+    assert stored is not None
+    assert stored.as_dict() == {
+        "native_value": 10.1,
+        "native_unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
+        "composition_offset_kwh": 16.18,
+        "composition_offset_reset_at": None,
+        "composition_source_start_date": "2023-08-10",
+        "composition_migration_checked": True,
+    }
+
+    restored = EnphaseSiteEnergySensor(
+        coord, "grid_export", "site_grid_export", "Grid Export"
+    )
+    restored.hass = hass
+    restored.async_get_last_extra_data = AsyncMock(return_value=stored)
+    restored.async_get_last_state = AsyncMock(return_value=None)
+
+    await restored.async_added_to_hass()
+
+    assert restored.native_value == pytest.approx(10.1)
+    assert restored._composition_offset_kwh == pytest.approx(16.18)  # noqa: SLF001
+    assert restored.async_get_last_extra_data.await_count == 2
+
+    non_export = EnphaseSiteEnergySensor(
+        coord, "grid_import", "site_grid_import", "Grid Import"
+    )
+    non_export._restored_value = 2.5  # noqa: SLF001
+    non_export_stored = non_export.extra_restore_state_data
+    assert non_export_stored is not None
+    assert non_export_stored.as_dict() == {
+        "native_value": 2.5,
+        "native_unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
+    }
+
+
+def test_site_energy_restore_data_handles_invalid_payloads() -> None:
+    assert _SiteEnergyRestoreData.from_dict(None).as_dict() == {
+        "native_value": None,
+        "native_unit_of_measurement": None,
+        "composition_offset_kwh": 0.0,
+        "composition_offset_reset_at": None,
+        "composition_source_start_date": None,
+        "composition_migration_checked": False,
+    }
+    assert _SiteEnergyRestoreData.from_dict(
+        {
+            "composition_offset_kwh": "bad",
+            "composition_offset_reset_at": 123,
+            "composition_source_start_date": 456,
+            "composition_migration_checked": "true",
+        }
+    ).as_dict() == {
+        "native_value": None,
+        "native_unit_of_measurement": None,
+        "composition_offset_kwh": 0.0,
+        "composition_offset_reset_at": None,
+        "composition_source_start_date": None,
+        "composition_migration_checked": False,
+    }
+    assert (
+        _SiteEnergyRestoreData.from_dict(
+            {
+                "composition_offset_kwh": -1,
+                "composition_offset_reset_at": "2026-08-03T00:00:00+00:00",
+                "composition_migration_checked": True,
+            }
+        ).composition_offset_kwh
+        == 0.0
+    )
+    assert (
+        _SiteEnergyRestoreData.from_dict(
+            {"composition_offset_kwh": float("nan")}
+        ).composition_offset_kwh
+        == 0.0
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Include `battery_grid` and `generator_grid` lifetime channels in the Site Grid Export total instead of reporting solar export alone.
- Preserve existing Home Assistant Energy Dashboard statistics by persisting a one-time composition offset across restarts and clearing it safely when lifetime data resets.
- Extend parsing, availability detection, restore-state handling, regression coverage, and the changelog for the corrected export composition.

Fixes #809.

## Related Issues

- None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api_parsers.py custom_components/enphase_ev/energy.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_site_energy.py && ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api_parsers.py,custom_components/enphase_ev/energy.py,custom_components/enphase_ev/sensor.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/git-main -e GIT_DIR=/git-main/worktrees/ha-enphase-ev-charger4 -e GIT_WORK_TREE=/workspace ha-dev bash -lc "python -m pre_commit run --all-files"
```

Results:

- Integration suite: 3,839 passed.
- Full suite: 3,971 passed, 2 skipped.
- Targeted coverage: 100% for `api_parsers.py`, `energy.py`, and `sensor.py`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- No translation, setup, or option text changed.
- No README or setup documentation change is required because the existing Site Grid Export entity retains its identity and configuration; only its accounting is corrected.
- The migration offset prevents historical battery and generator lifetime totals from appearing as newly exported energy on upgrade, while subsequent battery and generator export increments are included normally.
