### PR TITLE
Support Home Assistant 2026.9 device registry iteration

### DIFF
--- a/custom_components/enphase_ev/entity_cleanup.py
+++ b/custom_components/enphase_ev/entity_cleanup.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Mapping
 
 from homeassistant.helpers import entity_registry as er
 
@@ -32,14 +32,24 @@ def iter_device_registry_entries(dev_reg: object) -> list[object]:
     devices = getattr(dev_reg, "devices", None)
     if devices is None:
         return []
+    if isinstance(devices, dict):
+        return list(dict.values(devices))
+    if isinstance(devices, Mapping):
+        try:
+            return list(devices.values())
+        except Exception:  # noqa: BLE001
+            return []
+    if isinstance(devices, Iterable):
+        try:
+            return list(devices)
+        except Exception:  # noqa: BLE001
+            return []
     values = getattr(devices, "values", None)
     if callable(values):
         try:
             return list(values())
         except Exception:  # noqa: BLE001
             return []
-    if isinstance(devices, dict):
-        return list(dict.values(devices))
     return []
 
 

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+from collections import UserDict
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, call
@@ -391,6 +392,41 @@ def test_complete_startup_migrations_clears_reload_suppression_when_update_not_a
 
 def test_iter_device_registry_entries_handles_edge_paths() -> None:
     assert _iter_device_registry_entries(SimpleNamespace()) == []
+
+    device_entries = [SimpleNamespace(id="dev-1"), SimpleNamespace(id="dev-2")]
+
+    class DeviceCollection:
+        def __iter__(self):
+            return iter(device_entries)
+
+        def values(self):
+            raise AssertionError("collection values() must not be called")
+
+    assert (
+        _iter_device_registry_entries(SimpleNamespace(devices=DeviceCollection()))
+        == device_entries
+    )
+
+    class LegacyDevices:
+        def values(self):
+            return device_entries
+
+    assert (
+        _iter_device_registry_entries(SimpleNamespace(devices=LegacyDevices()))
+        == device_entries
+    )
+
+    class BadMapping(UserDict):
+        def values(self):
+            raise RuntimeError("boom")
+
+    assert _iter_device_registry_entries(SimpleNamespace(devices=BadMapping())) == []
+
+    class BadCollection:
+        def __iter__(self):
+            raise RuntimeError("boom")
+
+    assert _iter_device_registry_entries(SimpleNamespace(devices=BadCollection())) == []
 
     class BadDevices:
         def values(self):


### PR DESCRIPTION
## Summary

- Iterate Home Assistant 2026.9 device-registry collections without invoking the deprecated mapping compatibility shim.
- Preserve mapping-based iteration for older supported Home Assistant releases.
- Add regression coverage for collection, mapping, legacy fallback, and defensive failure paths.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/entity_cleanup.py tests/components/enphase_ev/test_init_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/entity_cleanup.py tests/components/enphase_ev/test_init_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/entity_cleanup.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

- Integration suite: 3,940 passed.
- Root suite: 4,079 passed.
- Targeted coverage: 100% for `custom_components/enphase_ev/entity_cleanup.py`.

## Checklist

- [x] `CHANGELOG.md` is not required because this only removes a framework deprecation warning without changing user-facing behavior.
- [x] Documentation is not required because supported behavior and options are unchanged.
- [x] Translations are unaffected.
- [x] I ran targeted coverage for the touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Home Assistant 2026.9 exposes `device_registry.devices` as a read-only collection whose supported enumeration API is direct iteration. Mapping access remains available only as a deprecated compatibility shim. The helper now distinguishes older mapping containers from the new collection interface.
