### PR TITLE
Fix live-stream service target resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed the administrator-only Start/Stop Live Stream actions so Home Assistant
+  entity, device, area, floor, and label targets, explicit site IDs, and config
+  entry IDs pass service validation and resolve to the intended Enphase site.
 
 ### 🔧 Improvements
-- None
+- Documented live-stream target selection and clarified the difference between
+  Home Assistant device IDs and numeric Enphase site IDs.
 
 ### 🔄 Other changes
 - None

--- a/README.md
+++ b/README.md
@@ -137,6 +137,23 @@ Manual install steps: see the wiki Installation page.
 
 Sign in with your Enlighten credentials; MFA is supported. See the wiki for details.
 
+## Live-stream actions
+
+`enphase_ev.start_live_stream` and `enphase_ev.stop_live_stream` are
+administrator-only, site-scoped actions for IQ EV Charger live updates. Select an
+Enphase entity, device, area, floor, or label belonging to the intended site, or
+enter the numeric Enphase site ID under Advanced options. A selected entity only
+identifies its owning site; it does not limit updates to that entity.
+
+When writing YAML manually, `device_id` means the Home Assistant device-registry
+ID. Use `site_id` for the numeric identifier shown by Enphase.
+
+```yaml
+action: enphase_ev.start_live_stream
+target:
+  entity_id: sensor.iq_battery_battery_available_power
+```
+
 ## Documentation
 
 Refer to the [Wiki](https://github.com/barneyonline/ha-enphase-energy/wiki) for setup,

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -331,6 +331,22 @@ def async_setup_services(
     CLEAR_SCHEMA = vol.Schema(
         {vol.Optional("device_id"): DEVICE_ID_LIST, vol.Optional("site_id"): cv.string}
     )
+    STREAM_SITE_SCHEMA = vol.Schema(
+        {
+            vol.Remove("metadata"): dict,
+            vol.Optional("site_id"): cv.string,
+            vol.Optional("config_entry_id"): cv.string,
+        }
+    )
+    STREAM_SCHEMA = vol.Any(
+        cv.make_entity_service_schema(
+            {
+                vol.Optional("site_id"): cv.string,
+                vol.Optional("config_entry_id"): cv.string,
+            }
+        ),
+        STREAM_SITE_SCHEMA,
+    )
     SYNC_SCHEMA = vol.Schema({vol.Optional("device_id"): DEVICE_ID_LIST})
     FORCE_REFRESH_SCHEMA = vol.Schema(
         {
@@ -740,14 +756,46 @@ def async_setup_services(
         _validate_update_tariff,
     )
 
-    def _extract_device_ids(call: ServiceCall) -> list[str]:
+    def _extract_target_references(
+        call: ServiceCall,
+    ) -> tuple[set[str], set[str], set[str], bool]:
+        referenced_entity_ids: set[str] = set()
+        indirect_entity_ids: set[str] = set()
         device_ids: set[str] = set()
+        extractor = getattr(ha_target, "async_extract_referenced_entity_ids", None)
+        target_selection = getattr(ha_target, "TargetSelection", None)
+        if not callable(extractor):
+            return referenced_entity_ids, indirect_entity_ids, device_ids, False
         try:
-            extractor = getattr(ha_service, "async_extract_referenced_device_ids", None)
-            if callable(extractor):
-                device_ids |= {str(value) for value in extractor(hass, call)}
+            selection = (
+                target_selection(call.data) if callable(target_selection) else call
+            )
+            selected = extractor(hass, selection)
         except Exception:
-            pass
+            return referenced_entity_ids, indirect_entity_ids, device_ids, False
+        referenced = getattr(selected, "referenced", None)
+        indirectly_referenced = getattr(selected, "indirectly_referenced", None)
+        referenced_devices = getattr(selected, "referenced_devices", None)
+        if referenced is None and indirectly_referenced is None:
+            referenced_entity_ids |= {str(entity_id) for entity_id in selected}
+        else:
+            referenced_entity_ids |= {str(entity_id) for entity_id in referenced or ()}
+            indirect_entity_ids |= {
+                str(entity_id) for entity_id in indirectly_referenced or ()
+            }
+        device_ids |= {str(device_id) for device_id in referenced_devices or ()}
+        return referenced_entity_ids, indirect_entity_ids, device_ids, True
+
+    def _extract_device_ids(call: ServiceCall) -> list[str]:
+        _entity_ids, _indirect_entity_ids, device_ids, _extracted = (
+            _extract_target_references(call)
+        )
+        extractor = getattr(ha_service, "async_extract_referenced_device_ids", None)
+        if callable(extractor):
+            try:
+                device_ids |= {str(value) for value in extractor(hass, call)}
+            except Exception:
+                pass
         data_ids = call.data.get("device_id")
         if data_ids:
             if isinstance(data_ids, str):
@@ -756,12 +804,51 @@ def async_setup_services(
                 device_ids |= {str(v) for v in data_ids}
         return list(device_ids)
 
+    def _extract_entity_ids(
+        call: ServiceCall, *, include_indirect: bool = False
+    ) -> list[str]:
+        entity_ids, indirect_entity_ids, _device_ids, extracted = (
+            _extract_target_references(call)
+        )
+        if include_indirect:
+            entity_ids |= indirect_entity_ids
+        if not extracted:
+            extractor = getattr(ha_service, "async_extract_referenced_entity_ids", None)
+            if callable(extractor):
+                try:
+                    entity_ids |= {
+                        str(entity_id) for entity_id in extractor(hass, call)
+                    }
+                except Exception:
+                    pass
+        raw_entity_ids = call.data.get("entity_id")
+        if raw_entity_ids:
+            if isinstance(raw_entity_ids, str):
+                entity_ids.add(raw_entity_ids)
+            else:
+                entity_ids |= {str(entity_id) for entity_id in raw_entity_ids}
+        return list(entity_ids)
+
     async def _resolve_site_ids_from_call(call: ServiceCall) -> set[str]:
         site_ids: set[str] = set()
         for device_id in _extract_device_ids(call):
             site_id = await _resolve_site_id(device_id)
             if site_id:
                 site_ids.add(site_id)
+        ent_reg = er.async_get(hass)
+        for entity_id in _extract_entity_ids(call, include_indirect=True):
+            reg_entry = ent_reg.async_get(entity_id)
+            if reg_entry is None or reg_entry.platform != DOMAIN:
+                continue
+            device_id = reg_entry.device_id
+            if device_id and (site_id := await _resolve_site_id(device_id)):
+                site_ids.add(site_id)
+                continue
+            config_entry_id = reg_entry.config_entry_id
+            if config_entry_id and (
+                coord := _get_coordinator_for_entry_id(config_entry_id)
+            ):
+                site_ids.add(str(coord.site_id))
         explicit = call.data.get("site_id")
         if explicit:
             site_ids.add(str(explicit))
@@ -795,31 +882,6 @@ def async_setup_services(
             translation_domain=DOMAIN,
             translation_key="grid_site_required",
         )
-
-    def _extract_entity_ids(call: ServiceCall) -> list[str]:
-        entity_ids: set[str] = set()
-        extractor = getattr(ha_target, "async_extract_referenced_entity_ids", None)
-        if callable(extractor):
-            try:
-                entity_ids |= {str(entity_id) for entity_id in extractor(hass, call)}
-            except Exception:
-                pass
-        else:
-            extractor = getattr(ha_service, "async_extract_referenced_entity_ids", None)
-            if callable(extractor):
-                try:
-                    entity_ids |= {
-                        str(entity_id) for entity_id in extractor(hass, call)
-                    }
-                except Exception:
-                    pass
-        raw_entity_ids = call.data.get("entity_id")
-        if raw_entity_ids:
-            if isinstance(raw_entity_ids, str):
-                entity_ids.add(raw_entity_ids)
-            else:
-                entity_ids |= {str(entity_id) for entity_id in raw_entity_ids}
-        return list(entity_ids)
 
     def _coordinator_from_tariff_entity(
         entity_id: str,
@@ -1851,8 +1913,12 @@ def async_setup_services(
         CLEAR_SCHEMA,
         supports_response=supports_response.OPTIONAL,
     )
-    async_register_admin_service(hass, DOMAIN, "start_live_stream", _svc_start_stream)
-    async_register_admin_service(hass, DOMAIN, "stop_live_stream", _svc_stop_stream)
+    async_register_admin_service(
+        hass, DOMAIN, "start_live_stream", _svc_start_stream, STREAM_SCHEMA
+    )
+    async_register_admin_service(
+        hass, DOMAIN, "stop_live_stream", _svc_stop_stream, STREAM_SCHEMA
+    )
     hass.services.async_register(
         DOMAIN, "sync_schedules", _svc_sync_schedules, schema=SYNC_SCHEMA
     )

--- a/tests/components/enphase_ev/test_entities_and_flow.py
+++ b/tests/components/enphase_ev/test_entities_and_flow.py
@@ -23,6 +23,9 @@ from custom_components.enphase_ev.const import (
     CONF_TOKEN_EXPIRES_AT,
     DOMAIN,
 )
+from custom_components.enphase_ev.device_registry_compat import (
+    get_device_by_identifier,
+)
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 from custom_components.enphase_ev.config_flow import CONF_TYPE_IQEVSE
 
@@ -150,18 +153,22 @@ async def test_integration_setup_creates_entities(
     coord = entry_data.coordinator
     assert coord is not None
 
-    gateway_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"type:{RANDOM_SITE_ID}:envoy")}
+    gateway_device = get_device_by_identifier(
+        device_registry,
+        (DOMAIN, f"type:{RANDOM_SITE_ID}:envoy"),
+        config_entry.entry_id,
     )
     assert gateway_device is not None
     assert gateway_device.name == "IQ Gateway"
 
-    charger_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, RANDOM_SERIAL)}
+    charger_device = get_device_by_identifier(
+        device_registry, (DOMAIN, RANDOM_SERIAL), config_entry.entry_id
     )
     assert charger_device is not None
-    ev_type_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"type:{RANDOM_SITE_ID}:iqevse")}
+    ev_type_device = get_device_by_identifier(
+        device_registry,
+        (DOMAIN, f"type:{RANDOM_SITE_ID}:iqevse"),
+        config_entry.entry_id,
     )
     assert ev_type_device is None
     assert charger_device.via_device_id is None

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -71,6 +71,10 @@ from custom_components.enphase_ev.const import (
     OPT_VPP_EVENTS_ENABLED,
 )
 from custom_components.enphase_ev.device_types import type_identifier
+from custom_components.enphase_ev.device_registry_compat import (
+    get_device_by_identifier,
+    via_device_kwargs,
+)
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 from custom_components.enphase_ev.services import async_setup_services
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
@@ -696,15 +700,19 @@ async def test_async_setup_entry_updates_existing_device(
     dummy_coord.schedule_sync.async_start.assert_awaited_once()
     forward.assert_awaited_once()
 
-    updated = device_registry.async_get_device(identifiers={(DOMAIN, RANDOM_SERIAL)})
+    updated = get_device_by_identifier(
+        device_registry, (DOMAIN, RANDOM_SERIAL), config_entry.entry_id
+    )
     assert updated is not None
     assert updated.name == "Garage Charger"
     assert updated.manufacturer == "Enphase"
     assert updated.model == "Garage Charger (IQ EVSE)"
     assert updated.hw_version == "321"
     assert updated.sw_version == "654"
-    ev_type_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"type:{site_id}:iqevse")}
+    ev_type_device = get_device_by_identifier(
+        device_registry,
+        (DOMAIN, f"type:{site_id}:iqevse"),
+        config_entry.entry_id,
     )
     assert ev_type_device is None
     assert updated.via_device_id is None
@@ -1224,7 +1232,11 @@ async def test_async_setup_entry_skips_legacy_cleanup_when_migration_current(
 
     assert dev_reg.async_get(legacy_site_device.id) is not None
     assert (
-        dev_reg.async_get_device(identifiers={(DOMAIN, f"type:{site_id}:envoy")})
+        get_device_by_identifier(
+            dev_reg,
+            (DOMAIN, f"type:{site_id}:envoy"),
+            config_entry.entry_id,
+        )
         is not None
     )
 
@@ -1732,11 +1744,11 @@ async def test_async_setup_entry_model_display_variants(
 
     assert await async_setup_entry(hass, config_entry)
 
-    model_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "MODEL_ONLY")}
+    model_device = get_device_by_identifier(
+        device_registry, (DOMAIN, "MODEL_ONLY"), config_entry.entry_id
     )
-    display_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "DISPLAY_ONLY")}
+    display_device = get_device_by_identifier(
+        device_registry, (DOMAIN, "DISPLAY_ONLY"), config_entry.entry_id
     )
 
     assert model_device is not None
@@ -1793,7 +1805,9 @@ async def test_async_setup_entry_uses_fallback_name_for_model(
 
     assert await async_setup_entry(hass, config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "FALLBACK_ONLY")})
+    device = get_device_by_identifier(
+        device_registry, (DOMAIN, "FALLBACK_ONLY"), config_entry.entry_id
+    )
     assert device is not None
     assert device.model == "Fallback Charger"
 
@@ -2472,7 +2486,11 @@ async def test_registered_services_cover_branches(
         identifiers={(DOMAIN, first_serial)},
         manufacturer="Enphase",
         name="Driveway Charger",
-        via_device=(DOMAIN, f"site:{site_id}"),
+        **via_device_kwargs(
+            device_registry,
+            via_device_id=site_device.id,
+            legacy_via_device=(DOMAIN, f"site:{site_id}"),
+        ),
     )
     charger_two = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -3367,7 +3385,7 @@ async def test_service_helper_resolve_functions_cover_none_branches(
     assert await resolve_device_routing_context(child_no_parent.id) is None
     assert await resolve_site(child_no_parent.id) is None
 
-    dev_reg.async_get_or_create(
+    parent_site_device = dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "site:PARENT")},
         manufacturer="Enphase",
@@ -3378,7 +3396,11 @@ async def test_service_helper_resolve_functions_cover_none_branches(
         identifiers={(DOMAIN, "EVCHILD")},
         manufacturer="Enphase",
         name="Child Device",
-        via_device=(DOMAIN, "site:PARENT"),
+        **via_device_kwargs(
+            dev_reg,
+            via_device_id=parent_site_device.id,
+            legacy_via_device=(DOMAIN, "site:PARENT"),
+        ),
     )
     assert await resolve_device_routing_context(child_with_via.id) == (
         "EVCHILD",
@@ -3401,7 +3423,11 @@ async def test_service_helper_resolve_functions_cover_none_branches(
         identifiers={(DOMAIN, "EVTYPED")},
         manufacturer="Enphase",
         name="Typed Child",
-        via_device=(DOMAIN, "type:TYPED:envoy"),
+        **via_device_kwargs(
+            dev_reg,
+            via_device_id=type_device.id,
+            legacy_via_device=(DOMAIN, "type:TYPED:envoy"),
+        ),
     )
     assert await resolve_site(child_with_type_parent.id) == "TYPED"
 
@@ -4079,7 +4105,11 @@ async def test_startup_migration_removes_evse_type_device_and_inventory_entity(
         identifiers={(DOMAIN, RANDOM_SERIAL)},
         manufacturer="Enphase",
         name="Garage Charger",
-        via_device=(DOMAIN, f"type:{site_id}:iqevse"),
+        **via_device_kwargs(
+            dev_reg,
+            via_device_id=evse_type.id,
+            legacy_via_device=(DOMAIN, f"type:{site_id}:iqevse"),
+        ),
     )
     entity = ent_reg.async_get_or_create(
         "sensor",
@@ -4957,8 +4987,10 @@ async def test_migrate_cloud_entities_to_cloud_device_rehomes_known_entities(
     coord = SimpleNamespace(site_id=site_id)
     _migrate_cloud_entities_to_cloud_device(hass, config_entry, coord, dev_reg, None)
 
-    cloud_device = dev_reg.async_get_device(
-        identifiers={(DOMAIN, f"type:{site_id}:cloud")}
+    cloud_device = get_device_by_identifier(
+        dev_reg,
+        (DOMAIN, f"type:{site_id}:cloud"),
+        config_entry.entry_id,
     )
     assert cloud_device is not None
 
@@ -5244,8 +5276,10 @@ async def test_migrate_cloud_entities_to_cloud_device_rehomes_legacy_cloud_suffi
     coord = SimpleNamespace(site_id=site_id)
     _migrate_cloud_entities_to_cloud_device(hass, config_entry, coord, dev_reg, None)
 
-    cloud_device = dev_reg.async_get_device(
-        identifiers={(DOMAIN, f"type:{site_id}:cloud")}
+    cloud_device = get_device_by_identifier(
+        dev_reg,
+        (DOMAIN, f"type:{site_id}:cloud"),
+        config_entry.entry_id,
     )
     assert cloud_device is not None
     reg_entry = ent_reg.async_get(legacy_cloud_error.entity_id)

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -21,6 +21,7 @@ from custom_components.enphase_ev.api import (
     OCPP_TRIGGER_MESSAGES_REQUIRING_CONFIRMATION,
 )
 from custom_components.enphase_ev.const import CONF_SITE_ID, CONF_SITE_ONLY, DOMAIN
+from custom_components.enphase_ev.device_registry_compat import via_device_kwargs
 from custom_components.enphase_ev.grid_profile_runtime import (
     SUPPORT_DENIED,
     SUPPORT_READ_ONLY,
@@ -945,7 +946,7 @@ async def test_services_route_evse_targets_to_owning_entry_with_site_only_entry(
         manufacturer="Enphase",
         name="Site Only Device",
     )
-    device_registry.async_get_or_create(
+    evse_site_device = device_registry.async_get_or_create(
         config_entry_id=evse_entry.entry_id,
         identifiers={(DOMAIN, "site:evse-site")},
         manufacturer="Enphase",
@@ -956,7 +957,11 @@ async def test_services_route_evse_targets_to_owning_entry_with_site_only_entry(
         identifiers={(DOMAIN, "EVSE123")},
         manufacturer="Enphase",
         name="Garage Charger",
-        via_device=(DOMAIN, "site:evse-site"),
+        **via_device_kwargs(
+            device_registry,
+            via_device_id=evse_site_device.id,
+            legacy_via_device=(DOMAIN, "site:evse-site"),
+        ),
     )
 
     await handlers[(DOMAIN, "start_charging")](
@@ -1250,7 +1255,7 @@ async def test_targeted_services_reject_mixed_valid_and_unknown_devices(
     entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     device_registry = dr.async_get(hass)
-    device_registry.async_get_or_create(
+    site_device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, "site:evse-site")},
         manufacturer="Enphase",
@@ -1261,7 +1266,11 @@ async def test_targeted_services_reject_mixed_valid_and_unknown_devices(
         identifiers={(DOMAIN, "EVSE123")},
         manufacturer="Enphase",
         name="Garage Charger",
-        via_device=(DOMAIN, "site:evse-site"),
+        **via_device_kwargs(
+            device_registry,
+            via_device_id=site_device.id,
+            legacy_via_device=(DOMAIN, "site:evse-site"),
+        ),
     )
     unknown_device_id = "missing-device-id"
 

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -12,6 +12,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.auth.const import GROUP_ID_ADMIN, GROUP_ID_USER
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import ServiceValidationError, Unauthorized
+from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
@@ -174,6 +175,103 @@ async def test_admin_reaches_credentialed_control_handler(hass: HomeAssistant) -
     assert err.value.translation_key == "grid_site_required"
 
 
+@pytest.mark.asyncio
+async def test_admin_live_stream_services_resolve_supported_site_targets(
+    hass: HomeAssistant,
+) -> None:
+    """Live-stream services accept UI targets and explicit site IDs."""
+
+    coord = _fake_service_coordinator(site_id="stream-site", serials=set())
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "stream-site", CONF_SITE_ONLY: True},
+        title="Stream Site",
+        unique_id="stream-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    area = ar.async_get(hass).async_create("Garage")
+    device_registry = dr.async_get(hass)
+    site_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "site:stream-site")},
+        manufacturer="Enphase",
+        name="Stream Site Device",
+    )
+    device_registry.async_update_device(site_device.id, area_id=area.id)
+    site_entity = er.async_get(hass).async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "stream-site-available-power",
+        config_entry=entry,
+        device_id=site_device.id,
+    )
+    entry_entity = er.async_get(hass).async_get_or_create(
+        "sensor",
+        DOMAIN,
+        "stream-site-without-device",
+        config_entry=entry,
+    )
+    foreign_entity = er.async_get(hass).async_get_or_create(
+        "sensor", "test", "foreign-stream-target"
+    )
+
+    async_setup_services(hass)
+    admin = await hass.auth.async_create_user(
+        "Live-stream owner", group_ids=[GROUP_ID_ADMIN]
+    )
+    context = Context(user_id=admin.id)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "start_live_stream",
+        {"entity_id": site_entity.entity_id},
+        blocking=True,
+        context=context,
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        "stop_live_stream",
+        {"device_id": site_device.id},
+        blocking=True,
+        context=context,
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        "start_live_stream",
+        {"area_id": area.id},
+        blocking=True,
+        context=context,
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        "stop_live_stream",
+        {"site_id": "stream-site"},
+        blocking=True,
+        context=context,
+    )
+    await hass.services.async_call(
+        DOMAIN,
+        "start_live_stream",
+        {"entity_id": entry_entity.entity_id},
+        blocking=True,
+        context=context,
+    )
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "start_live_stream",
+            {"entity_id": foreign_entity.entity_id},
+            blocking=True,
+            context=context,
+        )
+
+    assert coord.async_start_streaming.await_count == 3
+    assert coord.async_stop_streaming.await_count == 2
+    assert coord.async_request_refresh.await_count == 5
+
+
 def _register_service_handlers(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> dict[tuple[str, str], object]:
@@ -297,6 +395,29 @@ def test_trigger_message_schema_restricts_requested_message(
     ):
         with pytest.raises(vol.Invalid):
             schema({"requested_message": requested_message})
+
+
+def test_live_stream_schema_accepts_targets_and_explicit_site(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Live-stream schemas accept every target selector field and site routing."""
+
+    registered = _register_service_metadata(hass, monkeypatch)
+    for service in ("start_live_stream", "stop_live_stream"):
+        schema = registered[(DOMAIN, service)]["schema"]
+        for data in (
+            {"entity_id": "sensor.available_power"},
+            {"device_id": "device-id"},
+            {"area_id": "area-id"},
+            {"floor_id": "floor-id"},
+            {"label_id": "label-id"},
+            {"site_id": "1234567"},
+            {"config_entry_id": "entry-id"},
+        ):
+            assert schema(data)
+        assert schema({"site_id": "1234567", "metadata": {}}) == {"site_id": "1234567"}
+        with pytest.raises(vol.Invalid):
+            schema({"unknown_target": "value"})
 
 
 def test_trigger_message_service_options_match_allowlist() -> None:
@@ -1388,6 +1509,12 @@ async def test_update_tariff_accepts_friendly_rate_fields(
     )
     entry.add_to_hass(hass)
     entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    site_device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "site:tariff-site")},
+        manufacturer="Enphase",
+        name="Tariff Site Device",
+    )
     import_locator = {
         "branch": "purchase",
         "kind": "period",
@@ -1408,12 +1535,14 @@ async def test_update_tariff_accepts_friendly_rate_fields(
         DOMAIN,
         f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_peak_number",
         config_entry=entry,
+        device_id=site_device.id,
     )
     export_entity = ent_reg.async_get_or_create(
         "number",
         DOMAIN,
         f"{DOMAIN}_site_tariff-site_tariff_export_rate_default_week_peak_number",
         config_entry=entry,
+        device_id=site_device.id,
     )
     hass.states.async_set(
         import_entity.entity_id, 0.18, {"tariff_locator": import_locator}
@@ -1429,6 +1558,22 @@ async def test_update_tariff_accepts_friendly_rate_fields(
     coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
         billing=None,
         rate_updates=[{"locator": import_locator, "rate": 0.25}],
+    )
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={
+                "entity_id": import_entity.entity_id,
+                "device_id": site_device.id,
+                "rate": 0.255,
+            }
+        )
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[{"locator": import_locator, "rate": 0.255}],
     )
     coord.tariff_runtime.async_update_tariff.reset_mock()
 
@@ -1501,6 +1646,19 @@ async def test_update_tariff_rate_entity_extractor_fallback(
         config_entry=entry,
     )
     hass.states.async_set(reg_entry.entity_id, 0.18, {"tariff_locator": locator})
+    monkeypatch.setattr(
+        "homeassistant.helpers.target.async_extract_referenced_entity_ids",
+        lambda _hass, _selection: [reg_entry.entity_id],
+    )
+
+    await handlers[(DOMAIN, "update_tariff")](SimpleNamespace(data={"rate": 0.24}))
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[{"locator": locator, "rate": 0.24}],
+    )
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+
     monkeypatch.setattr(
         "homeassistant.helpers.target.async_extract_referenced_entity_ids",
         None,


### PR DESCRIPTION
## Summary

- Fix the administrator-only live-stream actions so Home Assistant entity, device, area, floor, and label targets pass validation and resolve to the correct Enphase site.
- Preserve explicit `site_id` and `config_entry_id` routing, including frontend-supplied target metadata.
- Keep tariff rate selection limited to directly selected entities while allowing indirect target expansion for site resolution.
- Document live-stream target selection and the difference between Home Assistant device IDs and Enphase site IDs.

Related discussion: https://github.com/barneyonline/ha-enphase-energy/discussions/838

## Related Issues

- Discussion #838

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/services.py tests/components/enphase_ev/test_services.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/services.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

- Component suite: 3,950 passed.
- Full suite: 4,089 passed.
- Home Assistant 2026.9 CI reproduction: 3,952 passed.
- Targeted coverage: `custom_components/enphase_ev/services.py` at 100% (867 statements, 0 missed).
- The pre-commit command passed with the linked worktree Git metadata mounted into the pinned Docker container.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid; no translation strings changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Regression tests cover live-stream calls routed by entity, device, area, explicit site ID, and config-entry-only entities.
- Schema coverage includes entity, device, area, floor, label, site, config entry, and frontend metadata payloads.
- No translation changes or screenshots are required.
