### PR TITLE
Optimize integration imports

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import importlib
 import inspect
 import logging
 import re
 import time as _time
 from typing import TYPE_CHECKING, Any, Coroutine, cast
 
-import aiohttp
 from homeassistant.config_entries import ConfigEntryState, OperationNotAllowed
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import (
@@ -17,7 +17,6 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
 )
-from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
     CONF_EMAIL,
@@ -82,6 +81,8 @@ from .serial_entity_metadata import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
+    import aiohttp
+
     from .coordinator import EnphaseCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -108,6 +109,34 @@ _RUNTIME_HANDOFF_DATA_KEYS = frozenset(
 )
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+_SETUP_MODULES = (
+    "aiohttp",
+    f"{__package__}.battery_schedule_editor",
+    f"{__package__}.coordinator",
+    f"{__package__}.evse_firmware",
+    f"{__package__}.evse_schedule_editor",
+    f"{__package__}.firmware_catalog",
+    f"{__package__}.gateway_software_update",
+    f"{__package__}.labels",
+)
+
+
+def _load_setup_modules() -> None:
+    """Load setup-only modules from Home Assistant's executor."""
+
+    for module_name in _SETUP_MODULES:
+        importlib.import_module(module_name)
+
+
+def async_create_clientsession(*args: Any, **kwargs: Any) -> aiohttp.ClientSession:
+    """Create a Home Assistant client session without loading it at import time."""
+
+    from homeassistant.helpers.aiohttp_client import (
+        async_create_clientsession as create_clientsession,
+    )
+
+    return create_clientsession(*args, **kwargs)
 
 
 def async_setup_services(
@@ -1743,6 +1772,8 @@ async def _async_setup_entry_impl(
     # Ensure services are present after config-entry reloads/transient unload states.
     async_setup_services(hass, supports_response=SupportsResponse)
 
+    await hass.async_add_import_executor_job(_load_setup_modules)
+
     # Create and prime the coordinator once, used by all platforms
     from .coordinator import (
         EnphaseCoordinator,
@@ -1780,6 +1811,8 @@ async def _async_setup_entry_impl(
         preserved_runtime.applied_data = dict(entry.data)
         preserved_runtime.applied_options = dict(entry.options)
     else:
+        import aiohttp
+
         coord = EnphaseCoordinator(
             hass,
             entry.data,

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -6,8 +6,8 @@ import asyncio
 import logging
 import re
 import time
-from collections.abc import Mapping
-from typing import Any, cast
+from collections.abc import Callable, Mapping
+from typing import TYPE_CHECKING, Any, cast
 
 import voluptuous as vol
 from homeassistant import config_entries
@@ -15,7 +15,6 @@ from homeassistant.const import CONF_PASSWORD
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult, section
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.selector import selector
 from homeassistant.helpers.translation import (
     async_get_cached_translations,
@@ -142,10 +141,14 @@ from .grid_profile_runtime import (
     GridProfile,
     GridProfileRuntime,
 )
-from .runtime_data import EnphaseConfigEntry
 from .log_redaction import redact_site_id, redact_text
+from .runtime_data import EnphaseConfigEntry
 from .runtime_helpers import normalize_poll_intervals
 from .voltage import coerce_nominal_voltage, resolve_nominal_voltage_for_hass
+
+if TYPE_CHECKING:  # pragma: no cover
+    import aiohttp
+    from homeassistant.core import HomeAssistant
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -159,6 +162,27 @@ CONF_TYPE_IQEVSE = "type_iqevse"
 CONF_TYPE_HEATPUMP = "type_heatpump"
 CONF_TYPE_MICROINVERTER = "type_microinverter"
 CONF_DEVICE_CATEGORIES_SECTION = "devices"
+
+
+def _load_get_clientsession() -> Callable[[HomeAssistant], aiohttp.ClientSession]:
+    """Load the Home Assistant session factory outside the event loop."""
+
+    from homeassistant.helpers.aiohttp_client import (
+        async_get_clientsession as get_clientsession,
+    )
+
+    return cast("Callable[[HomeAssistant], aiohttp.ClientSession]", get_clientsession)
+
+
+async def async_get_clientsession(hass: HomeAssistant) -> aiohttp.ClientSession:
+    """Return the shared client session without loading it at import time."""
+
+    get_clientsession = await hass.async_add_import_executor_job(
+        _load_get_clientsession
+    )
+    return get_clientsession(hass)
+
+
 CONF_DEVICE_FEATURES_SECTION = "device_features"
 CONF_MIGRATION_SOURCE_ENTRY = "selected_envoy_source"
 CONF_MIGRATION_BACKUP_CONFIRMED = "backup_confirmed"
@@ -383,7 +407,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
             remember = bool(user_input.get(CONF_REMEMBER_PASSWORD, False))
             self._clear_mfa()
 
-            session = async_get_clientsession(self.hass)
+            session = await async_get_clientsession(self.hass)
             try:
                 tokens, sites = await async_authenticate(session, email, password)
             except EnlightenAuthInvalidCredentials:
@@ -490,7 +514,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
             resend = bool(user_input.get(CONF_RESEND_CODE, False))
             otp = str(user_input.get(CONF_OTP, "")).strip()
 
-            session = async_get_clientsession(self.hass)
+            session = await async_get_clientsession(self.hass)
 
             if resend:
                 if not self._mfa_can_resend():
@@ -551,7 +575,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
     async def _send_mfa_code(self) -> dict[str, str]:
         if not self._mfa_tokens or not self._mfa_tokens.raw_cookies:
             return {"base": "unknown"}
-        session = async_get_clientsession(self.hass)
+        session = await async_get_clientsession(self.hass)
         try:
             updated = await async_resend_login_otp(
                 session, self._mfa_tokens.raw_cookies
@@ -859,7 +883,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
         if not self._auth_tokens or not self._selected_site_id:
             self._chargers_loaded = True
             return
-        session = async_get_clientsession(self.hass)
+        session = await async_get_clientsession(self.hass)
         chargers = await async_fetch_chargers(
             session, self._selected_site_id, self._auth_tokens
         )
@@ -875,7 +899,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
             self._available_type_keys = []
             self._inventory_iqevse_serials = []
             return
-        session = async_get_clientsession(self.hass)
+        session = await async_get_clientsession(self.hass)
         discovery_results = await asyncio.gather(
             async_fetch_devices_inventory(
                 session, self._selected_site_id, self._auth_tokens
@@ -1378,7 +1402,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[misc]
         if tokens is None or not site_id:
             return False
         payload = await async_fetch_battery_site_settings(
-            async_get_clientsession(self.hass),
+            await async_get_clientsession(self.hass),
             site_id,
             tokens,
         )
@@ -1692,7 +1716,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[misc]
             or self._entry.data.get(CONF_ACCESS_TOKEN),
             token_expires_at=self._entry.data.get(CONF_TOKEN_EXPIRES_AT),
         )
-        session = async_get_clientsession(self.hass)
+        session = await async_get_clientsession(self.hass)
 
         discovered: list[str] = []
         try:

--- a/tests/components/enphase_ev/conftest.py
+++ b/tests/components/enphase_ev/conftest.py
@@ -333,15 +333,16 @@ def mock_clientsession(monkeypatch):
 
     stateless_session = StatelessSession()
     create_calls = []
-    for target in (
+    monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.async_get_clientsession",
+        lambda *args, **kwargs: session,
+        raising=False,
+    )
+    monkeypatch.setattr(
         "custom_components.enphase_ev.config_flow.async_get_clientsession",
-    ):
-        monkeypatch.setattr(
-            target,
-            lambda *args, **kwargs: session,
-            raising=False,
-        )
+        AsyncMock(return_value=session),
+        raising=False,
+    )
     monkeypatch.setattr(
         "custom_components.enphase_ev.async_create_clientsession",
         lambda *args, **kwargs: create_calls.append((args, kwargs))

--- a/tests/components/enphase_ev/test_performance_audit_regressions.py
+++ b/tests/components/enphase_ev/test_performance_audit_regressions.py
@@ -13,6 +13,12 @@ import pytest
 
 from homeassistant.util import dt as dt_util
 
+from custom_components.enphase_ev import (
+    async_create_clientsession as lazy_create_clientsession,
+)
+from custom_components.enphase_ev.config_flow import (
+    async_get_clientsession as lazy_get_clientsession,
+)
 from custom_components.enphase_ev.const import (
     DEFAULT_CHARGE_LEVEL_SETTING,
     PHASE_SWITCH_CONFIG_SETTING,
@@ -22,22 +28,33 @@ from custom_components.enphase_ev.session_history import SessionCacheView
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
 
 
-def test_config_flow_import_keeps_heavy_modules_lazy() -> None:
-    script = """
+@pytest.mark.parametrize(
+    "target",
+    (
+        "custom_components.enphase_ev",
+        "custom_components.enphase_ev.config_flow",
+    ),
+)
+def test_import_keeps_heavy_modules_lazy(target: str) -> None:
+    script = f"""
 import importlib
 import json
 import sys
 
-importlib.import_module("custom_components.enphase_ev.config_flow")
-print(json.dumps({
+importlib.import_module({target!r})
+print(json.dumps({{
     name: name in sys.modules
     for name in (
-        "custom_components.enphase_ev.config_flow",
+        {target!r},
         "custom_components.enphase_ev.services",
         "homeassistant.components.recorder",
         "homeassistant.components.recorder.statistics",
+        "homeassistant.helpers.aiohttp_client",
+        "homeassistant.components.zeroconf",
+        "hass_nabucasa",
+        "boto3",
     )
-}))
+}}))
 """
 
     result = subprocess.run(
@@ -48,10 +65,29 @@ print(json.dumps({
     )
     modules = json.loads(result.stdout)
 
-    assert modules["custom_components.enphase_ev.config_flow"] is True
-    assert modules["custom_components.enphase_ev.services"] is False
-    assert modules["homeassistant.components.recorder"] is False
-    assert modules["homeassistant.components.recorder.statistics"] is False
+    assert modules.pop(target) is True
+    assert not any(modules.values())
+
+
+@pytest.mark.asyncio
+async def test_lazy_clientsession_wrappers_delegate(monkeypatch) -> None:
+    from homeassistant.helpers import aiohttp_client
+
+    get_session = MagicMock(return_value=object())
+    create_session = MagicMock(return_value=object())
+    monkeypatch.setattr(aiohttp_client, "async_get_clientsession", get_session)
+    monkeypatch.setattr(aiohttp_client, "async_create_clientsession", create_session)
+    hass = MagicMock()
+    hass.async_add_import_executor_job = AsyncMock(side_effect=lambda job: job())
+
+    assert await lazy_get_clientsession(hass) is get_session.return_value
+    assert (
+        lazy_create_clientsession(hass, auto_cleanup=True)
+        is create_session.return_value
+    )
+    hass.async_add_import_executor_job.assert_awaited_once()
+    get_session.assert_called_once_with(hass)
+    create_session.assert_called_once_with(hass, auto_cleanup=True)
 
 
 def _prepare_refresh_target(


### PR DESCRIPTION
## Summary

- Defer heavy Home Assistant and `aiohttp` imports until they are needed.
- Load first-use config-flow and setup imports through Home Assistant's import executor so cold imports do not block the event loop.
- Add regression coverage for package/config-flow import boundaries and executor usage.

Cold config-flow import measurements improved from approximately 963 ms median to 523 ms median (about 46%). In the first-use heartbeat probe, imports still took 891 ms and 1389 ms in worker threads, while event-loop heartbeat delays remained approximately 14 ms and 11 ms respectively.

## Related Issues

Performance audit follow-up; no linked issue.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Passed:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/config_flow.py tests/components/enphase_ev/conftest.py tests/components/enphase_ev/test_performance_audit_regressions.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/config_flow.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Results: 3,928 integration tests passed; 4,060 repository tests passed with 2 skipped; touched source modules remained at 100% coverage.

Known repository/environment exceptions:

- `ruff check .` reports 7,018 existing repository-wide violations, including pre-existing violations in touched files.
- `python -m pre_commit run --all-files` cannot detect this external Git worktree from the Docker source mount and exits before running hooks.
- The environment emits an external Rich `SyntaxWarning` from `rich/segment.py`; it is unrelated to this change.

## Checklist

- [x] No changelog update is needed; runtime behavior and user-facing features are unchanged.
- [x] No documentation update is needed; behavior and options are unchanged.
- [x] No translation changes are present.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The optimization changes import timing only. API refresh behavior and entity behavior are unchanged.
