### PR TITLE
Fix PowerMatch battery setting writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v4.2.1 - 2026-08-06
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Sent the exact first-party `powerMatch` BatteryConfig payload for PowerMatch
+  changes across every authentication attempt, preventing Enphase from silently
+  ignoring the previous merged `powerMatchControl` payload.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `4.2.1`.
+
 ## v4.2.0 - 2026-08-06
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -3975,6 +3975,7 @@ class EnphaseEVClient:
         write_intent: str = "generic",
         supports_mqtt: bool | None = None,
         strip_devices: bool = False,
+        partial_payload_only: bool = False,
     ) -> JsonDict:
         """Issue a BatteryConfig write using endpoint-specific compatibility attempts."""
 
@@ -3986,6 +3987,8 @@ class EnphaseEVClient:
             params=params,
             json_body=json_body,
         )
+        if partial_payload_only:
+            attempts = [attempt for attempt in attempts if not attempt.merged_payload]
         if strip_devices:
             attempts = [replace(attempt, strip_devices=True) for attempt in attempts]
         last_error: aiohttp.ClientResponseError | None = None
@@ -6106,6 +6109,7 @@ class EnphaseEVClient:
         include_source: bool = True,
         merged_payload: bool = False,
         strip_devices: bool = False,
+        partial_payload_only: bool = False,
     ) -> JsonDict:
         """Update battery settings using an explicit compatibility payload shape."""
 
@@ -6128,6 +6132,7 @@ class EnphaseEVClient:
             write_intent="battery_settings_update",
             supports_mqtt=self._battery_config_supports_mqtt,
             strip_devices=strip_devices,
+            partial_payload_only=partial_payload_only,
         )
 
     async def set_battery_profile(

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -2341,6 +2341,7 @@ class BatteryRuntime:
         include_source: bool = True,
         merged_payload: bool = False,
         strip_devices: bool = False,
+        partial_payload_only: bool = False,
         request_refresh: bool = True,
     ) -> None:
         coord = self.coordinator
@@ -2354,13 +2355,23 @@ class BatteryRuntime:
         async with state._battery_settings_write_lock:
             state._battery_settings_last_write_mono = time.monotonic()
             try:
-                await coord.client.set_battery_settings_compat(
-                    payload,
-                    schedule_type=schedule_type,
-                    include_source=include_source,
-                    merged_payload=merged_payload,
-                    strip_devices=strip_devices,
-                )
+                if partial_payload_only:
+                    await coord.client.set_battery_settings_compat(
+                        payload,
+                        schedule_type=schedule_type,
+                        include_source=include_source,
+                        merged_payload=merged_payload,
+                        strip_devices=strip_devices,
+                        partial_payload_only=True,
+                    )
+                else:
+                    await coord.client.set_battery_settings_compat(
+                        payload,
+                        schedule_type=schedule_type,
+                        include_source=include_source,
+                        merged_payload=merged_payload,
+                        strip_devices=strip_devices,
+                    )
             except aiohttp.ClientResponseError as err:
                 if err.status == HTTPStatus.FORBIDDEN:
                     self._raise_validation(
@@ -4406,27 +4417,21 @@ class BatteryRuntime:
             return
         previous_control = state._battery_power_match_control
 
+        payload: dict[str, object] = {"powerMatch": target}
         await self.async_apply_battery_settings_compat(
-            {"powerMatchControl": {"enabled": target}},
-            merged_payload=True,
+            payload,
             strip_devices=True,
+            partial_payload_only=True,
             request_refresh=False,
         )
 
-        authoritative_refresh_observed = False
-        for attempt in range(4):
-            refreshed = await self.async_refresh_battery_settings(force=True)
-            authoritative_refresh_observed |= refreshed
-            if (
-                refreshed
-                and coord.power_match_control_available
-                and coord.battery_power_match_enabled is target
-            ):
-                self.clear_battery_settings_write_pending()
-                coord.publish_runtime_state_update("power_match")
-                return
-            if attempt < 3:
-                await asyncio.sleep(0.75)
+        confirmed, authoritative_refresh_observed = (
+            await self._async_confirm_power_match(target)
+        )
+        if confirmed:
+            self.clear_battery_settings_write_pending()
+            coord.publish_runtime_state_update("power_match")
+            return
 
         if not authoritative_refresh_observed:
             state._battery_power_match_control = previous_control
@@ -4436,6 +4441,24 @@ class BatteryRuntime:
             "power_match_toggle_not_applied",
             message="PowerMatch toggle was not applied by Enphase.",
         )
+
+    async def _async_confirm_power_match(self, target: bool) -> tuple[bool, bool]:
+        """Confirm a PowerMatch write and report whether any read succeeded."""
+
+        coord = self.coordinator
+        authoritative_refresh_observed = False
+        for attempt in range(4):
+            refreshed = await self.async_refresh_battery_settings(force=True)
+            authoritative_refresh_observed |= refreshed
+            if (
+                refreshed
+                and coord.power_match_control_available
+                and coord.battery_power_match_enabled is target
+            ):
+                return True, True
+            if attempt < 3:
+                await asyncio.sleep(0.75)
+        return False, authoritative_refresh_observed
 
     async def async_set_charge_from_grid_schedule_enabled(self, enabled: bool) -> None:
         coord = self.coordinator

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "4.2.0"
+  "version": "4.2.1"
 }

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -6380,12 +6380,12 @@ Example payloads observed:
 ```
 
 ```json
-{ "powerMatchControl": { "enabled": true } }
+{ "powerMatch": true }
 ```
 
 PowerMatch implementation notes:
 - The runtime treats `batterySettings.data.powerMatchControl` as the sole capability and state source. The switch is offered only when `show=true`, `enabled` is Boolean, and `locked` is not `true`.
-- PowerMatch writes merge `powerMatchControl.enabled` into the latest allowlisted BatteryConfig settings payload so other control fields and unrelated settings are preserved.
+- PowerMatch writes send the first-party `{ "powerMatch": <boolean> }` payload unchanged across authentication retries. Stateful merged-payload attempts are disabled for this control.
 - The separate `/app-api/<site_id>/powermatch_details` route remains unused because captured evidence establishes only UI visibility/state flags, not writable backend semantics.
 
 ```json

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -7029,6 +7029,43 @@ async def test_battery_config_write_request_strips_devices_from_stateful_attempt
 
 
 @pytest.mark.asyncio
+async def test_power_match_partial_payload_skips_cached_stateful_attempt() -> None:
+    client = _make_client()
+    client._battery_config_supports_mqtt = True  # noqa: SLF001
+    client._remember_battery_config_write_base(  # noqa: SLF001
+        "battery_settings",
+        {
+            "data": {
+                "powerMatchControl": {"show": True, "enabled": False},
+                "devices": {"iqEvse": {"enabled": True}},
+            }
+        },
+    )
+    client._cache_battery_config_write_attempt(  # noqa: SLF001
+        "battery_settings",
+        "battery_settings_stateful_primary_source",
+        supports_mqtt=True,
+    )
+    client._acquire_xsrf_token = AsyncMock(return_value="token")  # noqa: SLF001
+    client._battery_config_attempt_headers = MagicMock(return_value={})  # noqa: SLF001
+    client._json = AsyncMock(return_value={"message": "success"})  # noqa: SLF001
+
+    await client.set_battery_settings_compat(
+        {"powerMatch": True},
+        strip_devices=True,
+        partial_payload_only=True,
+    )
+
+    assert client._json.await_args.kwargs["json"] == {
+        "powerMatch": True
+    }  # noqa: SLF001
+    assert (
+        client._json.await_args.kwargs["debug_battery_attempt_id"]  # noqa: SLF001
+        == "battery_settings_primary_source"
+    )
+
+
+@pytest.mark.asyncio
 async def test_cancel_battery_profile_update_uses_empty_body() -> None:
     token = _make_token({"user_id": "44"})
     client = _make_client()

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -1090,7 +1090,7 @@ async def test_set_charge_from_grid_disable_omits_disclaimer(
 
 
 @pytest.mark.asyncio
-async def test_set_power_match_uses_fresh_merged_settings_and_confirms(
+async def test_set_power_match_uses_partial_payload_and_confirms(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -1123,11 +1123,12 @@ async def test_set_power_match_uses_fresh_merged_settings_and_confirms(
     await coord.battery_runtime.async_set_power_match(True)
 
     coord.client.set_battery_settings_compat.assert_awaited_once_with(
-        {"powerMatchControl": {"enabled": True}},
+        {"powerMatch": True},
         schedule_type="cfg",
         include_source=True,
-        merged_payload=True,
+        merged_payload=False,
         strip_devices=True,
+        partial_payload_only=True,
     )
     assert coord.client.battery_settings_details.await_count == 2
     assert coord.battery_power_match_enabled is True
@@ -1209,12 +1210,19 @@ async def test_set_power_match_rejects_unconfirmed_server_state(
     monkeypatch.setattr(
         "custom_components.enphase_ev.battery_runtime.asyncio.sleep", sleep
     )
-
     with pytest.raises(ServiceValidationError, match="was not applied"):
         await coord.battery_runtime.async_set_power_match(True)
 
     assert coord.client.battery_settings_details.await_count == 5
     assert sleep.await_count == 3
+    coord.client.set_battery_settings_compat.assert_awaited_once_with(
+        {"powerMatch": True},
+        schedule_type="cfg",
+        include_source=True,
+        merged_payload=False,
+        strip_devices=True,
+        partial_payload_only=True,
+    )
     assert coord.battery_power_match_enabled is False
     assert coord.battery_settings_write_pending is False
     coord.publish_runtime_state_update.assert_called_once_with("power_match")
@@ -1269,6 +1277,14 @@ async def test_set_power_match_restores_authoritative_state_when_confirmation_fa
         "force_schedule_opted": None,
     }
     assert coord.battery_settings_write_pending is False
+    coord.client.set_battery_settings_compat.assert_awaited_once_with(
+        {"powerMatch": True},
+        schedule_type="cfg",
+        include_source=True,
+        merged_payload=False,
+        strip_devices=True,
+        partial_payload_only=True,
+    )
     coord.async_request_refresh.assert_not_awaited()
     coord.publish_runtime_state_update.assert_called_once_with("power_match")
 


### PR DESCRIPTION
## Summary

Fix PowerMatch updates that Enphase acknowledged but silently ignored by sending the first-party `{"powerMatch": <boolean>}` payload unchanged across every authentication attempt.

The BatteryConfig retry planner now excludes stateful merged-payload attempts for strict partial writes, so a cached compatibility strategy cannot rewrite PowerMatch requests. The runtime continues to confirm the authoritative state after each update. The integration version is bumped to 4.2.1 and the API documentation and changelog are updated.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git status --short && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pip install --quiet ruff==0.6.9 && ruff check . && black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_settings.py && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/battery_runtime.py --fail-under=100 && pytest -q tests/components/enphase_ev/test_service_translations.py && pytest -q"
```

Results:

- 4,010 tests passed, 2 skipped.
- 3,878 integration tests passed.
- 43 service-translation tests passed.
- 100% coverage for `api.py` and `battery_runtime.py`.
- Live Enphase verification: `{"powerMatch":true}` and `{"powerMatch":false}` both returned HTTP 200 and persisted after reload.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The original failure returned a successful HTTP response but left `powerMatchControl.enabled` unchanged. Browser capture of the first-party Enphase UI established that both directions use the scalar `powerMatch` field.
