### PR TITLE
Update pytest to 9.0.3

### DIFF
--- a/devtools/docker/requirements-ci-scripts.txt
+++ b/devtools/docker/requirements-ci-scripts.txt
@@ -1,4 +1,4 @@
 # Lightweight dependencies for maintenance-script tests.
 PyYAML==6.0.3
-pytest==9.0.0
+pytest==9.0.3
 pytest-asyncio==1.3.0

--- a/devtools/docker/requirements-min-ha.txt
+++ b/devtools/docker/requirements-min-ha.txt
@@ -17,7 +17,7 @@ paho-mqtt==2.1.0
 pydantic==2.12.2
 pipdeptree==2.26.1
 pylint-per-file-ignores==1.4.0
-pytest==9.0.0
+pytest==9.0.3
 pytest-aiohttp==1.1.0
 pytest-asyncio==1.3.0
 pytest-cov==7.0.0


### PR DESCRIPTION
## Summary

Update both direct pytest pins from 9.0.0 to 9.0.3.

Pytest 9.0.3 fixes the insecure Unix temporary-directory handling reported by Dependabot alert #5 (CVE-2025-71176 / GHSA-6w46-j5rx-g56g). Updating both manifests covers the maintenance-script and minimum-Home-Assistant CI environments while preserving their existing dependency structure.

## Related Issues

- Dependabot alert: https://github.com/barneyonline/ha-enphase-energy/security/dependabot/5
- Advisory: https://github.com/advisories/GHSA-6w46-j5rx-g56g

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

The isolated worktree was streamed into the pinned `docker-ha-dev` image because Docker Desktop did not expose the `/private/tmp` bind mount.

```bash
python -m venv /tmp/pytest-ci-scripts
/tmp/pytest-ci-scripts/bin/python -m pip install -r devtools/docker/requirements-ci-scripts.txt
/tmp/pytest-ci-scripts/bin/python -c 'import pytest; assert pytest.__version__ == "9.0.3", pytest.__version__'
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_PLUGINS=pytest_asyncio.plugin /tmp/pytest-ci-scripts/bin/pytest -q tests/scripts
```

Result: 137 passed.

```bash
python -m venv /tmp/pytest-min-ha
/tmp/pytest-min-ha/bin/python -m pip install -r devtools/docker/requirements-min-ha.txt
/tmp/pytest-min-ha/bin/python -m pip install --no-deps "pytest-homeassistant-custom-component==0.13.340"
/tmp/pytest-min-ha/bin/python -c 'import pytest; from homeassistant.const import __version__; assert pytest.__version__ == "9.0.3", pytest.__version__; assert __version__ == "2026.6.0", __version__'
PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_PLUGINS=pytest_asyncio.plugin,pytest_homeassistant_custom_component.plugins,pytest_github_actions_annotate_failures.plugin /tmp/pytest-min-ha/bin/pytest -q tests/components/enphase_ev/test_manifest.py tests/components/enphase_ev/test_device_action.py tests/components/enphase_ev/test_device_trigger.py tests/components/enphase_ev/test_schedule_sync.py tests/components/enphase_ev/test_services.py
```

Result: 177 passed.

```bash
python scripts/validate_quality_scale.py
python scripts/validate_quality_scale.py --validate-remote-brands
python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log
mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev
pytest -q tests/components/enphase_ev/test_service_translations.py
pytest -q
pre-commit run --files devtools/docker/requirements-ci-scripts.txt devtools/docker/requirements-min-ha.txt
git diff --check origin/main...HEAD
```

Results:

- Quality Scale validation: passed
- Remote brands validation: passed
- Import-time validation: passed
- Mypy: passed, 88 source files
- Translation tests: 54 passed
- Full test suite: 4,079 passed
- Changed-file pre-commit hooks: passed
- Diff validation: passed

`ruff check .` was also attempted and reported 7,014 existing findings across untouched Python files. The two-file dependency-only diff introduces no Ruff-applicable changes.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes. (Not applicable: developer/CI dependency only.)
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed. (Not applicable: no behavior or options changed.)
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] Targeted Python coverage is not applicable because no Python modules changed.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate). (Pending.)
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No runtime integration code or Home Assistant dependencies are changed. The patch only replaces two direct pytest 9.0.0 pins with the upstream patched 9.0.3 release.