### PR TITLE
Add current power consumption sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- None
+- Added a default-enabled Current Power Consumption sensor calculated from
+  consecutive Enphase consumption-energy buckets. The five-minute average uses
+  source timestamps and avoids negative values caused by combining independently
+  updated production, grid, and battery sensors.
 
 ### 🐛 Bug fixes
 - Retried owner-access Grid Profile discovery through Enlighten Settings after a

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - EV charging controls and session telemetry, including charge-mode aware behavior and persistent default charge-level controls when exposed by Enphase
 - Advisory firmware update entities for gateway and EV charger devices with locale-aware release-note links; the gateway entity also monitors read-only live update progress, percentage, timing, and sanitized component status when Enphase exposes it
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
-- Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
+- Site and battery energy telemetry, including a non-negative Current Power Consumption sensor averaged from Enphase consumption buckets, plus derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
 - Optional IQ Battery Scheduler controls and CFG, DTG, and RBD schedule sensors
 - Capability-gated PowerMatch cloud control for supported IQ Battery sites with permitted BatteryConfig write access
 - Optional current site weather on the Enphase Cloud device, created only when the authenticated Enphase weather endpoint is available

--- a/custom_components/enphase_ev/energy.py
+++ b/custom_components/enphase_ev/energy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -54,6 +55,9 @@ class SiteEnergyFlow:
     last_reset_at: str | None = None
     interval_minutes: float | None = None
     legacy_offset_kwh: float = 0.0
+    latest_bucket_wh: float | None = None
+    previous_bucket_wh: float | None = None
+    raw_bucket_count: int = 0
 
 
 class EnergyManager:
@@ -286,6 +290,26 @@ class EnergyManager:
             count += 1
         return total, count
 
+    def _latest_energy_buckets(
+        self, values: object
+    ) -> tuple[float | None, float | None, int]:
+        """Return the latest two valid-position bucket values and raw length."""
+
+        if not isinstance(values, list) or not values:
+            return None, None, 0
+
+        def _bucket_at(index: int) -> float | None:
+            numeric = self._coerce_energy_value(values[index])
+            if numeric is None or not math.isfinite(numeric) or numeric < 0:
+                return None
+            return numeric
+
+        return (
+            _bucket_at(-1),
+            _bucket_at(-2) if len(values) > 1 else None,
+            len(values),
+        )
+
     def _sum_energy_fields(
         self,
         payload: dict[str, object],
@@ -516,6 +540,9 @@ class EnergyManager:
             *,
             allow_zero: bool = False,
             legacy_offset_wh: float = 0.0,
+            latest_bucket_wh: float | None = None,
+            previous_bucket_wh: float | None = None,
+            raw_bucket_count: int = 0,
         ) -> None:
             if bucket_count <= 0 or total_wh < 0:
                 return
@@ -549,6 +576,9 @@ class EnergyManager:
                 last_reset_at=last_reset,
                 interval_minutes=interval_minutes,
                 legacy_offset_kwh=round(legacy_offset_wh / 1000.0, 3),
+                latest_bucket_wh=latest_bucket_wh,
+                previous_bucket_wh=previous_bucket_wh,
+                raw_bucket_count=raw_bucket_count,
             )
             if last_reset:
                 self._site_energy_last_reset[flow] = last_reset
@@ -563,7 +593,19 @@ class EnergyManager:
         cons_total, cons_count = self._sum_energy_buckets(
             payload.get("consumption"), interval_hours
         )
-        _store("consumption", cons_total, ["consumption"], cons_count)
+        cons_latest, cons_previous, cons_raw_count = self._latest_energy_buckets(
+            payload.get("consumption")
+        )
+        _store(
+            "consumption",
+            cons_total,
+            ["consumption"],
+            cons_count,
+            allow_zero=True,
+            latest_bucket_wh=cons_latest,
+            previous_bucket_wh=cons_previous,
+            raw_bucket_count=cons_raw_count,
+        )
 
         # EVSE lifetime charging energy when the backend provides a dedicated flow.
         evse_total, evse_count = self._sum_energy_buckets(

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -585,6 +585,13 @@ async def async_setup_entry(
             "current_production_power",
             EnphaseCurrentPowerConsumptionSensor(coord),
         )
+        if _site_lifetime_power_channel_present("consumption"):
+            _add_site_entity(
+                "site_consumption_power",
+                EnphaseSiteConsumptionPowerSensor(coord),
+            )
+        else:
+            _async_remove_site_sensor_entity("site_consumption_power")
         if _site_lifetime_power_channel_present(
             "grid_import"
         ) or _site_lifetime_power_channel_present("grid_export"):
@@ -1550,6 +1557,60 @@ class _SiteLifetimePowerRestoreData(ExtraStoredData):  # type: ignore[misc]
             ),
             last_live_flow_sources=_source_map("last_live_flow_sources"),
             previous_live_flow_sources=_source_map("previous_live_flow_sources"),
+        )
+
+
+@dataclass
+class _SiteConsumptionPowerRestoreData(ExtraStoredData):  # type: ignore[misc]
+    """Persist a validated site-consumption bucket baseline across restarts."""
+
+    latest_bucket_wh: float | None
+    raw_bucket_count: int | None
+    start_date: str | None
+    energy_ts: float | None
+    interval_minutes: float | None
+    last_power_w: int | None
+    last_window_seconds: float | None
+    method: str | None
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "latest_bucket_wh": self.latest_bucket_wh,
+            "raw_bucket_count": self.raw_bucket_count,
+            "start_date": self.start_date,
+            "energy_ts": self.energy_ts,
+            "interval_minutes": self.interval_minutes,
+            "last_power_w": self.last_power_w,
+            "last_window_seconds": self.last_window_seconds,
+            "method": self.method,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any] | None) -> _SiteConsumptionPowerRestoreData:
+        if not isinstance(data, dict):
+            return cls(None, None, None, None, None, None, None, None)
+
+        def _as_float(value: object) -> float | None:
+            try:
+                numeric = float(value)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                return None
+            return numeric if math.isfinite(numeric) else None
+
+        def _as_int(value: object) -> int | None:
+            return _restore_optional_int_value(value)
+
+        start_date = data.get("start_date")
+        method = data.get("method")
+        return cls(
+            latest_bucket_wh=_as_float(data.get("latest_bucket_wh")),
+            raw_bucket_count=_as_int(data.get("raw_bucket_count")),
+            start_date=start_date if isinstance(start_date, str) else None,
+            energy_ts=_as_float(data.get("energy_ts")),
+            interval_minutes=_as_float(data.get("interval_minutes")),
+            last_power_w=_as_int(data.get("last_power_w")),
+            last_window_seconds=_as_float(data.get("last_window_seconds")),
+            method=method if isinstance(method, str) else None,
         )
 
 
@@ -5723,6 +5784,335 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):  # type: 
             last_live_interval_minutes=self._last_live_interval_minutes,
             last_live_flow_sources=dict(self._last_live_flow_sources),
             previous_live_flow_sources=dict(self._previous_live_flow_sources),
+        )
+
+
+class EnphaseSiteConsumptionPowerSensor(_SiteBaseEntity, RestoreEntity):  # type: ignore[misc]
+    """Average site consumption from consecutive authoritative energy buckets."""
+
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_registry_enabled_default = True
+    _attr_translation_key = "site_consumption_power"
+    _unrecorded_attributes = _SiteBaseEntity._unrecorded_attributes | frozenset(
+        {"sampled_at_utc", "last_window_seconds", "method"}
+    )
+
+    _DEFAULT_INTERVAL_MINUTES = 5.0
+    _MAX_INTERVAL_FACTOR = 3.0
+    _MAX_FUTURE_SKEW_SECONDS = 60.0
+
+    def __init__(self, coord: EnphaseCoordinator) -> None:
+        super().__init__(
+            coord,
+            "site_consumption_power",
+            "Current Power Consumption",
+            type_key=None,
+        )
+        self._last_bucket_wh: float | None = None
+        self._last_bucket_count: int | None = None
+        self._last_start_date: str | None = None
+        self._last_energy_ts: float | None = None
+        self._last_interval_minutes: float | None = None
+        self._last_power_w: int | None = None
+        self._last_window_s: float | None = None
+        self._last_method = "seeded"
+        self._restored_pending_validation = False
+
+    @staticmethod
+    def _timestamp_age_seconds(timestamp: float) -> float:
+        now = dt_util.utcnow()
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        return float(now.timestamp()) - timestamp
+
+    def _timestamp_is_too_far_in_future(self, timestamp: float) -> bool:
+        return self._timestamp_age_seconds(timestamp) < -self._MAX_FUTURE_SKEW_SECONDS
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last_extra = await self.async_get_last_extra_data()
+        restored = _SiteConsumptionPowerRestoreData.from_dict(
+            last_extra.as_dict() if last_extra is not None else None
+        )
+        if (
+            restored.latest_bucket_wh is None
+            or restored.latest_bucket_wh < 0
+            or restored.raw_bucket_count is None
+            or restored.raw_bucket_count <= 0
+            or restored.energy_ts is None
+            or restored.energy_ts <= 0
+            or restored.interval_minutes is None
+            or restored.interval_minutes <= 0
+            or restored.last_power_w is None
+            or restored.last_power_w < 0
+        ):
+            return
+        if self._timestamp_is_too_far_in_future(restored.energy_ts):
+            return
+        self._last_bucket_wh = restored.latest_bucket_wh
+        self._last_bucket_count = restored.raw_bucket_count
+        self._last_start_date = restored.start_date
+        self._last_energy_ts = restored.energy_ts
+        self._last_interval_minutes = restored.interval_minutes
+        self._last_power_w = restored.last_power_w
+        self._last_window_s = restored.last_window_seconds
+        self._last_method = restored.method or "restored"
+        self._restored_pending_validation = True
+
+    @staticmethod
+    def _coerce_nonnegative_float(value: object) -> float | None:
+        try:
+            numeric = float(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return None
+        return numeric if math.isfinite(numeric) and numeric >= 0 else None
+
+    @staticmethod
+    def _coerce_positive_int(value: object) -> int | None:
+        numeric = _restore_optional_int_value(value)
+        return numeric if numeric is not None and numeric > 0 else None
+
+    def _flow_data(self) -> dict[str, object]:
+        energy = getattr(self._coord, "energy", None)
+        flows = (
+            getattr(energy, "site_energy", None)
+            if energy is not None
+            else getattr(self._coord, "site_energy", None)
+        )
+        if not isinstance(flows, dict):
+            return {}
+        entry = flows.get("consumption")
+        if isinstance(entry, SiteEnergyFlow):
+            return {
+                "latest_bucket_wh": entry.latest_bucket_wh,
+                "previous_bucket_wh": entry.previous_bucket_wh,
+                "raw_bucket_count": entry.raw_bucket_count,
+                "start_date": entry.start_date,
+                "last_report_date": entry.last_report_date,
+                "update_pending": entry.update_pending,
+                "interval_minutes": entry.interval_minutes,
+            }
+        return entry if isinstance(entry, dict) else {}
+
+    def _discard_baseline(self, method: str) -> None:
+        self._last_bucket_wh = None
+        self._last_bucket_count = None
+        self._last_start_date = None
+        self._last_energy_ts = None
+        self._last_interval_minutes = None
+        self._last_power_w = None
+        self._last_window_s = None
+        self._last_method = method
+        self._restored_pending_validation = False
+
+    def _seed(
+        self,
+        *,
+        latest_bucket_wh: float,
+        bucket_count: int,
+        start_date: str | None,
+        energy_ts: float,
+        interval_minutes: float,
+        method: str,
+    ) -> None:
+        self._last_bucket_wh = latest_bucket_wh
+        self._last_bucket_count = bucket_count
+        self._last_start_date = start_date
+        self._last_energy_ts = energy_ts
+        self._last_interval_minutes = interval_minutes
+        self._last_power_w = None
+        self._last_window_s = None
+        self._last_method = method
+        self._restored_pending_validation = False
+
+    def _process_current_sample(self) -> None:
+        data = self._flow_data()
+        if not data or data.get("update_pending") is True:
+            return
+
+        latest_bucket_wh = self._coerce_nonnegative_float(data.get("latest_bucket_wh"))
+        bucket_count = self._coerce_positive_int(data.get("raw_bucket_count"))
+        energy_ts = _EnphaseSiteLifetimePowerSensor._parse_sample_timestamp(
+            data.get("last_report_date")
+        )
+        interval_minutes = self._coerce_nonnegative_float(data.get("interval_minutes"))
+        if interval_minutes is None or interval_minutes <= 0:
+            interval_minutes = self._DEFAULT_INTERVAL_MINUTES
+        start_date_raw = data.get("start_date")
+        start_date = start_date_raw if isinstance(start_date_raw, str) else None
+
+        if latest_bucket_wh is None or bucket_count is None:
+            self._discard_baseline("invalid_bucket")
+            return
+        if energy_ts is None or energy_ts <= 0:
+            return
+        if self._timestamp_is_too_far_in_future(energy_ts):
+            return
+
+        if (
+            self._last_bucket_wh is None
+            or self._last_bucket_count is None
+            or self._last_energy_ts is None
+            or self._last_interval_minutes is None
+        ):
+            self._seed(
+                latest_bucket_wh=latest_bucket_wh,
+                bucket_count=bucket_count,
+                start_date=start_date,
+                energy_ts=energy_ts,
+                interval_minutes=interval_minutes,
+                method="seeded",
+            )
+            return
+
+        if energy_ts == self._last_energy_ts:
+            if not self._restored_pending_validation:
+                return
+            if (
+                bucket_count == self._last_bucket_count
+                and start_date == self._last_start_date
+                and math.isclose(
+                    latest_bucket_wh,
+                    self._last_bucket_wh,
+                    rel_tol=0.0,
+                    abs_tol=1e-6,
+                )
+                and math.isclose(
+                    interval_minutes,
+                    self._last_interval_minutes,
+                    rel_tol=0.0,
+                    abs_tol=1e-6,
+                )
+            ):
+                self._restored_pending_validation = False
+                return
+            self._seed(
+                latest_bucket_wh=latest_bucket_wh,
+                bucket_count=bucket_count,
+                start_date=start_date,
+                energy_ts=energy_ts,
+                interval_minutes=interval_minutes,
+                method="restore_mismatch",
+            )
+            return
+
+        elapsed_s = energy_ts - self._last_energy_ts
+        interval_s = interval_minutes * 60.0
+        if elapsed_s < 0:
+            return
+        if elapsed_s > interval_s * self._MAX_INTERVAL_FACTOR or not math.isclose(
+            interval_minutes,
+            self._last_interval_minutes,
+            rel_tol=0.0,
+            abs_tol=1e-6,
+        ):
+            self._seed(
+                latest_bucket_wh=latest_bucket_wh,
+                bucket_count=bucket_count,
+                start_date=start_date,
+                energy_ts=energy_ts,
+                interval_minutes=interval_minutes,
+                method="interval_discontinuity",
+            )
+            return
+
+        delta_wh: float | None = None
+        method = "consumption_bucket_delta"
+        if (
+            start_date == self._last_start_date
+            and bucket_count == self._last_bucket_count
+        ):
+            delta_wh = latest_bucket_wh - self._last_bucket_wh
+        elif (
+            start_date == self._last_start_date
+            and bucket_count == self._last_bucket_count + 1
+        ):
+            previous_bucket_wh = self._coerce_nonnegative_float(
+                data.get("previous_bucket_wh")
+            )
+            if (
+                previous_bucket_wh is not None
+                and previous_bucket_wh >= self._last_bucket_wh
+            ):
+                delta_wh = (
+                    previous_bucket_wh - self._last_bucket_wh
+                ) + latest_bucket_wh
+                method = "consumption_bucket_rollover"
+
+        if delta_wh is None or delta_wh < 0:
+            self._seed(
+                latest_bucket_wh=latest_bucket_wh,
+                bucket_count=bucket_count,
+                start_date=start_date,
+                energy_ts=energy_ts,
+                interval_minutes=interval_minutes,
+                method="bucket_discontinuity",
+            )
+            return
+
+        window_s = max(elapsed_s, interval_s)
+        self._last_power_w = max(round(delta_wh * 3600.0 / window_s), 0)
+        self._last_window_s = window_s
+        self._last_method = method
+        self._last_bucket_wh = latest_bucket_wh
+        self._last_bucket_count = bucket_count
+        self._last_start_date = start_date
+        self._last_energy_ts = energy_ts
+        self._last_interval_minutes = interval_minutes
+        self._restored_pending_validation = False
+
+    def _sample_is_fresh(self) -> bool:
+        if self._last_energy_ts is None or self._last_interval_minutes is None:
+            return False
+        age_s = self._timestamp_age_seconds(self._last_energy_ts)
+        return bool(
+            -self._MAX_FUTURE_SKEW_SECONDS
+            <= age_s
+            <= (self._last_interval_minutes * 60.0 * self._MAX_INTERVAL_FACTOR)
+        )
+
+    @property
+    def available(self) -> bool:
+        if not super().available:
+            return False
+        self._process_current_sample()
+        return bool(
+            self._last_power_w is not None
+            and not self._restored_pending_validation
+            and self._sample_is_fresh()
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        self._process_current_sample()
+        return self._last_power_w
+
+    @property
+    def extra_state_attributes(self) -> Any:
+        sampled_at = None
+        if self._last_energy_ts is not None:
+            sampled_at = datetime.fromtimestamp(
+                self._last_energy_ts, tz=timezone.utc
+            ).isoformat()
+        return {
+            "sampled_at_utc": sampled_at,
+            "last_window_seconds": self._last_window_s,
+            "method": self._last_method,
+        }
+
+    @property
+    def extra_restore_state_data(self) -> ExtraStoredData | None:
+        return _SiteConsumptionPowerRestoreData(
+            latest_bucket_wh=self._last_bucket_wh,
+            raw_bucket_count=self._last_bucket_count,
+            start_date=self._last_start_date,
+            energy_ts=self._last_energy_ts,
+            interval_minutes=self._last_interval_minutes,
+            last_power_w=self._last_power_w,
+            last_window_seconds=self._last_window_s,
+            method=self._last_method,
         )
 
 

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -1332,6 +1332,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Last Window (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "method": {
+            "name": "Method"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Current Grid Power",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Текуща консумация на мощност",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Последен прозорец (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
+          },
+          "method": {
+            "name": "Метод"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Текуща мощност на мрежата",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Aktuální příkon",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Poslední okno (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
+          },
+          "method": {
+            "name": "Metoda"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Aktuální výkon sítě",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Aktuelt strømforbrug",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Seneste vindue (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
+          },
+          "method": {
+            "name": "Metode"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Aktuel neteffekt",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Aktueller Stromverbrauch",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Letztes Fenster (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
+          },
+          "method": {
+            "name": "Methode"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Aktuelle Netzleistung",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Τρέχουσα κατανάλωση ισχύος",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Τελευταίο παράθυρο (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
+          },
+          "method": {
+            "name": "Μέθοδος"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Τρέχουσα ισχύς δικτύου",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -1332,6 +1332,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Last Window (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "method": {
+            "name": "Method"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Current Grid Power",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -1332,6 +1332,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Last Window (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "method": {
+            "name": "Method"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Current Grid Power",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -1332,6 +1332,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Last Window (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "method": {
+            "name": "Method"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Current Grid Power",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -1332,6 +1332,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Last Window (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "method": {
+            "name": "Method"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Current Grid Power",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -1332,6 +1332,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Last Window (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "method": {
+            "name": "Method"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Current Grid Power",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -1332,6 +1332,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Last Window (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "method": {
+            "name": "Method"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Current Grid Power",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Consumo de potencia actual",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Última ventana (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
+          },
+          "method": {
+            "name": "Método"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Potencia actual de la red",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Praegune võimsustarve",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Viimane aken (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
+          },
+          "method": {
+            "name": "Meetod"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Praegune võrguvõimsus",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Nykyinen tehonkulutus",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Viimeiset ikkunat"
+          },
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
+          },
+          "method": {
+            "name": "Menetelmä"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Nykyinen verkkoteho",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Consommation électrique actuelle",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Dernière fenêtre (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
+          },
+          "method": {
+            "name": "Méthode"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Puissance actuelle du réseau",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Aktuális teljesítményfelvétel",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Utolsó ablak (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
+          },
+          "method": {
+            "name": "Módszer"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Aktuális hálózati teljesítmény",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Consumo di potenza attuale",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Ultima finestra (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
+          },
+          "method": {
+            "name": "Metodo"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Potenza attuale della rete",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Dabartinis galios suvartojimas",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Paskutinis langas (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
+          },
+          "method": {
+            "name": "Metodas"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Dabartinė tinklo galia",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Pašreizējais jaudas patēriņš",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Pēdējais logs (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
+          },
+          "method": {
+            "name": "Metode"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Pašreizējā elektrotīkla jauda",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Nåværende effektforbruk",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Siste vindu (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
+          },
+          "method": {
+            "name": "Metode"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Nåværende netteffekt",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Huidig stroomverbruik",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Laatste venster (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
+          },
+          "method": {
+            "name": "Methode"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Huidig netvermogen",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Bieżący pobór mocy",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Ostatnie okno (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
+          },
+          "method": {
+            "name": "Metoda"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Bieżąca moc sieci",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Consumo de potência atual",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Última janela (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
+          },
+          "method": {
+            "name": "Método"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Potência atual da rede",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Consum curent de putere",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Ultima fereastră (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
+          },
+          "method": {
+            "name": "Metodă"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Puterea instantanee a rețelei",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -1224,6 +1224,20 @@
           }
         }
       },
+      "site_consumption_power": {
+        "name": "Aktuell effektförbrukning",
+        "state_attributes": {
+          "last_window_seconds": {
+            "name": "Senaste fönster (s)"
+          },
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
+          },
+          "method": {
+            "name": "Metod"
+          }
+        }
+      },
       "site_grid_power": {
         "name": "Aktuell näteffekt",
         "state_attributes": {

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -5457,7 +5457,20 @@ async def test_async_setup_entry_adds_site_energy_entities(
             last_report_date=None,
             update_pending=False,
             source_unit="Wh",
-        )
+        ),
+        "consumption": SimpleNamespace(
+            value_kwh=2.0,
+            bucket_count=2,
+            fields_used=["consumption"],
+            start_date="2024-01-01",
+            last_report_date=None,
+            update_pending=False,
+            source_unit="Wh",
+            latest_bucket_wh=1000.0,
+            previous_bucket_wh=900.0,
+            raw_bucket_count=2,
+            interval_minutes=5.0,
+        ),
     }
 
     callbacks: list = []
@@ -5477,6 +5490,7 @@ async def test_async_setup_entry_adds_site_energy_entities(
     created: list = []
     created_power: list = []
     created_battery_power: list = []
+    created_consumption_power: list = []
 
     class StubSiteEnergy(sensor_mod.EnphaseSiteEnergySensor):
         def __init__(self, *args, **kwargs):
@@ -5493,9 +5507,19 @@ async def test_async_setup_entry_adds_site_energy_entities(
             super().__init__(*args, **kwargs)
             created_battery_power.append(self)
 
+    class StubConsumptionPower(sensor_mod.EnphaseSiteConsumptionPowerSensor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created_consumption_power.append(self)
+
     monkeypatch.setattr(sensor_mod, "EnphaseSiteEnergySensor", StubSiteEnergy)
     monkeypatch.setattr(sensor_mod, "EnphaseGridPowerSensor", StubGridPower)
     monkeypatch.setattr(sensor_mod, "EnphaseBatteryPowerSensor", StubBatteryPower)
+    monkeypatch.setattr(
+        sensor_mod,
+        "EnphaseSiteConsumptionPowerSensor",
+        StubConsumptionPower,
+    )
 
     await async_setup_entry(hass, config_entry, _async_add_entities)
     for cb in callbacks:
@@ -5515,6 +5539,7 @@ async def test_async_setup_entry_adds_site_energy_entities(
         ent.translation_key == "site_water_heater_consumption" for ent in created
     )
     assert created_power[0].translation_key == "site_grid_power"
+    assert created_consumption_power[0].translation_key == "site_consumption_power"
     assert not created_battery_power
 
 

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -1575,8 +1575,8 @@ def test_cloud_current_power_string_localized_for_non_english_locales() -> None:
             ), f"{name} should localize {path} (still matches English)"
 
 
-def test_site_grid_power_string_localized_for_non_english_locales() -> None:
-    """Ensure grid-power label is translated for non-English locales."""
+def test_site_power_strings_localized_for_non_english_locales() -> None:
+    """Ensure site-power labels are translated for non-English locales."""
 
     translations_dir = (
         pathlib.Path(__file__).resolve().parents[3]
@@ -1584,17 +1584,21 @@ def test_site_grid_power_string_localized_for_non_english_locales() -> None:
         / "enphase_ev"
         / "translations"
     )
-    path = "entity.sensor.site_grid_power.name"
+    paths = (
+        "entity.sensor.site_consumption_power.name",
+        "entity.sensor.site_grid_power.name",
+    )
     en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
     for locale in translations_dir.glob("*.json"):
         name = locale.name
         data = json.loads(locale.read_text(encoding="utf-8"))
-        value = _at_path(data, path)
-        assert value.strip(), f"{name} missing value for {path}"
-        if name != "en.json" and not name.startswith("en-"):
-            assert value != _at_path(
-                en_data, path
-            ), f"{name} should localize {path} (still matches English)"
+        for path in paths:
+            value = _at_path(data, path)
+            assert value.strip(), f"{name} missing value for {path}"
+            if name != "en.json" and not name.startswith("en-"):
+                assert value != _at_path(
+                    en_data, path
+                ), f"{name} should localize {path} (still matches English)"
 
 
 def test_site_power_state_attribute_strings_exist_for_all_locales() -> None:
@@ -1608,6 +1612,9 @@ def test_site_power_state_attribute_strings_exist_for_all_locales() -> None:
     )
     en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
     paths = [
+        "entity.sensor.site_consumption_power.state_attributes.last_window_seconds.name",
+        "entity.sensor.site_consumption_power.state_attributes.sampled_at_utc.name",
+        "entity.sensor.site_consumption_power.state_attributes.method.name",
         "entity.sensor.site_grid_power.state_attributes.last_flow_kwh.name",
         "entity.sensor.site_grid_power.state_attributes.source_flows.name",
         "entity.sensor.site_grid_power.state_attributes.sampled_at_utc.name",

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -11,6 +11,7 @@ import pytest
 from homeassistant.const import UnitOfEnergy, UnitOfPower
 
 from custom_components.enphase_ev import energy as energy_mod
+from custom_components.enphase_ev import sensor as sensor_mod
 from custom_components.enphase_ev.api import SiteEnergyUnavailable
 from custom_components.enphase_ev.energy import (
     LifetimeGuardState,
@@ -19,7 +20,9 @@ from custom_components.enphase_ev.energy import (
 from custom_components.enphase_ev.sensor import (
     EnphaseBatteryPowerSensor,
     EnphaseGridPowerSensor,
+    EnphaseSiteConsumptionPowerSensor,
     EnphaseSiteEnergySensor,
+    _SiteConsumptionPowerRestoreData,
     _SiteEnergyRestoreData,
     _SiteLifetimePowerRestoreData,
     _lifetime_energy_delta,
@@ -57,6 +60,9 @@ def test_site_energy_aggregation_with_fallbacks(coordinator_factory) -> None:
     }
     assert flows["solar_production"].value_kwh == pytest.approx(3.0)
     assert flows["consumption"].value_kwh == pytest.approx(2.0)
+    assert flows["consumption"].latest_bucket_wh == pytest.approx(500.0)
+    assert flows["consumption"].previous_bucket_wh == pytest.approx(1500.0)
+    assert flows["consumption"].raw_bucket_count == 2
     assert flows["grid_import"].fields_used == [
         "consumption",
         "solar_home",
@@ -488,22 +494,565 @@ def test_site_energy_default_interval_applied(coordinator_factory) -> None:
     assert meta["interval_minutes"] == pytest.approx(5.0)
 
 
+def _consumption_flow(
+    *,
+    latest_bucket_wh: object,
+    reported_at: datetime,
+    bucket_count: int = 2,
+    previous_bucket_wh: object = 900.0,
+    start_date: str | None = "2024-01-01",
+    interval_minutes: float = 5.0,
+    update_pending: bool | None = False,
+) -> SiteEnergyFlow:
+    return SiteEnergyFlow(
+        value_kwh=2.0,
+        bucket_count=bucket_count,
+        fields_used=["consumption"],
+        start_date=start_date,
+        last_report_date=reported_at,
+        update_pending=update_pending,
+        interval_minutes=interval_minutes,
+        latest_bucket_wh=latest_bucket_wh,  # type: ignore[arg-type]
+        previous_bucket_wh=previous_bucket_wh,  # type: ignore[arg-type]
+        raw_bucket_count=bucket_count,
+    )
+
+
+def test_site_consumption_power_uses_active_bucket_delta(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=1)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            reported_at=base_ts,
+        )
+    }
+
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["method"] == "seeded"
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1100.0,
+        reported_at=base_ts + timedelta(minutes=5),
+    )
+
+    assert sensor.native_value == 1200
+    assert sensor.translation_key == "site_consumption_power"
+    assert sensor.unique_id.endswith("_site_consumption_power")
+    assert sensor.extra_state_attributes == {
+        "sampled_at_utc": (base_ts + timedelta(minutes=5)).isoformat(),
+        "last_window_seconds": 300.0,
+        "method": "consumption_bucket_delta",
+    }
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1100.0,
+        reported_at=base_ts + timedelta(minutes=10),
+    )
+    assert sensor.native_value == 0
+
+
+def test_site_consumption_power_ignores_historical_bucket_corrections(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=1)
+    first, _ = coord.energy._aggregate_site_energy(
+        {
+            "consumption": [1000.0, 2000.0],
+            "last_report_date": base_ts.timestamp(),
+            "interval_minutes": 5,
+        }
+    )
+    coord.energy.site_energy = first
+    assert sensor.native_value is None
+
+    corrected, _ = coord.energy._aggregate_site_energy(
+        {
+            "consumption": [9000.0, 2100.0],
+            "production": [999999.0],
+            "charge": [888888.0],
+            "last_report_date": (base_ts + timedelta(minutes=5)).timestamp(),
+            "interval_minutes": 5,
+        }
+    )
+    coord.energy.site_energy = corrected
+
+    assert sensor.native_value == 1200
+
+
+def test_site_consumption_power_handles_bucket_rollover(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=1)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            previous_bucket_wh=800.0,
+            bucket_count=2,
+            reported_at=base_ts,
+        )
+    }
+    assert sensor.native_value is None
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=50.0,
+        previous_bucket_wh=1100.0,
+        bucket_count=3,
+        reported_at=base_ts + timedelta(minutes=5),
+    )
+
+    assert sensor.native_value == 1800
+    assert sensor.extra_state_attributes["method"] == "consumption_bucket_rollover"
+
+
+def test_site_consumption_power_reseeds_decreasing_rollover_bucket(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=1)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            previous_bucket_wh=800.0,
+            bucket_count=2,
+            reported_at=base_ts,
+        )
+    }
+    assert sensor.native_value is None
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=200.0,
+        previous_bucket_wh=900.0,
+        bucket_count=3,
+        reported_at=base_ts + timedelta(minutes=5),
+    )
+
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["method"] == "bucket_discontinuity"
+
+
+@pytest.mark.parametrize(
+    ("next_flow", "expected_method"),
+    [
+        ({"latest_bucket_wh": 900.0}, "bucket_discontinuity"),
+        ({"latest_bucket_wh": None}, "invalid_bucket"),
+        ({"latest_bucket_wh": float("nan")}, "invalid_bucket"),
+        ({"latest_bucket_wh": 1100.0, "bucket_count": 4}, "bucket_discontinuity"),
+        (
+            {"latest_bucket_wh": 1100.0, "start_date": "2024-01-02"},
+            "bucket_discontinuity",
+        ),
+        (
+            {"latest_bucket_wh": 1100.0, "interval_minutes": 10.0},
+            "interval_discontinuity",
+        ),
+    ],
+)
+def test_site_consumption_power_reseeds_untrustworthy_samples(
+    coordinator_factory,
+    next_flow,
+    expected_method,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=1)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            reported_at=base_ts,
+        )
+    }
+    assert sensor.native_value is None
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        reported_at=base_ts + timedelta(minutes=5),
+        **next_flow,
+    )
+
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["method"] == expected_method
+
+
+def test_site_consumption_power_ignores_pending_and_repeated_samples(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=1)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            reported_at=base_ts,
+        )
+    }
+    assert sensor.native_value is None
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1100.0,
+        reported_at=base_ts + timedelta(minutes=5),
+    )
+    assert sensor.native_value == 1200
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=9000.0,
+        reported_at=base_ts + timedelta(minutes=10),
+        update_pending=True,
+    )
+    assert sensor.native_value == 1200
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1100.0,
+        reported_at=base_ts + timedelta(minutes=5),
+    )
+    assert sensor.native_value == 1200
+
+
+def test_site_consumption_power_ignores_out_of_order_source_sample(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=1)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            reported_at=base_ts,
+        )
+    }
+    assert sensor.native_value is None
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1100.0,
+        reported_at=base_ts + timedelta(minutes=5),
+    )
+    assert sensor.native_value == 1200
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1050.0,
+        reported_at=base_ts + timedelta(minutes=2),
+    )
+    assert sensor.native_value == 1200
+    assert (
+        sensor.extra_state_attributes["sampled_at_utc"]
+        == (base_ts + timedelta(minutes=5)).isoformat()
+    )
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1200.0,
+        reported_at=base_ts + timedelta(minutes=10),
+    )
+    assert sensor.native_value == 1200
+
+
+def test_site_consumption_power_interval_floor_and_long_gap(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(hours=1)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            interval_minutes=10,
+            reported_at=base_ts,
+        )
+    }
+    assert sensor.native_value is None
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1100.0,
+        interval_minutes=10,
+        reported_at=base_ts + timedelta(minutes=5),
+    )
+    assert sensor.native_value == 600
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1500.0,
+        interval_minutes=10,
+        reported_at=base_ts + timedelta(minutes=40),
+    )
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["method"] == "interval_discontinuity"
+
+
+def test_site_consumption_power_stale_sample_is_unavailable(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(minutes=25)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            reported_at=base_ts,
+        )
+    }
+    assert sensor.native_value is None
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1100.0,
+        reported_at=base_ts + timedelta(minutes=5),
+    )
+    assert sensor.native_value == 1200
+    assert sensor.available is False
+
+
+def test_site_consumption_power_rejects_future_sample_and_recovers(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            reported_at=now + timedelta(minutes=2),
+        )
+    }
+    assert sensor.native_value is None
+    assert sensor._last_energy_ts is None
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1000.0,
+        reported_at=now - timedelta(minutes=5),
+    )
+    assert sensor.native_value is None
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1100.0,
+        reported_at=now,
+    )
+    assert sensor.native_value == 1200
+    assert sensor.available is True
+
+
+def test_site_consumption_power_restore_data_round_trip() -> None:
+    restored = _SiteConsumptionPowerRestoreData.from_dict(
+        _SiteConsumptionPowerRestoreData(
+            latest_bucket_wh=1100.0,
+            raw_bucket_count=2,
+            start_date="2024-01-01",
+            energy_ts=1_700_000_000.0,
+            interval_minutes=5.0,
+            last_power_w=1200,
+            last_window_seconds=300.0,
+            method="consumption_bucket_delta",
+        ).as_dict()
+    )
+
+    assert restored.last_power_w == 1200
+    assert restored.latest_bucket_wh == pytest.approx(1100.0)
+    assert _SiteConsumptionPowerRestoreData.from_dict(None).last_power_w is None
+    invalid = _SiteConsumptionPowerRestoreData.from_dict(
+        {
+            "latest_bucket_wh": "bad",
+            "raw_bucket_count": "bad",
+            "energy_ts": float("inf"),
+        }
+    )
+    assert invalid.latest_bucket_wh is None
+    assert invalid.raw_bucket_count is None
+    assert invalid.energy_ts is None
+
+
+@pytest.mark.asyncio
+async def test_site_consumption_power_validates_and_uses_restored_baseline(
+    hass,
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(minutes=5)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1100.0,
+            reported_at=base_ts,
+        )
+    }
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    sensor.hass = hass
+    sensor.async_get_last_extra_data = AsyncMock(
+        return_value=_SiteConsumptionPowerRestoreData(
+            latest_bucket_wh=1100.0,
+            raw_bucket_count=2,
+            start_date="2024-01-01",
+            energy_ts=base_ts.timestamp(),
+            interval_minutes=5.0,
+            last_power_w=1200,
+            last_window_seconds=300.0,
+            method="consumption_bucket_delta",
+        )
+    )
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.available is True
+    assert sensor.native_value == 1200
+    stored = sensor.extra_restore_state_data
+    assert isinstance(stored, _SiteConsumptionPowerRestoreData)
+    assert stored.last_power_w == 1200
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1200.0,
+        reported_at=base_ts + timedelta(minutes=5),
+    )
+    assert sensor.native_value == 1200
+
+
+@pytest.mark.asyncio
+async def test_site_consumption_power_rejects_invalid_or_mismatched_restore(
+    hass,
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1200.0,
+            reported_at=base_ts,
+        )
+    }
+    invalid = EnphaseSiteConsumptionPowerSensor(coord)
+    invalid.hass = hass
+    invalid.async_get_last_extra_data = AsyncMock(
+        return_value=_SiteConsumptionPowerRestoreData(
+            None, None, None, None, None, None, None, None
+        )
+    )
+    await invalid.async_added_to_hass()
+    assert invalid.native_value is None
+
+    mismatched = EnphaseSiteConsumptionPowerSensor(coord)
+    mismatched.hass = hass
+    mismatched.async_get_last_extra_data = AsyncMock(
+        return_value=_SiteConsumptionPowerRestoreData(
+            latest_bucket_wh=1100.0,
+            raw_bucket_count=2,
+            start_date="2024-01-01",
+            energy_ts=base_ts.timestamp(),
+            interval_minutes=5.0,
+            last_power_w=1200,
+            last_window_seconds=300.0,
+            method="consumption_bucket_delta",
+        )
+    )
+    await mismatched.async_added_to_hass()
+    assert mismatched.available is False
+    assert mismatched.extra_state_attributes["method"] == "restore_mismatch"
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1200.0,
+        reported_at=base_ts,
+        interval_minutes=10.0,
+    )
+    interval_mismatch = EnphaseSiteConsumptionPowerSensor(coord)
+    interval_mismatch.hass = hass
+    interval_mismatch.async_get_last_extra_data = AsyncMock(
+        return_value=_SiteConsumptionPowerRestoreData(
+            latest_bucket_wh=1200.0,
+            raw_bucket_count=2,
+            start_date="2024-01-01",
+            energy_ts=base_ts.timestamp(),
+            interval_minutes=5.0,
+            last_power_w=1200,
+            last_window_seconds=300.0,
+            method="consumption_bucket_delta",
+        )
+    )
+    await interval_mismatch.async_added_to_hass()
+    assert interval_mismatch.available is False
+    assert interval_mismatch.extra_state_attributes["method"] == "restore_mismatch"
+
+    future_restore = EnphaseSiteConsumptionPowerSensor(coord)
+    future_restore.hass = hass
+    future_restore.async_get_last_extra_data = AsyncMock(
+        return_value=_SiteConsumptionPowerRestoreData(
+            latest_bucket_wh=1200.0,
+            raw_bucket_count=2,
+            start_date="2024-01-01",
+            energy_ts=(base_ts + timedelta(hours=1)).timestamp(),
+            interval_minutes=10.0,
+            last_power_w=1200,
+            last_window_seconds=600.0,
+            method="consumption_bucket_delta",
+        )
+    )
+    await future_restore.async_added_to_hass()
+    assert future_restore.native_value is None
+    assert future_restore._last_energy_ts == base_ts.timestamp()
+
+
+def test_site_consumption_power_guard_paths(coordinator_factory, monkeypatch) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+
+    assert sensor._sample_is_fresh() is False
+    assert sensor._coerce_positive_int("bad") is None
+    coord.energy.site_energy = None  # type: ignore[assignment]
+    assert sensor._flow_data() == {}
+    coord.energy.site_energy = {"consumption": {"latest_bucket_wh": 1.0}}
+    assert sensor._flow_data() == {"latest_bucket_wh": 1.0}
+
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(minutes=5)
+    coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            reported_at=base_ts,
+            interval_minutes=0,
+        )
+    }
+    assert sensor.native_value is None
+    assert sensor._last_interval_minutes == 5.0
+
+    coord.energy.site_energy["consumption"] = _consumption_flow(
+        latest_bucket_wh=1100.0,
+        reported_at=base_ts + timedelta(minutes=5),
+        interval_minutes=0,
+    )
+    assert sensor.native_value == 1200
+    monkeypatch.setattr(
+        sensor_mod.dt_util,
+        "utcnow",
+        lambda: (base_ts + timedelta(minutes=6)).replace(tzinfo=None),
+    )
+    assert sensor._sample_is_fresh() is True
+
+    coord.last_success_utc = None
+    coord.last_update_success = False
+    assert sensor.available is False
+
+    missing_timestamp = EnphaseSiteConsumptionPowerSensor(coordinator_factory())
+    missing_timestamp._coord.energy.site_energy = {
+        "consumption": _consumption_flow(
+            latest_bucket_wh=1000.0,
+            reported_at=base_ts,
+        )
+    }
+    missing_timestamp._coord.energy.site_energy["consumption"].last_report_date = None
+    assert missing_timestamp.native_value is None
+
+
 def test_site_energy_interval_hours_edge_cases(coordinator_factory) -> None:
     coord = coordinator_factory()
     # Non-dict payload falls back to default interval
     hours, minutes = coord.energy._site_energy_interval_hours(None)  # noqa: SLF001
     assert minutes == pytest.approx(5.0)
     assert hours == pytest.approx(5.0 / 60.0)
+
+
+def test_latest_energy_buckets_rejects_invalid_tail_values(coordinator_factory) -> None:
+    manager = coordinator_factory().energy
+
+    assert manager._latest_energy_buckets(None) == (None, None, 0)
+    assert manager._latest_energy_buckets([100.0, -1.0]) == (None, 100.0, 2)
+    assert manager._latest_energy_buckets([float("nan")]) == (None, None, 1)
     # Fallback "interval" key is honored
-    hours, minutes = coord.energy._site_energy_interval_hours(
-        {"interval": 10}
-    )  # noqa: SLF001
+    hours, minutes = manager._site_energy_interval_hours({"interval": 10})
     assert minutes == pytest.approx(10.0)
     assert hours == pytest.approx(10.0 / 60.0)
 
-    hours, minutes = coord.energy._site_energy_interval_hours(
-        {"interval_minutes": 0}
-    )  # noqa: SLF001
+    hours, minutes = manager._site_energy_interval_hours({"interval_minutes": 0})
     assert minutes == pytest.approx(5.0)
     assert hours == pytest.approx(5.0 / 60.0)
 


### PR DESCRIPTION
## Summary

Add a native, default-enabled Current Power Consumption sensor derived exclusively from consecutive Enphase consumption-energy buckets.

The sensor uses source timestamps and the active consumption bucket to calculate a non-negative average power reading without combining independently timed production, grid, and battery sensors. It handles bucket rollover, stale or repeated samples, resets, malformed payloads, future timestamps, and compatible restoration across Home Assistant restarts.

Documentation, changelog entries, localized entity and diagnostic-attribute strings, and regression coverage are included.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/energy.py,custom_components/enphase_ev/sensor.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/energy.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_sensor_additional_coverage.py tests/components/enphase_ev/test_service_translations.py tests/components/enphase_ev/test_site_energy.py && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
```

Results:

- Full test suite: 4,029 passed, 2 skipped.
- Integration suite: 3,897 passed.
- Targeted coverage: 100% for `energy.py` and `sensor.py`.
- Pre-commit, Black, Ruff, codespell, strict mypy, import-time validation, and both platinum quality-scale checks passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The sensor reports a source-timestamped average over the latest accepted consumption interval. It remains unavailable until two comparable samples are available and whenever the source becomes stale or discontinuous.
