### PR TITLE
Prepare release 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,38 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- Added a default-enabled Current Power Consumption sensor calculated from
-  consecutive Enphase consumption-energy buckets. The five-minute average uses
-  source timestamps and avoids negative values caused by combining independently
-  updated production, grid, and battery sensors.
+- None
 
 ### 🐛 Bug fixes
-- Retried owner-access Grid Profile discovery through Enlighten Settings after a
-  preserved installer-access denial, and kept that non-degrading denial out of
-  the Service Status failure details.
+- None
 
 ### 🔧 Improvements
 - None
 
 ### 🔄 Other changes
 - None
+
+## v4.2.2 - 2026-08-09
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added a default-enabled Current Power Consumption sensor calculated from
+  consecutive Enphase consumption-energy buckets. The five-minute average uses
+  source timestamps and avoids negative values caused by combining independently
+  updated production, grid, and battery sensors. (#821)
+
+### 🐛 Bug fixes
+- Retried owner-access Grid Profile discovery through Enlighten Settings after a
+  preserved installer-access denial, and kept that non-degrading denial out of
+  the Service Status failure details. (#819)
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `4.2.2`.
 
 ## v4.2.1 - 2026-08-06
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "4.2.1"
+  "version": "4.2.2"
 }


### PR DESCRIPTION
## Summary

Prepare release 4.2.2 by updating the integration manifest version and moving the completed Unreleased notes into a dated release section.

The release notes cover the Grid Profile recovery fix from #819 and the Current Power Consumption sensor from #821.

## Related Issues

- #819
- #821

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (release preparation)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
python3 -m json.tool custom_components/enphase_ev/manifest.json
git diff --check
```

- Pinned pre-commit hooks passed, including Ruff, Black, codespell, and full-package mypy.
- Integration tests: 3,900 passed.
- Full repository tests: 4,032 passed, 2 skipped.
- The standalone unpinned `ruff check .` invocation reported 6,979 existing repository-wide findings; the pinned Ruff pre-commit hook passed. Neither release file contains Python code.
- Targeted Python coverage and Black-on-changed-Python checks are not applicable because this PR changes only Markdown and JSON.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation changes are not required; behavior and options are unchanged.
- [x] Translation changes are not required; no user-facing strings changed.
- [x] Targeted Python coverage is not applicable; no Python modules changed.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots are required for this release metadata-only change.
