### PR TITLE
Recover Grid Profile access after live reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Retried owner-access Grid Profile discovery through Enlighten Settings after a
+  preserved installer-access denial, and kept that non-degrading denial out of
+  the Service Status failure details.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -145,7 +145,7 @@ from .evse_runtime import (
     evse_power_is_actively_charging,
 )
 from .evse_power import build_evse_power_snapshot
-from .grid_profile_runtime import SUPPORT_DENIED, SUPPORT_UNKNOWN, GridProfileRuntime
+from .grid_profile_runtime import SUPPORT_UNKNOWN, GridProfileRuntime
 from .heatpump_runtime import HeatpumpRuntime
 from .inventory_runtime import CoordinatorTopologySnapshot, InventoryRuntime
 from .inventory_view import InventoryView
@@ -4033,10 +4033,7 @@ class EnphaseCoordinator(
         if context.first_refresh:
             return
         runtime = self.grid_profile_runtime
-        if getattr(runtime, "support_state", SUPPORT_UNKNOWN) in {
-            SUPPORT_UNKNOWN,
-            SUPPORT_DENIED,
-        }:
+        if getattr(runtime, "support_state", SUPPORT_UNKNOWN) == SUPPORT_UNKNOWN:
             return
         task = self._grid_profile_metadata_task
         if task is not None and not task.done():

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -1115,7 +1115,8 @@ class CoordinatorDiagnostics:
                 "retry_utc": state.get("next_retry_utc"),
             }
             for family, state in endpoint_family_health.items()
-            if isinstance(state, dict)
+            if family not in _NON_DEGRADING_OPTIONAL_ENDPOINT_FAMILIES
+            and isinstance(state, dict)
             and isinstance(state.get("last_error"), str)
             and bool(state.get("last_error"))
         }

--- a/custom_components/enphase_ev/grid_profile_runtime.py
+++ b/custom_components/enphase_ev/grid_profile_runtime.py
@@ -1111,7 +1111,13 @@ class GridProfileRuntime:
             family = ACTIVATION_GRID_PROFILE_FAMILY
             if not self.coordinator._endpoint_family_should_run(family, force=force):
                 return self.browse()
-            if self.support_state == SUPPORT_READ_ONLY and not force:
+            if not force and (
+                self.support_state == SUPPORT_READ_ONLY
+                or (
+                    self.support_state == SUPPORT_DENIED
+                    and not self.installer_access_ever_confirmed
+                )
+            ):
                 return await self._async_refresh_read_only_settings()
             errors: list[Exception] = []
             successful_requests = 0

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -329,7 +329,7 @@ def test_grid_profile_failure_does_not_degrade_service(
     )
     assert metrics["degraded_endpoint_families"] == []
     assert "activation_grid_profile" not in metrics["degraded_services"]
-    assert "activation_grid_profile" in metrics["endpoint_failure_details"]
+    assert "activation_grid_profile" not in metrics["endpoint_failure_details"]
 
 
 def test_degraded_endpoint_family_rollup_tolerates_unexpected_health(

--- a/tests/components/enphase_ev/test_grid_profile_runtime.py
+++ b/tests/components/enphase_ev/test_grid_profile_runtime.py
@@ -868,10 +868,16 @@ async def test_coordinator_refreshes_grid_profile_metadata_after_first_poll() ->
     refresh.reset_mock()
     coordinator.grid_profile_runtime.support_state = SUPPORT_UNKNOWN
     coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
-    coordinator.grid_profile_runtime.support_state = SUPPORT_DENIED
-    coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
     refresh.assert_not_awaited()
 
+    coordinator.grid_profile_runtime.support_state = SUPPORT_DENIED
+    coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
+    task = coordinator._grid_profile_metadata_task
+    assert task is not None
+    await task
+    refresh.assert_awaited_once_with(force=False, load_profiles=True)
+
+    refresh.reset_mock()
     coordinator.grid_profile_runtime.support_state = SUPPORT_READ_ONLY
     coordinator._schedule_grid_profile_metadata_refresh(steady_refresh)
     task = coordinator._grid_profile_metadata_task
@@ -1107,6 +1113,51 @@ async def test_runtime_retains_read_only_settings_profile_when_activation_denied
     client.async_get_activation_reference_data.assert_awaited_once()  # type: ignore[attr-defined]
     client.async_get_activation_record.assert_awaited_once()  # type: ignore[attr-defined]
     client.async_get_activation_device_list.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+async def test_runtime_recovers_preserved_denied_state_from_settings() -> None:
+    client = _FakeGridProfileClient()
+    client.settings_grid_profiles = [
+        ("122532006376", "AS/NZS 4777.2: 2020 Australia A Region")
+    ]
+    client.async_get_activation_reference_data = AsyncMock()  # type: ignore[method-assign]
+    client.async_get_activation_record = AsyncMock()  # type: ignore[method-assign]
+    client.async_get_activation_device_list = AsyncMock()  # type: ignore[method-assign]
+    coordinator = _FakeCoordinator(client)
+    runtime = GridProfileRuntime(coordinator)
+    runtime.support_state = SUPPORT_DENIED
+
+    result = await runtime.async_refresh(force=False)
+
+    assert result.support_state == SUPPORT_READ_ONLY
+    assert runtime.current_profile_display() == (
+        "AS/NZS 4777.2: 2020 Australia A Region"
+    )
+    assert coordinator.successes == ["activation_grid_profile"]
+    assert coordinator.failures == []
+    assert client.activation_auth_prepare_forces == [True]
+    client.async_get_activation_reference_data.assert_not_awaited()  # type: ignore[attr-defined]
+    client.async_get_activation_record.assert_not_awaited()  # type: ignore[attr-defined]
+    client.async_get_activation_device_list.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+async def test_runtime_retries_activation_for_previously_confirmed_installer() -> None:
+    client = _FakeGridProfileClient()
+    coordinator = _FakeCoordinator(client)
+    runtime = GridProfileRuntime(coordinator)
+    runtime.support_state = SUPPORT_DENIED
+    runtime.installer_access_ever_confirmed = True
+
+    result = await runtime.async_refresh(force=False, load_profiles=False)
+
+    assert result.support_state == SUPPORT_CONFIRMED
+    assert runtime.installer_access_confirmed
+    assert client.activation_auth_prepare_forces == [False]
+    assert client.reference_requests == 1
+    assert client.activation_record_requests == 1
+    assert client.activation_device_requests == 1
+    assert coordinator.successes == ["activation_grid_profile"]
+    assert coordinator.failures == []
 
 
 @pytest.mark.parametrize("prepare_failure", [False, RuntimeError("unavailable")])


### PR DESCRIPTION
## Summary

Recover owner-visible Grid Profile discovery after a live integration reload preserves an earlier installer-access denial.

The preserved runtime previously skipped all background Grid Profile refreshes while denied, leaving an expired cooldown and stale access-denied detail indefinitely. Denied owner accounts now retry through the read-only Enlighten Settings surface, while previously confirmed installer accounts retain the full Activation retry path. Expected Grid Profile access denials are also omitted from Service Status failure details because this optional family does not degrade the site service.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_grid_profile_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/grid_profile_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

- Integration package: 3,880 passed.
- Full suite: 4,012 passed, 2 skipped.
- Touched modules: 100% coverage.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation behavior remains accurate; no README or docs changes were required.
- [x] No translation keys or locale files changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The supplied diagnostics showed `activation_grid_profile` retaining a two-day-old `Activation access denied` failure and an expired retry timestamp while the current degraded service and endpoint-family counts were both zero. The runtime had been reused across a live reload, but denied states were excluded from background metadata refresh scheduling.

The development image's unpinned direct `ruff check .` currently reports pre-existing baseline violations across `origin/main`. The repository-pinned Ruff hook in `pre-commit run --all-files` passed across all files.
