### PR TITLE
Stabilize Ruff configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
         args: [--check]
         files: "^((custom_components/enphase_ev|tests/components/enphase_ev)/.*|scripts/validate_quality_scale|tests/scripts/test_validate_quality_scale)\\.py$"
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.16.4
     hooks:
       - id: ruff
         files: "^((custom_components/enphase_ev|tests/components/enphase_ev)/.*|scripts/validate_quality_scale|tests/scripts/test_validate_quality_scale)\\.py$"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,6 @@
+target-version = "py314"
+
+[lint]
+# Keep local Docker checks and pre-commit on a stable rule baseline instead of
+# inheriting Ruff's version-dependent defaults.
+select = ["E4", "E7", "E9", "F"]

--- a/devtools/docker/requirements-dev.txt
+++ b/devtools/docker/requirements-dev.txt
@@ -5,7 +5,7 @@ pytest-homeassistant-custom-component
 pytest-cov
 PyYAML
 mypy==2.2.0
-ruff
+ruff==0.16.4
 black
 freezegun
 pre-commit


### PR DESCRIPTION
## Summary

Pin Ruff 0.16.4 across the Docker development environment and pre-commit, and add an explicit Python 3.14 Ruff configuration.

This keeps local, Docker, and CI lint results consistent instead of inheriting Ruff's version-dependent default rule set.

## Related Issues

Addresses the Ruff failures observed after the development environment began resolving Ruff 0.16.x.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Commands were run using the freshly rebuilt pinned `docker-ha-dev` image:

```bash
docker compose -f devtools/docker/docker-compose.yml build ha-dev
ruff check .
python -m pre_commit run --all-files
python scripts/validate_quality_scale.py
python scripts/validate_quality_scale.py --validate-remote-brands
python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log
mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev
pytest -q tests/components/enphase_ev/test_service_translations.py
pytest -q
```

Results:

- Ruff 0.16.4: passed
- Pre-commit all files: passed
- Mypy: 88 source files passed
- Translation tests: 54 passed
- Full test suite: 4,079 passed

No Python modules were changed, so targeted Python coverage is not applicable.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes. (Not applicable; developer tooling only.)
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed. (Not applicable.)
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (No translation changes; translation tests passed.)
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage. (Not applicable; no Python modules changed.)
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The Docker development requirements previously left Ruff unpinned while pre-commit used Ruff 0.6.9. Ruff 0.16.x expanded its default lint rule set, causing thousands of failures unrelated to source changes. The new configuration preserves the repository's established `E4`, `E7`, `E9`, and `F` baseline explicitly.