### PR TITLE
Prevent zero consumption lifetime resets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
   a fresh cached grid state; degradation now begins only after that data is stale.
 - Kept optional inverter parameter telemetry rate limits from degrading the
   overall cloud service, and retained fresh cached readings until they expire.
+- Prevented zero-only consumption payloads from resetting an established site
+  lifetime total and corrupting Home Assistant long-term energy statistics. (#823)
 
 ### 🔧 Improvements
 - Extended owner-access Grid Profile retry backoff from hourly polling to one

--- a/custom_components/enphase_ev/energy.py
+++ b/custom_components/enphase_ev/energy.py
@@ -539,6 +539,7 @@ class EnergyManager:
             bucket_count: int,
             *,
             allow_zero: bool = False,
+            hold_zero_after_positive: bool = False,
             legacy_offset_wh: float = 0.0,
             latest_bucket_wh: float | None = None,
             previous_bucket_wh: float | None = None,
@@ -555,9 +556,43 @@ class EnergyManager:
             if isinstance(prev_entry, SiteEnergyFlow):
                 prev_value = prev_entry.value_kwh
                 prev_reset_at = prev_entry.last_reset_at
-            filtered, reset_at = self._apply_site_energy_guard(
-                flow, total_kwh, prev_value
+            guard_state = self._site_energy_guard.get(flow)
+            accepted_baseline = (
+                guard_state.last
+                if guard_state is not None
+                and guard_state.last is not None
+                and guard_state.last > 0
+                else prev_value
             )
+            filtered: float | None
+            reset_at: str | None
+            if (
+                hold_zero_after_positive
+                and total_kwh == 0
+                and accepted_baseline is not None
+                and accepted_baseline > 0
+            ):
+                guard_state = self._site_energy_guard.setdefault(
+                    flow, LifetimeGuardState()
+                )
+                guard_state.last = accepted_baseline
+                guard_state.pending_value = None
+                guard_state.pending_ts = None
+                guard_state.pending_count = 0
+                filtered = accepted_baseline
+                reset_at = None
+                latest_bucket_wh = None
+                previous_bucket_wh = None
+                raw_bucket_count = 0
+                self._logger.debug(
+                    "Holding site energy flow %s at %.3f after a zero dropout",
+                    flow,
+                    accepted_baseline,
+                )
+            else:
+                filtered, reset_at = self._apply_site_energy_guard(
+                    flow, total_kwh, prev_value
+                )
             if filtered is None:
                 return
             last_reset = (
@@ -602,6 +637,7 @@ class EnergyManager:
             ["consumption"],
             cons_count,
             allow_zero=True,
+            hold_zero_after_positive=True,
             latest_bucket_wh=cons_latest,
             previous_bucket_wh=cons_previous,
             raw_bucket_count=cons_raw_count,

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -585,6 +585,68 @@ def test_site_consumption_power_ignores_historical_bucket_corrections(
     assert sensor.native_value == 1200
 
 
+def test_site_consumption_power_reseeds_after_zero_lifetime_dropout(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseSiteConsumptionPowerSensor(coord)
+    base_ts = datetime.now(timezone.utc).replace(microsecond=0) - timedelta(minutes=20)
+
+    first, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {
+            "consumption": [1000.0, 2000.0],
+            "last_report_date": base_ts.timestamp(),
+            "interval_minutes": 5,
+        }
+    )
+    coord.energy.site_energy = first
+    assert sensor.native_value is None
+
+    second, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {
+            "consumption": [1000.0, 2100.0],
+            "last_report_date": (base_ts + timedelta(minutes=5)).timestamp(),
+            "interval_minutes": 5,
+        }
+    )
+    coord.energy.site_energy = second
+    assert sensor.native_value == 1200
+
+    dropout, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {
+            "consumption": [0.0, 0.0],
+            "last_report_date": (base_ts + timedelta(minutes=10)).timestamp(),
+            "interval_minutes": 5,
+        }
+    )
+    coord.energy.site_energy = dropout
+    assert dropout["consumption"].value_kwh == pytest.approx(3.1)
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["method"] == "invalid_bucket"
+
+    recovered, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {
+            "consumption": [1000.0, 2200.0],
+            "last_report_date": (base_ts + timedelta(minutes=15)).timestamp(),
+            "interval_minutes": 5,
+        }
+    )
+    coord.energy.site_energy = recovered
+    assert recovered["consumption"].last_reset_at is None
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["method"] == "seeded"
+
+    next_sample, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {
+            "consumption": [1000.0, 2300.0],
+            "last_report_date": (base_ts + timedelta(minutes=20)).timestamp(),
+            "interval_minutes": 5,
+        }
+    )
+    coord.energy.site_energy = next_sample
+    assert sensor.native_value == 1200
+
+
 def test_site_consumption_power_handles_bucket_rollover(coordinator_factory) -> None:
     coord = coordinator_factory()
     sensor = EnphaseSiteConsumptionPowerSensor(coord)
@@ -1510,6 +1572,109 @@ def test_site_energy_guard_confirms_reset(coordinator_factory) -> None:
     flows_reset, _ = coord.energy._aggregate_site_energy(drop_payload)  # noqa: SLF001
     assert flows_reset["solar_production"].value_kwh == pytest.approx(0.1)
     assert flows_reset["solar_production"].last_reset_at is not None
+
+
+def test_site_energy_zero_consumption_holds_positive_lifetime_baseline(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    healthy = {
+        "consumption": [4000.0, 3_500_000.0],
+        "start_date": "2023-08-10",
+        "last_report_date": 1_700_000_001,
+        "update_pending": False,
+        "interval_minutes": 5,
+    }
+    flows, _ = coord.energy._aggregate_site_energy(healthy)  # noqa: SLF001
+    coord.energy.site_energy = flows
+
+    for report_date in (1_700_000_301, 1_700_000_601, 1_700_000_901):
+        coord.energy._site_energy_force_refresh = False  # noqa: SLF001
+        held, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+            {
+                **healthy,
+                "consumption": [0.0, 0.0],
+                "last_report_date": report_date,
+            }
+        )
+        coord.energy.site_energy = held
+
+        consumption = held["consumption"]
+        assert consumption.value_kwh == pytest.approx(3504.0)
+        assert consumption.last_reset_at is None
+        assert consumption.bucket_count == 2
+        assert consumption.latest_bucket_wh is None
+        assert consumption.previous_bucket_wh is None
+        assert consumption.raw_bucket_count == 0
+        assert coord.energy._site_energy_force_refresh is False  # noqa: SLF001
+
+    recovered, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {
+            **healthy,
+            "consumption": [4100.0, 3_500_100.0],
+            "last_report_date": 1_700_001_201,
+        }
+    )
+    assert recovered["consumption"].value_kwh == pytest.approx(3504.2)
+    assert recovered["consumption"].last_reset_at is None
+
+
+def test_site_energy_zero_consumption_uses_guard_baseline_without_previous_flow(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    healthy, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {"consumption": [4000.0, 3_500_000.0], "interval_minutes": 5}
+    )
+    assert healthy["consumption"].value_kwh == pytest.approx(3504.0)
+    coord.energy.site_energy = {}
+
+    held, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {"consumption": [0.0, 0.0], "interval_minutes": 5}
+    )
+
+    assert held["consumption"].value_kwh == pytest.approx(3504.0)
+    assert held["consumption"].last_reset_at is None
+    assert held["consumption"].raw_bucket_count == 0
+
+
+def test_site_energy_initial_zero_consumption_keeps_bucket_metadata(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    flows, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {"consumption": [0.0, 0.0], "interval_minutes": 5}
+    )
+
+    consumption = flows["consumption"]
+    assert consumption.value_kwh == 0.0
+    assert consumption.latest_bucket_wh == 0.0
+    assert consumption.previous_bucket_wh == 0.0
+    assert consumption.raw_bucket_count == 2
+
+
+def test_site_energy_consumption_guard_confirms_nonzero_reset(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    base, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {"consumption": [1000.0], "interval_minutes": 60}
+    )
+    coord.energy.site_energy = base
+
+    first, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {"consumption": [100.0], "interval_minutes": 60}
+    )
+    coord.energy.site_energy = first
+    assert first["consumption"].value_kwh == pytest.approx(1.0)
+    assert coord.energy._site_energy_force_refresh is True  # noqa: SLF001
+
+    confirmed, _ = coord.energy._aggregate_site_energy(  # noqa: SLF001
+        {"consumption": [100.0], "interval_minutes": 60}
+    )
+    assert confirmed["consumption"].value_kwh == pytest.approx(0.1)
+    assert confirmed["consumption"].last_reset_at is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Prevent all-zero site consumption payloads from resetting an established lifetime energy total.

The v4.2.2 current-consumption power sensor made zero-valued consumption flows publishable so initial-zero sites retained bucket metadata. After a positive lifetime baseline, however, repeated zero payloads could pass reset confirmation and publish `0.0 kWh`, causing Home Assistant to interpret the transition as a meter reset and potentially add the recovered lifetime total to long-term statistics again.

This change holds the last positive lifetime total during a zero dropout, clears pending reset confirmation, and invalidates the current-power bucket baseline so power reseeds safely after recovery. Initial-zero sites and confirmed non-zero lifetime resets remain supported.

Fixes #823.

## Related Issues

- #821 introduced the current consumption power sensor and the unconditional zero opt-out.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/energy.py tests/components/enphase_ev/test_site_energy.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_site_energy.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/energy.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Results:

- Full suite: 4,037 passed, 2 skipped.
- Integration suite: 3,905 passed.
- Targeted `energy.py` coverage: 100%.
- Black, repository-pinned Ruff, codespell, strict mypy, import-time validation, pre-commit, and both platinum quality-scale checks passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation changes are not required for this regression fix.
- [x] Translations are unchanged; no user-facing strings were added or modified.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- No diagnostics or repair output changed.
- The fix intentionally delays an exact-zero legitimate reset until Enphase reports the first positive post-reset sample, prioritizing long-term statistics integrity.
