### PR TITLE
Prepare release 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v4.2.3 - 2026-08-12
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
 - Added a default-off Device Features option for installer-only Grid Profile
   controls. Disabled entries no longer probe Enphase Activation, while migration
   preserves the feature for entries with an existing Current Grid Profile entity.
@@ -29,7 +46,7 @@ All notable changes to this project will be documented in this file.
   429 entity details with a concise, URL-free rate-limit summary.
 
 ### 🔄 Other changes
-- None
+- Bumped the integration manifest version to `4.2.3`.
 
 ## v4.2.2 - 2026-08-09
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "4.2.2"
+  "version": "4.2.3"
 }


### PR DESCRIPTION
## Summary

Prepare the 4.2.3 release by bumping the integration manifest version and moving the accumulated Unreleased notes into a dated release section.

The changelog covers the Grid Profile controls feature, optional cloud request resilience improvements, diagnostics enhancements, and the consumption lifetime-total zero-dropout fix included since v4.2.2.

## Related Issues

- #823

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (release preparation)

## Testing

Passed:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Results:

- Pinned pre-commit Black, Ruff 0.6.9, codespell, and strict mypy passed.
- Integration suite: 3,910 passed.
- Full suite: 4,042 passed, 2 skipped.
- Service translation suite: 43 passed.
- Both local and remote-brand quality-scale validation passed.
- Strict import-time profiling passed.
- Direct Docker `ruff check .` is not included as a passing result because the unpinned Docker Ruff has advanced to 0.16.1 and reports pre-existing repository-wide findings; no Python files change in this PR, and the repository-pinned Ruff 0.6.9 hook passes all files.

Black on changed Python files and targeted Python coverage are not applicable because this PR changes only Markdown and JSON.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation changes are limited to the release changelog; runtime behaviour and options are unchanged by this PR.
- [x] Translations are unchanged and the service translation suite passes.
- [x] No Python modules are touched, so targeted module coverage is not applicable.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots are required for this metadata-only release preparation.
