### PR TITLE
Harden service authorization and diagnostics redaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,16 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### 🚧 Breaking changes
-- None
+- Restricted credential-backed charger, reauthentication, live-stream, battery
+  schedule, tariff, and Grid Profile service actions to Home Assistant
+  administrators.
 
 ### ✨ New features
 - None
 
 ### 🐛 Bug fixes
-- None
+- Redacted raw inverter and device identifiers, including identifier-keyed maps,
+  from exported diagnostics.
 
 ### 🔧 Improvements
 - None

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
   under Options > Devices > Device Features; it is disabled by default and makes
   no Grid Profile requests until enabled
 - Read-only Grid Mode monitoring with a guided, OTP-confirmed control workflow under Configure > Advanced > Grid Mode and admin-only actions for scripts
+- Administrator-only service actions for charger control, cloud reauthentication, live streaming, battery schedule changes, tariff updates, and Grid Profile application
 - Health diagnostics, service-availability tracking, and actionable repair issues
 - Read-only System Dashboard event and standing-alarm monitoring, including a
   diagnostic Problem sensor with bounded sanitized event context and optional,

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -53,6 +53,14 @@ DIAGNOSTIC_IDENTIFIER_KEYS = [
     "grid_profile_id",
     "name",
     "device_name",
+    "device_id",
+    "device-id",
+    "deviceId",
+    "deviceID",
+    "inverter_id",
+    "inverter-id",
+    "inverterId",
+    "inverterID",
     "hostname",
     "host",
     "ip",
@@ -180,6 +188,45 @@ def _redact_diagnostics_payload(
 
     redacted = async_redact_data(payload, DIAGNOSTICS_REDACT_KEYS)
     return cast(dict[str, Any], _redact_embedded_diagnostics_text(redacted, site_ids))
+
+
+def _redact_identifier_map(
+    payload: Any, *, aliases: dict[object, str] | None = None
+) -> Any:
+    """Redact every key in a map known to be keyed by an Enphase identifier."""
+
+    if not isinstance(payload, dict):
+        return payload
+    if aliases is None:
+        aliases = {}
+    redacted: dict[str, Any] = {}
+    for key, value in payload.items():
+        alias = aliases.get(key)
+        if alias is None:
+            alias = f"[inverter_{len(aliases) + 1}]"
+            aliases[key] = alias
+        redacted[alias] = value
+    return redacted
+
+
+def _redact_identifier_keyed_payload(payload: Any) -> Any:
+    """Redact identifier-keyed maps within raw inverter diagnostics."""
+
+    if not isinstance(payload, dict):
+        return payload
+    redacted = dict(payload)
+    aliases: dict[object, str] = {}
+    redacted["status_payload"] = _redact_identifier_map(
+        redacted.get("status_payload"), aliases=aliases
+    )
+    production_payload = redacted.get("production_payload")
+    if isinstance(production_payload, dict):
+        production_payload = dict(production_payload)
+        production_payload["production"] = _redact_identifier_map(
+            production_payload.get("production"), aliases=aliases
+        )
+        redacted["production_payload"] = production_payload
+    return redacted
 
 
 def _text(value: Any) -> str | None:
@@ -516,6 +563,8 @@ async def async_get_config_entry_diagnostics(
         inverters = coord.inverter_diagnostics_payloads()
     except DIAGNOSTIC_CAPTURE_ERRORS:
         inverters = {}
+    else:
+        inverters = _redact_identifier_keyed_payload(inverters)
 
     try:
         payload_health = coord.payload_health_diagnostics()

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -1796,26 +1796,25 @@ def async_setup_services(
         _svc_refresh_grid_profiles,
         **grid_profile_refresh_kwargs,
     )
-    grid_profile_set_kwargs: dict[str, object] = {
-        "schema": SET_GRID_PROFILE_SCHEMA,
-        "supports_response": supports_response.OPTIONAL,
-    }
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         "set_grid_profile",
         _svc_set_grid_profile,
-        **grid_profile_set_kwargs,
+        SET_GRID_PROFILE_SCHEMA,
+        supports_response=supports_response.OPTIONAL,
     )
-    hass.services.async_register(
-        DOMAIN, "start_charging", _svc_start, schema=START_SCHEMA
+    async_register_admin_service(
+        hass, DOMAIN, "start_charging", _svc_start, START_SCHEMA
     )
-    hass.services.async_register(DOMAIN, "stop_charging", _svc_stop, schema=STOP_SCHEMA)
+    async_register_admin_service(hass, DOMAIN, "stop_charging", _svc_stop, STOP_SCHEMA)
 
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         "trigger_message",
         _svc_trigger,
-        schema=TRIGGER_SCHEMA,
+        TRIGGER_SCHEMA,
         supports_response=supports_response.OPTIONAL,
     )
 
@@ -1836,33 +1835,43 @@ def async_setup_services(
     hass.services.async_register(
         DOMAIN, "clear_reauth_issue", _svc_clear_issue, schema=CLEAR_SCHEMA
     )
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         "try_reauth_now",
         _svc_try_reauth_now,
-        schema=CLEAR_SCHEMA,
+        CLEAR_SCHEMA,
         supports_response=supports_response.OPTIONAL,
     )
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         "clear_hems_auth_backoff",
         _svc_clear_hems_auth_backoff,
-        schema=CLEAR_SCHEMA,
+        CLEAR_SCHEMA,
         supports_response=supports_response.OPTIONAL,
     )
-    hass.services.async_register(DOMAIN, "start_live_stream", _svc_start_stream)
-    hass.services.async_register(DOMAIN, "stop_live_stream", _svc_stop_stream)
+    async_register_admin_service(hass, DOMAIN, "start_live_stream", _svc_start_stream)
+    async_register_admin_service(hass, DOMAIN, "stop_live_stream", _svc_stop_stream)
     hass.services.async_register(
         DOMAIN, "sync_schedules", _svc_sync_schedules, schema=SYNC_SCHEMA
     )
-    hass.services.async_register(
-        DOMAIN, "add_schedule", _svc_add_schedule, schema=ADD_SCHEDULE_SCHEMA
+    async_register_admin_service(
+        hass, DOMAIN, "add_schedule", _svc_add_schedule, ADD_SCHEDULE_SCHEMA
     )
-    hass.services.async_register(
-        DOMAIN, "update_schedule", _svc_update_schedule, schema=UPDATE_SCHEDULE_SCHEMA
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        "update_schedule",
+        _svc_update_schedule,
+        UPDATE_SCHEDULE_SCHEMA,
     )
-    hass.services.async_register(
-        DOMAIN, "delete_schedule", _svc_delete_schedule, schema=DELETE_SCHEDULE_SCHEMA
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        "delete_schedule",
+        _svc_delete_schedule,
+        DELETE_SCHEDULE_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN,
@@ -1871,17 +1880,19 @@ def async_setup_services(
         schema=VALIDATE_SCHEDULE_SCHEMA,
         supports_response=supports_response.OPTIONAL,
     )
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         "update_cfg_schedule",
         _svc_update_cfg_schedule,
-        schema=UPDATE_CFG_SCHEMA,
+        UPDATE_CFG_SCHEMA,
     )
-    hass.services.async_register(
+    async_register_admin_service(
+        hass,
         DOMAIN,
         "update_tariff",
         _svc_update_tariff,
-        schema=UPDATE_TARIFF_SCHEMA,
+        UPDATE_TARIFF_SCHEMA,
     )
 
 

--- a/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
+++ b/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
@@ -30,6 +30,28 @@ from custom_components.enphase_ev.labels import battery_schedule_create_label
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 
 
+@pytest.fixture(autouse=True)
+def _expose_admin_service_handlers_for_unit_tests(monkeypatch) -> None:
+    """Keep direct handler tests focused on schedule behavior, not HA authorization."""
+
+    def fake_register_admin(
+        hass, domain, service, handler, schema=None, supports_response=None, **kwargs
+    ) -> None:
+        hass.services.async_register(
+            domain,
+            service,
+            handler,
+            schema,
+            supports_response,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.async_register_admin_service",
+        fake_register_admin,
+    )
+
+
 def _schedule_payload() -> dict[str, object]:
     return {
         "cfg": {

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -160,6 +160,17 @@ def test_diagnostics_redacts_numeric_site_ids_in_nested_payloads() -> None:
     )
 
 
+def test_inverter_identifier_redaction_handles_malformed_payload_shapes() -> None:
+    """Identifier-key redaction must leave malformed payload families safe to inspect."""
+
+    assert diagnostics._redact_identifier_map(None) is None
+    assert diagnostics._redact_identifier_map({"raw-id": 1}) == {"[inverter_1]": 1}
+    assert diagnostics._redact_identifier_keyed_payload(None) is None
+    assert diagnostics._redact_identifier_keyed_payload(
+        {"status_payload": [], "production_payload": []}
+    ) == {"status_payload": [], "production_payload": []}
+
+
 class DummyClient(SimpleNamespace):
     def __init__(self) -> None:
         super().__init__()
@@ -1299,6 +1310,49 @@ async def test_config_entry_diagnostics_handles_snapshot_helper_errors(
     assert coordinator["session_history"] == {}
     assert coordinator["battery_config"] == {}
     assert coordinator["inverters"] == {}
+
+
+@pytest.mark.asyncio
+async def test_config_diagnostics_redacts_raw_inverter_identifiers(
+    hass, config_entry
+) -> None:
+    """Raw inverter identifiers must not survive config diagnostics redaction."""
+
+    raw_inverter_id = "987611111234"
+    production_only_inverter_id = "987622221234"
+    raw_serial = "INV-SERIAL-123456"
+    coord = DummyCoordinator()
+    coord._inverter_status_payload = {
+        raw_inverter_id: {
+            "deviceId": raw_inverter_id,
+            "serialNum": raw_serial,
+            "status": "normal",
+        }
+    }
+    coord._inverter_production_payload = {
+        "production": {
+            raw_inverter_id: 123.0,
+            production_only_inverter_id: 456.0,
+        }
+    }
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
+
+    inverter_diag = diag["coordinator"]["inverters"]
+    serialized = json.dumps(inverter_diag, default=str)
+    assert raw_inverter_id not in serialized
+    assert production_only_inverter_id not in serialized
+    assert raw_serial not in serialized
+    status_key, status = next(iter(inverter_diag["status_payload"].items()))
+    assert status["deviceId"] == "**REDACTED**"
+    assert status["serialNum"] == "**REDACTED**"
+    assert inverter_diag["production_payload"]["production"][status_key] == 123.0
+    assert sorted(inverter_diag["production_payload"]["production"].values()) == [
+        123.0,
+        456.0,
+    ]
+    assert inverter_diag["summary_counts"]["total"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -75,6 +75,28 @@ from custom_components.enphase_ev.services import async_setup_services
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
 
 
+@pytest.fixture(autouse=True)
+def _expose_admin_service_handlers_for_unit_tests(monkeypatch) -> None:
+    """Keep direct handler tests focused on routing, not HA authorization."""
+
+    def fake_register_admin(
+        hass, domain, service, handler, schema=None, supports_response=None, **kwargs
+    ) -> None:
+        hass.services.async_register(
+            domain,
+            service,
+            handler,
+            schema,
+            supports_response,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.async_register_admin_service",
+        fake_register_admin,
+    )
+
+
 def _with_inventory_view(coord):
     coord.inventory_view = SimpleNamespace(
         iter_type_keys=getattr(coord, "iter_type_keys", lambda: []),
@@ -2358,7 +2380,7 @@ async def test_registered_services_cover_branches(
 
     monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
 
-    def fake_register_admin(hass_, domain, service, handler, schema, **kwargs):
+    def fake_register_admin(hass_, domain, service, handler, schema=None, **kwargs):
         hass_.services.async_register(domain, service, handler, schema=schema, **kwargs)
 
     monkeypatch.setattr(

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -86,6 +86,94 @@ async def test_grid_mode_services_require_admin(hass: HomeAssistant) -> None:
         )
 
 
+@pytest.mark.parametrize(
+    ("service", "data"),
+    (
+        ("set_grid_profile", {"profile_id": "agf:test", "confirm": True}),
+        ("start_charging", {}),
+        ("stop_charging", {}),
+        ("trigger_message", {"requested_message": "Heartbeat"}),
+        ("try_reauth_now", {}),
+        ("clear_hems_auth_backoff", {}),
+        ("start_live_stream", {}),
+        ("stop_live_stream", {}),
+        (
+            "add_schedule",
+            {
+                "schedule_type": "cfg",
+                "start_time": "01:00",
+                "end_time": "02:00",
+                "limit": 50,
+                "days": [1],
+            },
+        ),
+        (
+            "update_schedule",
+            {
+                "schedule_id": "schedule-1",
+                "schedule_type": "cfg",
+                "start_time": "01:00",
+                "end_time": "02:00",
+                "limit": 50,
+                "days": [1],
+                "confirm": True,
+            },
+        ),
+        ("delete_schedule", {"schedule_id": "schedule-1", "confirm": True}),
+        ("update_cfg_schedule", {"limit": 50}),
+        (
+            "update_tariff",
+            {
+                "billing_start_date": "2026-01-01",
+                "billing_frequency": "MONTH",
+                "billing_interval_value": 1,
+            },
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_credentialed_control_services_require_admin(
+    hass: HomeAssistant, service: str, data: dict[str, object]
+) -> None:
+    """Non-admin users must not invoke services backed by stored credentials."""
+
+    async_setup_services(hass)
+    await hass.auth.async_create_user("Owner", group_ids=[GROUP_ID_ADMIN])
+    user = await hass.auth.async_create_user(
+        "Control service user", group_ids=[GROUP_ID_USER]
+    )
+
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            data,
+            blocking=True,
+            context=Context(user_id=user.id),
+        )
+
+
+@pytest.mark.asyncio
+async def test_admin_reaches_credentialed_control_handler(hass: HomeAssistant) -> None:
+    """Admin callers must continue through authorization to service validation."""
+
+    async_setup_services(hass)
+    admin = await hass.auth.async_create_user(
+        "Control service owner", group_ids=[GROUP_ID_ADMIN]
+    )
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            "start_charging",
+            {},
+            blocking=True,
+            context=Context(user_id=admin.id),
+        )
+
+    assert err.value.translation_key == "grid_site_required"
+
+
 def _register_service_handlers(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> dict[tuple[str, str], object]:
@@ -94,7 +182,23 @@ def _register_service_handlers(
     def fake_register(self, domain, service, handler, schema=None, *args, **kwargs):
         registered[(domain, service)] = handler
 
+    def fake_register_admin(
+        hass_, domain, service, handler, schema=None, supports_response=None, **kwargs
+    ):
+        hass_.services.async_register(
+            domain,
+            service,
+            handler,
+            schema,
+            supports_response,
+            **kwargs,
+        )
+
     monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.async_register_admin_service",
+        fake_register_admin,
+    )
     async_setup_services(hass)
     return registered
 
@@ -111,7 +215,23 @@ def _register_service_metadata(
             "kwargs": kwargs,
         }
 
+    def fake_register_admin(
+        hass_, domain, service, handler, schema=None, supports_response=None, **kwargs
+    ):
+        hass_.services.async_register(
+            domain,
+            service,
+            handler,
+            schema,
+            supports_response,
+            **kwargs,
+        )
+
     monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.async_register_admin_service",
+        fake_register_admin,
+    )
     async_setup_services(hass)
     return registered
 


### PR DESCRIPTION
## Summary

- Require Home Assistant administrator access for credential-backed charger control, reauthentication, live-stream, battery schedule, tariff, and Grid Profile service actions.
- Redact raw inverter and device identifiers from exported diagnostics, including identifiers used as mapping keys.
- Preserve inverter diagnostic cardinality and cross-payload correlation with opaque, collision-safe aliases.
- Add integration regressions for non-admin service calls and raw identifier disclosure.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/diagnostics.py custom_components/enphase_ev/services.py tests/components/enphase_ev/test_battery_schedule_editor_parity.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_services.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /tmp/ha-enphase-precommit.bEzioG:/precommit-cache -e PRE_COMMIT_HOME=/precommit-cache ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/diagnostics.py,custom_components/enphase_ev/services.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

- Full repository suite: 4,058 passed, 2 skipped.
- Integration suite: 3,926 passed.
- Targeted coverage: 100% for `diagnostics.py` and `services.py`.
- The standalone container Ruff is newer than the repository pin and reports pre-existing findings; the pinned all-files Ruff hook passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Exported inverter status and production maps now use shared opaque aliases such as `[inverter_1]`. This removes raw identifiers without merging distinct records or losing the relationship between corresponding status and production values.
