### PR TITLE
Fix already-processed profile cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed cancellation of stale IQ Battery profile changes when Enphase reports
+  that the request was already processed, while preserving sanitized HTTP error
+  messages and continuing to raise unrelated conflicts. (#839)
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -133,6 +133,7 @@ OCPP_TRIGGER_MESSAGES_REQUIRING_CONFIRMATION = frozenset(
 )
 _OCPP_TRIGGER_MESSAGE_MAX_LENGTH = 64
 _OCPP_TRIGGER_MESSAGE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]{0,63}$")
+_ENPHASE_ERROR_STATUS_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
 # Enlighten web pages and XHR endpoints share service capacity with the mobile
 # app. A module-level limiter keeps parallel refresh helpers from creating a
 # burst of browser-like reads during one Home Assistant update cycle.
@@ -429,6 +430,29 @@ def _safe_response_error_message(
     if body_text is not None:
         detail_parts.append(f"body_length={len(body_text)}")
     return f"HTTP error from Enphase endpoint ({', '.join(detail_parts)})"
+
+
+def _enphase_error_status_from_text(text: str | None) -> str | None:
+    """Return a bounded Enphase error status without retaining the response body."""
+
+    if not text:
+        return None
+    try:
+        payload = json.loads(text)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    status = error.get("status")
+    if not isinstance(status, str):
+        return None
+    normalized = status.strip().upper()
+    if not _ENPHASE_ERROR_STATUS_RE.fullmatch(normalized):
+        return None
+    return normalized
 
 
 def _scheduler_error_context_from_text(
@@ -4847,6 +4871,11 @@ class EnphaseEVClient:
                                         )
                                     ),
                                 )
+                                setattr(
+                                    response_error,
+                                    "enphase_error_status",
+                                    _enphase_error_status_from_text(body_text),
+                                )
                                 if _is_scheduler_charging_mode_endpoint(endpoint):
                                     code, display = _scheduler_error_context_from_text(
                                         body_text
@@ -5027,13 +5056,19 @@ class EnphaseEVClient:
                                 headers=r.headers,
                                 body_text=body_text,
                             )
-                            raise aiohttp.ClientResponseError(
+                            response_error = aiohttp.ClientResponseError(
                                 r.request_info,
                                 r.history,
                                 status=r.status,
                                 message=message,
                                 headers=r.headers,
                             )
+                            setattr(
+                                response_error,
+                                "enphase_error_status",
+                                _enphase_error_status_from_text(body_text),
+                            )
+                            raise response_error
                         text = await _timed_response_text(r)
                         if _is_enphase_login_wall(
                             endpoint=endpoint or None, payload=text

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1755,6 +1755,12 @@ class BatteryRuntime:
     ) -> bool:
         if err.status != HTTPStatus.CONFLICT:
             return False
+        error_status = getattr(err, "enphase_error_status", None)
+        if (
+            isinstance(error_status, str)
+            and error_status.strip().upper() == "ALREADY_PROCESSED"
+        ):
+            return True
         raw_message = getattr(err, "message", None)
         if not isinstance(raw_message, str) or not raw_message.strip():
             return False

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -164,6 +164,25 @@ def test_safe_response_error_message_handles_header_failures() -> None:
     assert "content_type" not in message
 
 
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (None, None),
+        ("not-json", None),
+        (json.dumps(["bad"]), None),
+        (json.dumps({"error": "bad"}), None),
+        (json.dumps({"error": {"status": 409}}), None),
+        (json.dumps({"error": {"status": "contains spaces"}}), None),
+        (
+            json.dumps({"error": {"status": " already_processed "}}),
+            "ALREADY_PROCESSED",
+        ),
+    ],
+)
+def test_enphase_error_status_from_text(body, expected) -> None:
+    assert api._enphase_error_status_from_text(body) == expected  # noqa: SLF001
+
+
 def test_scheduler_error_code_ignores_unexpected_payload_shapes() -> None:
     assert api._scheduler_error_context_from_text(None) == (None, None)  # noqa: SLF001
     assert api._scheduler_error_context_from_text(
@@ -2056,6 +2075,35 @@ async def test_json_attaches_scheduler_error_context_without_raw_body() -> None:
         "display": "No Schedules enabled for Scheduled Charging",
     }
     assert not hasattr(err.value, "enphase_response_body")
+
+
+@pytest.mark.asyncio
+async def test_json_preserves_profile_cancel_status_without_raw_body() -> None:
+    body = json.dumps(
+        {
+            "error": {
+                "status": "ALREADY_PROCESSED",
+                "message": "Changes already processed.",
+            }
+        }
+    )
+    session = _FakeSession([_FakeResponse(status=409, json_body={}, text_body=body)])
+    client = api.EnphaseEVClient(session, "SITE", None, None)
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client._json(
+            "PUT",
+            "https://example.test/service/batteryConfig/api/v1/cancel/profile/SITE",
+            json={},
+        )
+
+    assert err.value.enphase_error_status == "ALREADY_PROCESSED"
+    assert "ALREADY_PROCESSED" not in err.value.message
+    assert not hasattr(err.value, "enphase_response_body")
+
+    from custom_components.enphase_ev.battery_runtime import BatteryRuntime
+
+    assert BatteryRuntime._is_already_processed_profile_cancel_error(err.value)
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -259,9 +259,14 @@ async def test_cancel_pending_profile_change_reraises_non_benign_conflict(
             message='{"error":{"status":"NOT_ALLOWED","message":"Denied."}}',
         )
     )
+    coord.client.cancel_battery_profile_update.side_effect.enphase_error_status = (
+        "NOT_ALLOWED"
+    )
 
     with pytest.raises(aiohttp.ClientResponseError):
         await coord.async_cancel_pending_profile_change()
+
+    assert coord.battery_profile_pending is True
 
 
 def test_pending_profile_timeout_issue_lifecycle(


### PR DESCRIPTION
## Summary

Fixes #839.

Enphase can return HTTP 409 with `error.status` set to `ALREADY_PROCESSED` when a stale battery profile change has already completed or been abandoned. The existing cancellation guard could not recognize that response after HTTP exception messages were sanitized, so the button raised and left local pending state stuck.

This change parses only a bounded, validated Enphase error-status token at the HTTP boundary and attaches it to the sanitized exception. Profile cancellation treats `ALREADY_PROCESSED` as an idempotent success while unrelated conflicts still raise and preserve pending state. The raw response body remains excluded from exception messages and attributes.

## Related Issues

- Regression of the cancellation handling introduced in #574 after response sanitization in #624.
- Related pending-state history: #301, #518, #520, #692, #694, and #800.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_battery_profile.py && ruff check custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_battery_profile.py'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'pytest -q tests/components/enphase_ev/test_api_client_methods.py::test_enphase_error_status_from_text tests/components/enphase_ev/test_api_client_methods.py::test_json_preserves_profile_cancel_status_without_raw_body tests/components/enphase_ev/test_coordinator_battery_profile.py::test_cancel_pending_profile_change_ignores_already_processed_conflict tests/components/enphase_ev/test_coordinator_battery_profile.py::test_cancel_pending_profile_change_reraises_non_benign_conflict'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/battery_runtime.py --fail-under=100'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev'
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc 'git config --global --add safe.directory /workspace && python -m pre_commit run --all-files'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'pytest -q'
```

- Focused regression cases: 10 passed.
- Integration suite: 3,948 passed.
- Full suite: 4,087 passed.
- Targeted coverage: 100% for `api.py` and `battery_runtime.py`.
- A read-only review-agent pass reported no findings.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] Documentation changes are not required for this narrow bug fix.
- [x] Translations are not affected.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The regression was reproduced locally by passing an actual sanitized HTTP 409 exception generated from an `ALREADY_PROCESSED` response into the runtime classifier.
- The structured status token is restricted to uppercase letters, digits, and underscores with a maximum length of 64 characters.
- No raw Enphase response body is retained on the exception.
