### PR TITLE
Prepare release 4.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v4.2.4 - 2026-08-15
+
+### 🚧 Breaking changes
 - Restricted credential-backed charger, reauthentication, live-stream, battery
   schedule, tariff, and Grid Profile service actions to Home Assistant
   administrators.
@@ -17,10 +34,11 @@ All notable changes to this project will be documented in this file.
   from exported diagnostics.
 
 ### 🔧 Improvements
-- None
+- Deferred setup-only imports to Home Assistant's executor to reduce event-loop
+  blocking during integration and config-flow startup. (#828)
 
 ### 🔄 Other changes
-- None
+- Bumped the integration manifest version to `4.2.4`.
 
 ## v4.2.3 - 2026-08-12
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "4.2.3"
+  "version": "4.2.4"
 }


### PR DESCRIPTION
## Summary

Prepare release 4.2.4 by bumping the integration manifest version and promoting the current Unreleased changelog entries into a dated release section.

The release notes cover the administrator restriction for credential-backed service actions, diagnostics identifier redaction, and the integration import optimization merged since 4.2.3.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (release preparation)

## Testing

Passed:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm -v /tmp/enphase-precommit-cache.Ma2OkZ:/root/.cache -v /tmp/enphase-precommit-tmp.9l1C79:/tmp ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

The direct repository-wide `ruff check .` command reports 7,014 existing findings on the synced `origin/main` baseline. The repository-pinned Ruff pre-commit hook passed across all files. Black and targeted Python coverage are not applicable because this release-only change touches no Python files.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation changes are limited to the release changelog.
- [x] Translations are unaffected.
- [x] Targeted Python coverage is not applicable because no Python modules changed.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots are required for this release metadata update.
