### PR TITLE
Handle read-only Grid Profile access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Displayed battery state value `7` as Error on per-battery status entities.
+- Kept the current Grid Profile readable for owner accounts while treating the
+  Activation UI's installer-only response as a read-only capability instead of
+  a recurring endpoint failure, and followed the current cross-origin
+  Activation launch-token format used by Enlighten Settings.
 - Exposed the discharge-to-grid switch and configured window for IQ Battery sites
   that use the `dtgControl` window without per-day schedule rows. (#810)
 - Included battery-to-grid and generator-to-grid energy in the Site Grid Export

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -84,6 +84,22 @@ _ACTIVATION_UI_URL_RE = re.compile(
     r"(?:(?:https?:)?//[^\"'<>\s]+)?/app/activation_ui/\?[^\"'<>\s]+",
     re.IGNORECASE,
 )
+_ACTIVATION_UI_TEMPLATE_RE = re.compile(
+    r"https://activations-ui\.enphaseenergy\.com/?\?[^`\"'<>\s]+",
+    re.IGNORECASE,
+)
+_ACTIVATION_TOKEN_ASSIGNMENT_RE = re.compile(
+    r"\b(?:const|let|var)\s+token\s*=\s*['\"]"
+    r"(?P<token>[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)['\"]",
+    re.IGNORECASE,
+)
+_ACTIVATION_GRID_PROFILE_RE = re.compile(
+    r"Gateway\s*-\s*(?P<serial>[A-Za-z0-9_-]+)\s*</h[1-6]>"
+    r"(?:(?!</div>).){0,2000}?Grid\s+Profile\s*:\s*"
+    r"(?P<name>.*?)(?=<button\b|</div>)",
+    re.IGNORECASE | re.DOTALL,
+)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
 _ENLIGHTEN_READ_CONCURRENCY_LIMIT = 3
 _ENLIGHTEN_OPTIONAL_READ_CONCURRENCY_LIMIT = 2
 _SYSTEM_EVENTS_PAGE_SIZE = 200
@@ -788,12 +804,60 @@ def _activation_context_from_settings_html(
             activation_url = URL(candidate)
         except Exception:  # noqa: BLE001 - malformed unrelated page content
             continue
-        if activation_url.host != URL(BASE_URL).host:
+        if (
+            activation_url.host != URL(BASE_URL).host
+            or activation_url.path != "/app/activation_ui/"
+        ):
             continue
         token = activation_url.query.get("token")
         if token and token.count(".") >= 2:
             return str(token), str(activation_url)
-    return None
+
+    # Current Settings pages create a cross-origin Activation iframe only after
+    # Change is selected. Reconstruct that browser referer from the inert script
+    # template without executing page JavaScript.
+    token_match = _ACTIVATION_TOKEN_ASSIGNMENT_RE.search(normalized)
+    template_match = _ACTIVATION_UI_TEMPLATE_RE.search(normalized)
+    if token_match is None or template_match is None:
+        return None
+    token = token_match.group("token")
+    candidate = template_match.group(0).replace("${token}", token)
+    serial_match = re.search(
+        r"showGridProfileModal\(\s*['\"](?P<serial>[A-Za-z0-9_-]+)['\"]\s*\)",
+        normalized,
+        re.IGNORECASE,
+    )
+    if serial_match is not None:
+        candidate = candidate.replace("${serialnum}", serial_match.group("serial"))
+    if "${" in candidate:
+        return None
+    try:
+        activation_url = URL(candidate)
+    except Exception:  # noqa: BLE001 - malformed unrelated page content
+        return None
+    if (
+        activation_url.host != "activations-ui.enphaseenergy.com"
+        or activation_url.path not in {"", "/"}
+        or activation_url.query.get("token") != token
+    ):
+        return None
+    return token, str(activation_url)
+
+
+def _activation_grid_profiles_from_settings_html(
+    payload: str,
+) -> list[tuple[str, str]]:
+    """Extract read-only Gateway Grid Profile labels from Settings HTML."""
+
+    normalized = unescape(payload).replace(r"\u0026", "&").replace(r"\/", "/")
+    profiles: list[tuple[str, str]] = []
+    for match in _ACTIVATION_GRID_PROFILE_RE.finditer(normalized):
+        serial = match.group("serial").strip()
+        name = _HTML_TAG_RE.sub(" ", match.group("name"))
+        name = " ".join(unescape(name).split())
+        if serial and name:
+            profiles.append((serial, name))
+    return profiles
 
 
 def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
@@ -2115,6 +2179,7 @@ class EnphaseEVClient:
         self._eauth = eauth or None
         self._activation_token: str | None = None
         self._activation_referer: str | None = None
+        self._activation_settings_grid_profiles: list[tuple[str, str]] = []
         self._hems_site_supported: bool | None = None
         self._system_dashboard_summary_payload: dict[str, object] | None = None
         self._reauth_cb: Callable[[], Awaitable[bool]] | None = reauth_callback
@@ -2768,18 +2833,20 @@ class EnphaseEVClient:
         """Return cloud Activation API headers."""
 
         token = self._activation_auth_token()
+        referer = self._activation_referer or (
+            f"{BASE_URL}/app/activation_ui/?system_id={self._site}"
+        )
         headers: dict[str, str | None] = {
             "Accept": "application/json, text/plain, */*",
             "Authorization": f"Bearer {token}" if token else None,
             "Cookie": self._activation_cookie(token),
-            "Referer": self._activation_referer
-            or f"{BASE_URL}/app/activation_ui/?system_id={self._site}",
+            "Referer": referer,
             "X-Requested-With": None,
             "e-auth-token": None,
         }
         if write:
             headers["Content-Type"] = "application/json"
-            headers["Origin"] = BASE_URL
+            headers["Origin"] = str(URL(referer).origin())
         return headers
 
     def _activation_auth_token(self) -> str | None:
@@ -2797,10 +2864,16 @@ class EnphaseEVClient:
         return self._battery_config_single_auth_token()
 
     def _clear_activation_auth_context(self) -> None:
-        """Discard the in-memory Activation JWT and its matching referer."""
+        """Discard the in-memory Activation data tied to the current session."""
 
         self._activation_token = None
         self._activation_referer = None
+        self._activation_settings_grid_profiles = []
+
+    def activation_settings_grid_profiles(self) -> list[tuple[str, str]]:
+        """Return Grid Profile labels visible on the classic Settings page."""
+
+        return list(self._activation_settings_grid_profiles)
 
     def _activation_cookie(self, token: str | None) -> str | None:
         """Return session cookies with the Activation Manager token synchronized."""
@@ -2842,6 +2915,9 @@ class EnphaseEVClient:
                 redact_text(err, site_ids=(self._site,)),
             )
             return False
+        self._activation_settings_grid_profiles = (
+            _activation_grid_profiles_from_settings_html(payload)
+        )
         context = _activation_context_from_settings_html(payload)
         if context is None:
             _LOGGER.debug(

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -136,6 +136,7 @@ from .grid_profile_runtime import (
     ALL_PROFILES_OPTION,
     COMMONLY_USED_OPTION,
     SUPPORT_DENIED,
+    SUPPORT_READ_ONLY,
     GridProfile,
     GridProfileRuntime,
 )
@@ -1778,7 +1779,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[misc]
     def _grid_profile_unavailable_reason(runtime: GridProfileRuntime) -> str:
         return (
             "grid_profile_installer_required"
-            if runtime.support_state == SUPPORT_DENIED
+            if runtime.support_state in {SUPPORT_DENIED, SUPPORT_READ_ONLY}
             else "grid_profile_unavailable"
         )
 

--- a/custom_components/enphase_ev/grid_profile_runtime.py
+++ b/custom_components/enphase_ev/grid_profile_runtime.py
@@ -10,7 +10,7 @@ from typing import Any
 import aiohttp
 from homeassistant.exceptions import ServiceValidationError
 
-from .api import ActivationAccessDenied, Unauthorized
+from .api import ActivationAccessDenied, OptionalEndpointUnavailable, Unauthorized
 from .const import DOMAIN
 from .service_validation import raise_translated_service_validation
 
@@ -18,6 +18,7 @@ ACTIVATION_GRID_PROFILE_FAMILY = "activation_grid_profile"
 SUPPORT_UNKNOWN = "unknown"
 SUPPORT_CONFIRMED = "installer_access_confirmed"
 SUPPORT_DENIED = "installer_access_denied"
+SUPPORT_READ_ONLY = "read_only_available"
 SUPPORT_UNAVAILABLE = "activation_unavailable"
 COMMONLY_USED_OPTION = "commonly_used"
 ALL_PROFILES_OPTION = "all_profiles"
@@ -378,7 +379,15 @@ class GridProfileRuntime:
         source = (
             "ambiguous_gateway"
             if ambiguous_gateway
-            else ("gateway" if target is not None else "activation_record")
+            else (
+                "gateway"
+                if target is not None
+                else (
+                    "enlighten_settings"
+                    if self.support_state == SUPPORT_READ_ONLY
+                    else "activation_record"
+                )
+            )
         )
         profile = self.profile_for_id_in_region(profile_id, self.site_region_code)
         if profile is not None:
@@ -981,12 +990,71 @@ class GridProfileRuntime:
             ACTIVATION_GRID_PROFILE_FAMILY, err
         )
 
-    async def _async_prepare_activation_auth(self) -> None:
+    def _sync_settings_profiles(self) -> bool:
+        """Use read-only Grid Profile labels exposed by classic Settings."""
+
+        getter = getattr(self.client, "activation_settings_grid_profiles", None)
+        if not callable(getter):
+            return False
+        try:
+            profiles = getter()
+        except Exception:  # noqa: BLE001 - optional compatibility surface
+            return False
+        normalized: list[tuple[str, str]] = []
+        if isinstance(profiles, list):
+            for item in profiles:
+                if not isinstance(item, (list, tuple)) or len(item) != 2:
+                    continue
+                serial = _clean_text(item[0])
+                name = _clean_text(item[1])
+                if serial and name:
+                    normalized.append((serial, name))
+        if not normalized:
+            return False
+        names = {name for _serial, name in normalized}
+        self.gateway_targets = {}
+        self.current_profile_id = None
+        self.current_profile_name = next(iter(names)) if len(names) == 1 else None
+        return True
+
+    def _mark_read_only(self) -> None:
+        """Record expected owner access without an endpoint failure."""
+
+        self.support_state = SUPPORT_READ_ONLY
+        self.coordinator._note_endpoint_family_success(
+            ACTIVATION_GRID_PROFILE_FAMILY,
+            success_ttl_s=3600.0,
+        )
+
+    async def _async_prepare_activation_auth(self, *, force: bool = False) -> bool:
         """Allow the client to acquire the settings-page Activation JWT."""
 
         prepare = getattr(self.client, "async_prepare_activation_auth", None)
         if callable(prepare):
-            await prepare()
+            return bool(await prepare(force=force))
+        return False
+
+    async def _async_refresh_read_only_settings(self) -> GridProfileBrowseResult:
+        """Refresh the Settings-derived profile without installer-only calls."""
+
+        try:
+            prepared = await self._async_prepare_activation_auth(force=True)
+        except Exception as err:  # noqa: BLE001
+            self.coordinator._note_endpoint_family_failure(
+                ACTIVATION_GRID_PROFILE_FAMILY, err
+            )
+        else:
+            if prepared and self._sync_settings_profiles():
+                self._mark_read_only()
+            else:
+                self.coordinator._note_endpoint_family_failure(
+                    ACTIVATION_GRID_PROFILE_FAMILY,
+                    OptionalEndpointUnavailable(
+                        "Grid profile was unavailable in Enlighten Settings"
+                    ),
+                )
+        self._publish_state_update()
+        return self.browse()
 
     @staticmethod
     def _is_access_denied(err: Exception) -> bool:
@@ -1014,6 +1082,14 @@ class GridProfileRuntime:
             except Exception as err:  # noqa: BLE001
                 if (
                     self._is_access_denied(err)
+                    and not self.installer_access_ever_confirmed
+                    and self._sync_settings_profiles()
+                ):
+                    self._mark_read_only()
+                    self._publish_state_update()
+                    return self.browse()
+                if (
+                    self._is_access_denied(err)
                     or not self.installer_access_ever_confirmed
                 ):
                     self._mark_denied(err)
@@ -1035,9 +1111,11 @@ class GridProfileRuntime:
             family = ACTIVATION_GRID_PROFILE_FAMILY
             if not self.coordinator._endpoint_family_should_run(family, force=force):
                 return self.browse()
+            if self.support_state == SUPPORT_READ_ONLY and not force:
+                return await self._async_refresh_read_only_settings()
             errors: list[Exception] = []
             successful_requests = 0
-            await self._async_prepare_activation_auth()
+            await self._async_prepare_activation_auth(force=force)
             if force or self.reference_payload is None:
                 try:
                     reference = await self.client.async_get_activation_reference_data()
@@ -1061,6 +1139,13 @@ class GridProfileRuntime:
                 (err for err in errors if self._is_access_denied(err)), None
             )
             if denied_error is not None:
+                if (
+                    not self.installer_access_ever_confirmed
+                    and self._sync_settings_profiles()
+                ):
+                    self._mark_read_only()
+                    self._publish_state_update()
+                    return self.browse()
                 self._mark_denied(denied_error)
                 self._publish_state_update()
                 return self.browse()

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -71,6 +71,7 @@ from .entity import (
 from .labels import friendly_status_text, status_label
 from .log_redaction import redact_text
 from .grid_profile_runtime import (
+    SUPPORT_READ_ONLY,
     SUPPORT_UNKNOWN,
     SUPPORT_UNAVAILABLE,
     GridProfileRuntime,
@@ -194,6 +195,8 @@ def _retain_grid_profile_sensors(coord: EnphaseCoordinator) -> bool:
         return False
     if getattr(runtime, "installer_access_confirmed", False):
         return True
+    if getattr(runtime, "support_state", None) == SUPPORT_READ_ONLY:
+        return bool(runtime.current_profile_display())
     return bool(
         getattr(runtime, "installer_access_ever_confirmed", False)
         and getattr(runtime, "support_state", None) == SUPPORT_UNAVAILABLE
@@ -5807,7 +5810,16 @@ class _GridProfileSensor(_SiteBaseEntity):
     @property
     def available(self) -> bool:
         runtime = self._coord.grid_profile_runtime
-        return bool(super().available and runtime.installer_access_confirmed)
+        return bool(
+            super().available
+            and (
+                runtime.installer_access_confirmed
+                or (
+                    runtime.support_state == SUPPORT_READ_ONLY
+                    and runtime.current_profile_display()
+                )
+            )
+        )
 
 
 class EnphaseCurrentGridProfileSensor(_GridProfileSensor):

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -40,7 +40,7 @@ from .device_types import parse_type_identifier
 from .device_registry_compat import device_config_entry_ids
 from .log_redaction import redact_site_id
 from .parsing_helpers import coerce_optional_bool
-from .grid_profile_runtime import SUPPORT_DENIED, GridProfileRuntime
+from .grid_profile_runtime import SUPPORT_DENIED, SUPPORT_READ_ONLY, GridProfileRuntime
 from .runtime_data import EnphaseRuntimeData, iter_coordinators
 from .service_validation import raise_translated_service_validation
 
@@ -1177,7 +1177,10 @@ def async_setup_services(
     def _require_grid_profile_installer(runtime: object) -> None:
         if getattr(runtime, "installer_access_confirmed", False):
             return
-        if getattr(runtime, "support_state", None) != SUPPORT_DENIED:
+        if getattr(runtime, "support_state", None) not in {
+            SUPPORT_DENIED,
+            SUPPORT_READ_ONLY,
+        }:
             _raise_service_validation(
                 "grid_profile_unavailable",
                 message="Grid profile control is unavailable.",

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -207,7 +207,7 @@ Status labels:
 | BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | BatteryConfig write shape plus `X-XSRF-Token`; ordinary time/limit edits can omit `isEnabled`, while explicit schedule-entry toggle writes may include it; verified working update uses the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) from a stateless client session; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | Runtime |
 | BatteryConfig schedule legacy delete alias | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>/delete` | same BatteryConfig write planner as schedule create/update; cookie-backed browser request is the verified working compatibility shape on affected sites | Runtime |
 | BatteryConfig disclaimer accept | `POST` | `/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/<site_id>` | same BatteryConfig write planner as other battery settings mutations | Runtime |
-| Activation auth bootstrap | `GET` | `/systems/<site_id>/details` | authenticated Enlighten Settings HTML embeds a same-origin `/app/activation_ui/` URL containing the short-lived Activation JWT and exact referer context; token and referer are retained in memory only | Runtime |
+| Activation auth bootstrap | `GET` | `/systems/<site_id>/details` | authenticated Enlighten Settings HTML contains the short-lived Activation JWT and launch context; current pages interpolate it into `https://activations-ui.enphaseenergy.com/`, while older pages embed a same-origin `/app/activation_ui/` URL; token and referer are retained in memory only | Runtime |
 | Activation reference data | `GET` | `/service/activation_service/api/details/reference_data` | authenticated session cookies with `enlighten_manager_token_production` synchronized to the bootstrapped Activation JWT, plus the JWT in `enlm-token`; browser capture did not include an explicit `Authorization` header | Runtime |
 | Activation record | `GET` | `/service/activation_backend/api/gateway/v4/activations/<site_id>?expand=owner,host` | synchronized Activation cookie, exact embedded Activation UI referer, and `Authorization: Bearer <activation_jwt>`; requires account role with Activation access | Runtime |
 | Activation device list and grid-profile status | `GET` | `/service/activation_backend/api/gateway/v4/systems/<site_id>/devices/list` | same synchronized Activation bearer/cookie/referer context; requires installer-level Activation access | Runtime |
@@ -6976,21 +6976,38 @@ Operational constraints:
 GET /systems/<site_id>/details
 ```
 
-The authenticated classic Enlighten Settings HTML contains a same-origin iframe
-URL with this sanitized shape:
+The authenticated classic Enlighten Settings HTML contains the Grid Profile
+label for each Gateway. Current pages also contain an inert launch script with a
+short-lived token and this cross-origin iframe template:
 ```text
-https://enlighten.enphaseenergy.com/app/activation_ui/?locale=<locale>&token=<activation_jwt>&siteid=<site_id>&gridprofile=gridprofile&envoyserialnumber=<gateway_serial>
+https://activations-ui.enphaseenergy.com/?locale=<locale>&token=${token}&siteid=<site_id>&gridprofile=gridprofile&envoyserialnumber=${serialnum}
 ```
 
-The 2026-07-22 browser capture confirmed that requests made by this iframe use
-the query-string JWT both as `Authorization: Bearer <activation_jwt>` and as the
-value of the `enlighten_manager_token_production` cookie. The full iframe URL is
-also sent as the request `Referer`.
+The 2026-08-06 browser capture confirmed this replaced the earlier same-origin
+`/app/activation_ui/` launch shape captured on 2026-07-22. Requests made by the
+iframe use the query-string JWT as `Authorization: Bearer <activation_jwt>` and
+the full interpolated iframe URL as the request `Referer`; the integration also
+synchronizes that JWT into the `enlighten_manager_token_production` cookie for
+the Activation backend requests.
 
 Current runtime behavior:
 - Fetch the Settings page with the authenticated Enlighten session before an Activation refresh, profile-list request, or profile write.
-- HTML-decode the embedded iframe URL and accept it only when its host is `enlighten.enphaseenergy.com` and its path is `/app/activation_ui/`.
-- Retain the extracted JWT and exact iframe referer in memory only. Do not persist either value to config-entry data or diagnostics.
+- HTML-decode the page, accept either the legacy same-origin iframe or the
+  current `activations-ui.enphaseenergy.com` template, and interpolate only the
+  page's validated JWT and concrete Gateway serial into the current template.
+- Derive the write-request `Origin` from that validated referer so current
+  cross-origin launches and legacy same-origin launches each use their matching
+  browser context.
+- Parse the current Grid Profile label already rendered by Settings. If the
+  Activation backend rejects the account as installer-ineligible, retain that
+  label as read-only state and do not record the expected role limitation as an
+  endpoint failure. Refresh read-only labels hourly from Settings without
+  repeating installer-only Activation calls. Profile discovery and apply remain
+  installer/maintainer-only.
+- Retain the extracted JWT, exact iframe referer, and Settings-derived profile
+  labels in memory only. Invalidate them together when credentials or the
+  Activation auth context changes; do not persist them to config-entry data or
+  diagnostics.
 - Replace the `enlighten_manager_token_production` value in the outbound serialized cookie header with the extracted JWT so the cookie and bearer contexts agree, while preserving the other authenticated session cookies.
 - Treat a JWT as expired 60 seconds before its `exp` claim and reacquire it from the Settings page. A normal credential refresh also clears the cached Activation JWT and referer.
 - If the Settings page or embedded token is temporarily unavailable, preserve the original session cookies and fall back to the Manager JWT already present in the cookie, then to the stored Enlighten access token.

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -112,6 +112,7 @@ from custom_components.enphase_ev.grid_profile_runtime import (
     GridProfileRuntime,
     SUPPORT_CONFIRMED,
     SUPPORT_DENIED,
+    SUPPORT_READ_ONLY,
     SUPPORT_UNAVAILABLE,
 )
 
@@ -3337,12 +3338,15 @@ async def test_options_flow_grid_profile_aborts_without_runtime(hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_options_flow_grid_profile_aborts_without_installer_access(hass) -> None:
+@pytest.mark.parametrize("support_state", [SUPPORT_DENIED, SUPPORT_READ_ONLY])
+async def test_options_flow_grid_profile_aborts_without_installer_access(
+    hass, support_state: str
+) -> None:
     entry = MockConfigEntry(domain=DOMAIN, data={CONF_SITE_ID: "12345"})
     entry.runtime_data = SimpleNamespace(
         coordinator=SimpleNamespace(
             grid_profile_runtime=_options_flow_grid_profile_runtime(
-                support_state=SUPPORT_DENIED
+                support_state=support_state
             )
         )
     )

--- a/tests/components/enphase_ev/test_grid_profile_runtime.py
+++ b/tests/components/enphase_ev/test_grid_profile_runtime.py
@@ -25,9 +25,11 @@ from custom_components.enphase_ev.grid_profile_runtime import (
     COMMONLY_USED_OPTION,
     SUPPORT_CONFIRMED,
     SUPPORT_DENIED,
+    SUPPORT_READ_ONLY,
     SUPPORT_UNKNOWN,
     SUPPORT_UNAVAILABLE,
     ActivationRegion,
+    GatewayGridProfileTarget,
     GridProfile,
     GridProfileRuntime,
     _clean_text,
@@ -89,6 +91,12 @@ def test_activation_auth_parser_handles_protocol_relative_and_malformed_urls() -
         )
         is None
     )
+    assert (
+        api._activation_context_from_settings_html(  # noqa: SLF001
+            f"https://enlighten.enphaseenergy.com/not-activation/?token={token}"
+        )
+        is None
+    )
     with patch.object(api, "URL", side_effect=ValueError):
         assert (
             api._activation_context_from_settings_html(  # noqa: SLF001
@@ -98,13 +106,107 @@ def test_activation_auth_parser_handles_protocol_relative_and_malformed_urls() -
         )
 
 
+def test_activation_auth_parser_handles_current_cross_origin_launch_script() -> None:
+    token = "header.payload.signature"
+    payload = f"""
+        <div class="modern_block">
+          <h4>Gateway - 122532006376</h4>
+          Grid Profile: AS/NZS 4777.2: 2020 Australia A Region
+          <button onclick="showGridProfileModal('122532006376')">Change</button>
+        </div>
+        <script>
+          showGridProfileModal = function(serialnum) {{
+            var token = "{token}";
+            document.getElementById("myFrame").src =
+              `https://activations-ui.enphaseenergy.com?locale=en-AU&amp;token=${{token}}&amp;siteid=3381244&amp;gridprofile=gridprofile&amp;envoyserialnumber=${{serialnum}}`;
+          }};
+        </script>
+    """
+
+    assert api._activation_context_from_settings_html(payload) == (  # noqa: SLF001
+        token,
+        "https://activations-ui.enphaseenergy.com/"
+        f"?locale=en-AU&token={token}&siteid=3381244&gridprofile=gridprofile"
+        "&envoyserialnumber=122532006376",
+    )
+    assert api._activation_grid_profiles_from_settings_html(
+        payload
+    ) == [  # noqa: SLF001
+        ("122532006376", "AS/NZS 4777.2: 2020 Australia A Region")
+    ]
+
+
+async def test_activation_auth_bootstrap_caches_settings_profile_labels() -> None:
+    client = _make_api_client()
+    token = "header.payload.signature"
+    client._text = AsyncMock(
+        return_value=f"""
+            <div><h4>Gateway - 122532006376</h4>
+            Grid Profile: Australia A Region <button>Change</button></div>
+            <button onclick="showGridProfileModal('122532006376')">Change</button>
+            <script>var token = "{token}";
+            const url = `https://activations-ui.enphaseenergy.com/?token=${{token}}&envoyserialnumber=${{serialnum}}`;</script>
+        """
+    )  # noqa: SLF001
+
+    assert await client.async_prepare_activation_auth()
+    assert client.activation_settings_grid_profiles() == [
+        ("122532006376", "Australia A Region")
+    ]
+    assert client._activation_headers(write=True)["Origin"] == (  # noqa: SLF001
+        "https://activations-ui.enphaseenergy.com"
+    )
+
+
+def test_activation_auth_parser_rejects_incomplete_cross_origin_template() -> None:
+    token = "header.payload.signature"
+    payload = (
+        f'<script>const token = "{token}"; '
+        "const url = `https://activations-ui.enphaseenergy.com/"
+        "?token=${token}&envoyserialnumber=${serialnum}`;</script>"
+    )
+
+    assert api._activation_context_from_settings_html(payload) is None  # noqa: SLF001
+    assert (
+        api._activation_grid_profiles_from_settings_html(  # noqa: SLF001
+            "<h4>Gateway - serial</h4>Grid Profile: <button>Change</button>"
+        )
+        == []
+    )
+
+    complete_payload = payload.replace(
+        "</script>",
+        "<button onclick=\"showGridProfileModal('gateway')\">Change</button></script>",
+    )
+    with patch.object(api, "URL", side_effect=ValueError):
+        assert (  # noqa: SLF001
+            api._activation_context_from_settings_html(complete_payload) is None
+        )
+    with patch.object(
+        api,
+        "URL",
+        return_value=SimpleNamespace(
+            host="example.com",
+            path="/",
+            query={"token": token},
+        ),
+    ):
+        assert (  # noqa: SLF001
+            api._activation_context_from_settings_html(complete_payload) is None
+        )
+
+
 def test_activation_auth_expired_cached_token_uses_stored_fallback() -> None:
     client = _make_api_client()
     client._activation_token = "header.eyJleHAiOjF9.signature"  # noqa: SLF001
+    client._activation_settings_grid_profiles = [  # noqa: SLF001
+        ("gateway", "Old profile")
+    ]
 
     assert client._activation_auth_token() == "TOKEN"  # noqa: SLF001
     assert client._activation_token is None  # noqa: SLF001
     assert client._activation_referer is None  # noqa: SLF001
+    assert client.activation_settings_grid_profiles() == []
 
 
 @pytest.mark.parametrize(
@@ -409,6 +511,8 @@ async def test_activation_api_validates_response_shapes() -> None:
 class _FakeGridProfileClient:
     def __init__(self) -> None:
         self.activation_auth_prepare_requests = 0
+        self.activation_auth_prepare_forces: list[bool] = []
+        self.settings_grid_profiles: list[tuple[str, str]] = []
         self.profile_requests: list[tuple[str, str, bool]] = []
         self.apply_requests: list[dict[str, object]] = []
         self.reference_payload: dict[str, object] = {
@@ -505,9 +609,13 @@ class _FakeGridProfileClient:
         self.activation_record_requests = 0
         self.activation_device_requests = 0
 
-    async def async_prepare_activation_auth(self) -> bool:
+    async def async_prepare_activation_auth(self, *, force: bool = False) -> bool:
         self.activation_auth_prepare_requests += 1
+        self.activation_auth_prepare_forces.append(force)
         return True
+
+    def activation_settings_grid_profiles(self) -> list[tuple[str, str]]:
+        return list(self.settings_grid_profiles)
 
     async def async_get_activation_reference_data(self) -> dict[str, object]:
         self.reference_requests += 1
@@ -764,6 +872,14 @@ async def test_coordinator_refreshes_grid_profile_metadata_after_first_poll() ->
     coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
     refresh.assert_not_awaited()
 
+    coordinator.grid_profile_runtime.support_state = SUPPORT_READ_ONLY
+    coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
+    task = coordinator._grid_profile_metadata_task
+    assert task is not None
+    await task
+    refresh.assert_awaited_once_with(force=False, load_profiles=True)
+
+    refresh.reset_mock()
     coordinator.grid_profile_runtime.support_state = SUPPORT_CONFIRMED
     coordinator.grid_profile_runtime.async_refresh = None
     await coordinator.async_refresh_grid_profile_metadata()
@@ -914,6 +1030,8 @@ async def test_runtime_denies_feature_when_activation_access_unavailable() -> No
         raise ActivationAccessDenied("denied")
 
     client.async_get_activation_reference_data = denied_reference  # type: ignore[method-assign]
+    client.async_get_activation_record = denied_reference  # type: ignore[method-assign]
+    client.async_get_activation_device_list = denied_reference  # type: ignore[method-assign]
     runtime = GridProfileRuntime(_FakeCoordinator(client))
 
     result = await runtime.async_refresh(force=True)
@@ -921,6 +1039,155 @@ async def test_runtime_denies_feature_when_activation_access_unavailable() -> No
     assert result.support_state == SUPPORT_DENIED
     assert not runtime.installer_access_confirmed
     assert runtime.region_options == []
+
+
+async def test_runtime_retains_read_only_settings_profile_when_activation_denied() -> (
+    None
+):
+    client = _FakeGridProfileClient()
+    client.settings_grid_profiles = [
+        ("122532006376", "AS/NZS 4777.2: 2020 Australia A Region")
+    ]
+
+    activation_calls = 0
+
+    async def denied_reference() -> dict[str, object]:
+        nonlocal activation_calls
+        activation_calls += 1
+        raise ActivationAccessDenied("denied")
+
+    client.async_get_activation_reference_data = denied_reference  # type: ignore[method-assign]
+    client.async_get_activation_record = denied_reference  # type: ignore[method-assign]
+    client.async_get_activation_device_list = denied_reference  # type: ignore[method-assign]
+    coordinator = _FakeCoordinator(client)
+    runtime = GridProfileRuntime(coordinator)
+
+    result = await runtime.async_refresh(force=True)
+
+    assert result.support_state == SUPPORT_READ_ONLY
+    assert runtime.current_profile_display() == (
+        "AS/NZS 4777.2: 2020 Australia A Region"
+    )
+    assert runtime.current_profile_attributes()["source"] == "enlighten_settings"
+    assert coordinator.successes == ["activation_grid_profile"]
+    assert coordinator.failures == []
+
+    client.settings_grid_profiles = [
+        ("122532006376", "AS/NZS 4777.2: 2020 Australia B Region")
+    ]
+    refreshed = await runtime.async_refresh(force=False)
+
+    assert refreshed.support_state == SUPPORT_READ_ONLY
+    assert runtime.current_profile_display() == (
+        "AS/NZS 4777.2: 2020 Australia B Region"
+    )
+    assert activation_calls == 3
+    assert client.activation_auth_prepare_forces == [True, True]
+    assert coordinator.successes == [
+        "activation_grid_profile",
+        "activation_grid_profile",
+    ]
+
+    client.async_get_activation_reference_data = AsyncMock(  # type: ignore[method-assign]
+        return_value=client.reference_payload
+    )
+    client.async_get_activation_record = AsyncMock(  # type: ignore[method-assign]
+        return_value=client.activation_record
+    )
+    client.async_get_activation_device_list = AsyncMock(  # type: ignore[method-assign]
+        return_value={"devices": []}
+    )
+
+    upgraded = await runtime.async_refresh(force=True, load_profiles=False)
+
+    assert upgraded.support_state == SUPPORT_CONFIRMED
+    assert runtime.installer_access_confirmed
+    assert activation_calls == 3
+    assert client.activation_auth_prepare_forces == [True, True, True]
+    client.async_get_activation_reference_data.assert_awaited_once()  # type: ignore[attr-defined]
+    client.async_get_activation_record.assert_awaited_once()  # type: ignore[attr-defined]
+    client.async_get_activation_device_list.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize("prepare_failure", [False, RuntimeError("unavailable")])
+async def test_runtime_read_only_refresh_preserves_stale_profile_on_settings_failure(
+    prepare_failure: bool | Exception,
+) -> None:
+    client = _FakeGridProfileClient()
+    client.settings_grid_profiles = [("gateway", "Australia A Region")]
+    client.async_prepare_activation_auth = AsyncMock(  # type: ignore[method-assign]
+        side_effect=(
+            prepare_failure if isinstance(prepare_failure, Exception) else None
+        ),
+        return_value=prepare_failure if isinstance(prepare_failure, bool) else None,
+    )
+    coordinator = _FakeCoordinator(client)
+    runtime = GridProfileRuntime(coordinator)
+    runtime.support_state = SUPPORT_READ_ONLY
+    runtime.current_profile_name = "Australia A Region"
+
+    result = await runtime.async_refresh(force=False)
+
+    assert result.support_state == SUPPORT_READ_ONLY
+    assert runtime.current_profile_display() == "Australia A Region"
+    assert len(coordinator.failures) == 1
+    assert coordinator.failures[0][0] == "activation_grid_profile"
+    client.async_prepare_activation_auth.assert_awaited_once_with(force=True)  # type: ignore[attr-defined]
+
+
+async def test_runtime_status_refresh_retains_read_only_settings_profile() -> None:
+    client = _FakeGridProfileClient()
+    client.settings_grid_profiles = [
+        ("gateway-a", "Australia A Region"),
+        ("gateway-b", "Australia A Region"),
+    ]
+
+    async def denied_devices() -> dict[str, object]:
+        raise ActivationAccessDenied("denied")
+
+    client.async_get_activation_device_list = denied_devices  # type: ignore[method-assign]
+    coordinator = _FakeCoordinator(client)
+    runtime = GridProfileRuntime(coordinator)
+
+    result = await runtime.async_refresh_device_status(force=True)
+
+    assert result.support_state == SUPPORT_READ_ONLY
+    assert runtime.current_profile_display() == "Australia A Region"
+    assert coordinator.failures == []
+
+    client.settings_grid_profiles = [
+        ("gateway-a", "Australia A Region"),
+        ("gateway-b", "Australia B Region"),
+    ]
+    runtime.gateway_targets["stale-gateway"] = GatewayGridProfileTarget(
+        serial_num="stale-gateway",
+        part_num=None,
+        ensemble_envoy=False,
+        current_profile_name="Stale profile",
+    )
+    assert runtime._sync_settings_profiles()  # noqa: SLF001
+    assert runtime.current_profile_display() is None
+    assert runtime.gateway_targets == {}
+
+
+async def test_runtime_settings_profile_compatibility_edge_paths() -> None:
+    without_getter = GridProfileRuntime(SimpleNamespace(client=object()))
+    assert not without_getter._sync_settings_profiles()  # noqa: SLF001
+    assert not await without_getter._async_prepare_activation_auth()  # noqa: SLF001
+
+    raising_client = SimpleNamespace(
+        activation_settings_grid_profiles=lambda: (_ for _ in ()).throw(
+            RuntimeError("failed")
+        )
+    )
+    raising = GridProfileRuntime(SimpleNamespace(client=raising_client))
+    assert not raising._sync_settings_profiles()  # noqa: SLF001
+
+    malformed_client = SimpleNamespace(
+        activation_settings_grid_profiles=lambda: [None, ("only-one",)]
+    )
+    malformed = GridProfileRuntime(SimpleNamespace(client=malformed_client))
+    assert not malformed._sync_settings_profiles()  # noqa: SLF001
 
 
 async def test_runtime_marks_optional_activation_failure_unavailable() -> None:
@@ -1172,6 +1439,7 @@ def test_grid_profile_sensor_survives_only_transient_unavailability() -> None:
         installer_access_confirmed=False,
         installer_access_ever_confirmed=True,
         support_state=SUPPORT_UNAVAILABLE,
+        current_profile_display=lambda: None,
     )
     coordinator = SimpleNamespace(grid_profile_runtime=runtime)
 
@@ -1179,6 +1447,10 @@ def test_grid_profile_sensor_survives_only_transient_unavailability() -> None:
 
     runtime.support_state = SUPPORT_DENIED
     assert not _retain_grid_profile_sensors(coordinator)
+
+    runtime.support_state = SUPPORT_READ_ONLY
+    runtime.current_profile_display = lambda: "AS/NZS 4777.2"
+    assert _retain_grid_profile_sensors(coordinator)
 
     runtime.support_state = SUPPORT_UNAVAILABLE
     runtime.installer_access_ever_confirmed = False

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -132,6 +132,9 @@ async def test_async_setup_entry_registers_entities(
     assert grid_profile.available
     assert grid_profile.native_value == "Australia A Region (1.3.12)"
     assert grid_profile.extra_state_attributes == {"profile_id": "agf:current"}
+    coord.grid_profile_runtime.installer_access_confirmed = False
+    coord.grid_profile_runtime.support_state = "read_only_available"
+    assert grid_profile.available
 
     sync_topology_cb = next(
         cb for cb in callbacks if cb.__name__ == "_async_sync_topology"

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -22,6 +22,7 @@ from custom_components.enphase_ev.api import (
 from custom_components.enphase_ev.const import CONF_SITE_ID, CONF_SITE_ONLY, DOMAIN
 from custom_components.enphase_ev.grid_profile_runtime import (
     SUPPORT_DENIED,
+    SUPPORT_READ_ONLY,
     SUPPORT_UNAVAILABLE,
 )
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
@@ -240,13 +241,14 @@ def test_grid_mode_automation_blueprint_uses_config_entry_routing() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("support_state", [SUPPORT_DENIED, SUPPORT_READ_ONLY])
 async def test_grid_profile_browse_services_require_installer_access(
-    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch, support_state: str
 ) -> None:
     handlers = _register_service_handlers(hass, monkeypatch)
     runtime = SimpleNamespace(
         installer_access_confirmed=False,
-        support_state=SUPPORT_DENIED,
+        support_state=support_state,
         async_refresh=AsyncMock(),
         async_load_profiles=AsyncMock(),
     )


### PR DESCRIPTION
## Summary

- Read the current Grid Profile from the authenticated Enlighten Settings page when the Activation backend rejects an owner account as installer-ineligible.
- Support the current cross-origin Activation launch-token and referer format while retaining the legacy same-origin format.
- Expose the Settings-derived profile as read-only Home Assistant state without recording expected installer-role denials as recurring endpoint failures.
- Refresh read-only values hourly without repeating installer-only calls, invalidate auth-bound caches safely, and allow forced refreshes to detect later installer access.

## Related Issues

- None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pip install --quiet black==25.9.0 && black tests/components/enphase_ev/test_grid_profile_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pip install --quiet ruff==0.6.9 && ruff check . && black --check custom_components/enphase_ev/api.py custom_components/enphase_ev/config_flow.py custom_components/enphase_ev/grid_profile_runtime.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/services.py tests/components/enphase_ev/test_config_flow_coverage.py tests/components/enphase_ev/test_grid_profile_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py tests/components/enphase_ev/test_services.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/grid_profile_runtime.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/services.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/.codex/worktrees/79be/ha-enphase-ev-charger:/Users/james/.codex/worktrees/79be/ha-enphase-ev-charger -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
```

Results:

- Integration suite: 3,877 passed.
- Full repository suite: 4,009 passed, 2 skipped.
- Targeted coverage: 100% for every touched Python module.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (No user-facing strings changed.)
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The supplied diagnostics and signed-in Settings flow showed that the owner account can read the installed Grid Profile in Enlighten Settings while the embedded Activation application rejects installer-only feature applicability. This change treats that combination as a read-only capability and keeps profile discovery/application restricted to installer or maintainer accounts.
