### PR TITLE
Fix entity targets for Enphase service actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
+- Fixed entity targets being rejected by charging, schedule, grid-profile, refresh,
+  and authentication actions. Charger entity targets now resolve to their owning
+  charger, and site actions resolve to the selected Enphase site.
 - Fixed the administrator-only Start/Stop Live Stream actions so Home Assistant
   entity, device, area, floor, and label targets, explicit site IDs, and config
   entry IDs pass service validation and resolve to the intended Enphase site.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug fixes
 - Fixed entity targets being rejected by charging, schedule, grid-profile, refresh,
   and authentication actions. Charger entity targets now resolve to their owning
-  charger, and site actions resolve to the selected Enphase site.
+  charger, and site actions resolve to the selected Enphase site. Area, floor, and
+  label charging targets ignore unrelated devices while explicit invalid device
+  targets remain rejected.
 - Fixed the administrator-only Start/Stop Live Stream actions so Home Assistant
   entity, device, area, floor, and label targets, explicit site IDs, and config
   entry IDs pass service validation and resolve to the intended Enphase site.

--- a/README.md
+++ b/README.md
@@ -143,7 +143,9 @@ Charging, battery schedule, grid-profile, refresh, and authentication actions
 accept the entity targets offered in Developer Tools → Actions. Site actions
 resolve the selected Enphase entity to its site; charging actions resolve it to
 its charger. Device, area, floor, and label targets are also supported for these
-actions. Actions operating on a single site reject selections spanning multiple sites.
+actions. Charging actions ignore unrelated devices selected through an area, floor,
+or label, but reject explicitly selected invalid devices. Actions operating on a
+single site reject selections spanning multiple sites.
 Existing explicit `device_id`, `site_id`, and `config_entry_id` fields remain
 supported where offered by the action.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,24 @@ Manual install steps: see the wiki Installation page.
 
 Sign in with your Enlighten credentials; MFA is supported. See the wiki for details.
 
+## Action targets
+
+Charging, battery schedule, grid-profile, refresh, and authentication actions
+accept the entity targets offered in Developer Tools → Actions. Site actions
+resolve the selected Enphase entity to its site; charging actions resolve it to
+its charger. Device, area, floor, and label targets are also supported for these
+actions. Actions operating on a single site reject selections spanning multiple sites.
+Existing explicit `device_id`, `site_id`, and `config_entry_id` fields remain
+supported where offered by the action.
+
+```yaml
+action: enphase_ev.validate_schedule
+target:
+  entity_id: switch.my_discharge_to_grid_schedule
+data:
+  schedule_type: dtg
+```
+
 ## Live-stream actions
 
 `enphase_ev.start_live_stream` and `enphase_ev.stop_live_stream` are

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -271,6 +271,13 @@ def async_setup_services(
     DEVICE_ID_LIST = vol.All(cv.ensure_list, [cv.string])
     ENTRY_SCHEMA: dict[object, object] = {vol.Optional("config_entry_id"): cv.string}
 
+    def _target_schema(fields: dict[object, object]) -> vol.Any:
+        """Accept Home Assistant targets while preserving explicit service fields."""
+        return vol.Any(
+            cv.make_entity_service_schema(fields),
+            vol.Schema({vol.Remove("metadata"): dict, **fields}),
+        )
+
     def _validate_trigger_message(value: object) -> str:
         try:
             return str(validate_ocpp_trigger_message(value))
@@ -299,7 +306,7 @@ def async_setup_services(
             message=f"{message} requires confirm_advanced.",
         )
 
-    START_SCHEMA = vol.Schema(
+    START_SCHEMA = _target_schema(
         {
             vol.Optional("device_id"): DEVICE_ID_LIST,
             vol.Optional("charging_level", default=32): vol.All(
@@ -310,8 +317,8 @@ def async_setup_services(
             ),
         }
     )
-    STOP_SCHEMA = vol.Schema({vol.Optional("device_id"): DEVICE_ID_LIST})
-    TRIGGER_SCHEMA = vol.Schema(
+    STOP_SCHEMA = _target_schema({vol.Optional("device_id"): DEVICE_ID_LIST})
+    TRIGGER_SCHEMA = _target_schema(
         {
             vol.Optional("device_id"): DEVICE_ID_LIST,
             vol.Required("requested_message"): vol.All(
@@ -328,34 +335,24 @@ def async_setup_services(
             vol.Required("otp"): cv.string,
         }
     )
-    CLEAR_SCHEMA = vol.Schema(
+    CLEAR_SCHEMA = _target_schema(
         {vol.Optional("device_id"): DEVICE_ID_LIST, vol.Optional("site_id"): cv.string}
     )
-    STREAM_SITE_SCHEMA = vol.Schema(
+    STREAM_SCHEMA = _target_schema(
         {
-            vol.Remove("metadata"): dict,
             vol.Optional("site_id"): cv.string,
             vol.Optional("config_entry_id"): cv.string,
         }
     )
-    STREAM_SCHEMA = vol.Any(
-        cv.make_entity_service_schema(
-            {
-                vol.Optional("site_id"): cv.string,
-                vol.Optional("config_entry_id"): cv.string,
-            }
-        ),
-        STREAM_SITE_SCHEMA,
-    )
     SYNC_SCHEMA = vol.Schema({vol.Optional("device_id"): DEVICE_ID_LIST})
-    FORCE_REFRESH_SCHEMA = vol.Schema(
+    FORCE_REFRESH_SCHEMA = _target_schema(
         {
             vol.Optional("device_id"): DEVICE_ID_LIST,
             vol.Optional("site_id"): cv.string,
             vol.Optional("config_entry_id"): cv.string,
         }
     )
-    BROWSE_GRID_PROFILES_SCHEMA = vol.Schema(
+    BROWSE_GRID_PROFILES_SCHEMA = _target_schema(
         {
             **ENTRY_SCHEMA,
             vol.Optional("device_id"): DEVICE_ID_LIST,
@@ -365,7 +362,7 @@ def async_setup_services(
             vol.Optional("commonly_used", default=True): cv.boolean,
         }
     )
-    REFRESH_GRID_PROFILES_SCHEMA = vol.Schema(
+    REFRESH_GRID_PROFILES_SCHEMA = _target_schema(
         {
             **ENTRY_SCHEMA,
             vol.Optional("device_id"): DEVICE_ID_LIST,
@@ -374,7 +371,7 @@ def async_setup_services(
             vol.Optional("commonly_used", default=True): cv.boolean,
         }
     )
-    SET_GRID_PROFILE_SCHEMA = vol.Schema(
+    SET_GRID_PROFILE_SCHEMA = _target_schema(
         {
             **ENTRY_SCHEMA,
             vol.Optional("device_id"): DEVICE_ID_LIST,
@@ -385,7 +382,7 @@ def async_setup_services(
             vol.Required("confirm"): cv.boolean,
         }
     )
-    ADD_SCHEDULE_SCHEMA = vol.Schema(
+    ADD_SCHEDULE_SCHEMA = _target_schema(
         {
             **ENTRY_SCHEMA,
             vol.Optional("device_id"): DEVICE_ID_LIST,
@@ -397,7 +394,7 @@ def async_setup_services(
             vol.Required("days"): DAYS_SCHEMA,
         }
     )
-    UPDATE_SCHEDULE_SCHEMA = vol.Schema(
+    UPDATE_SCHEDULE_SCHEMA = _target_schema(
         {
             **ENTRY_SCHEMA,
             vol.Optional("device_id"): DEVICE_ID_LIST,
@@ -411,7 +408,7 @@ def async_setup_services(
             vol.Required("confirm"): cv.boolean,
         }
     )
-    DELETE_SCHEDULE_SCHEMA = vol.Schema(
+    DELETE_SCHEDULE_SCHEMA = _target_schema(
         {
             **ENTRY_SCHEMA,
             vol.Optional("device_id"): DEVICE_ID_LIST,
@@ -422,7 +419,7 @@ def async_setup_services(
             vol.Required("confirm"): cv.boolean,
         }
     )
-    VALIDATE_SCHEDULE_SCHEMA = vol.Schema(
+    VALIDATE_SCHEDULE_SCHEMA = _target_schema(
         {
             **ENTRY_SCHEMA,
             vol.Optional("device_id"): DEVICE_ID_LIST,
@@ -625,7 +622,7 @@ def async_setup_services(
         return data
 
     UPDATE_CFG_SCHEMA = vol.All(
-        vol.Schema(
+        _target_schema(
             {
                 vol.Optional("device_id"): DEVICE_ID_LIST,
                 vol.Optional("site_id"): cv.string,
@@ -802,6 +799,15 @@ def async_setup_services(
                 device_ids.add(data_ids)
             else:
                 device_ids |= {str(v) for v in data_ids}
+        ent_reg = er.async_get(hass)
+        for entity_id in _extract_entity_ids(call, include_indirect=True):
+            reg_entry = ent_reg.async_get(entity_id)
+            if (
+                reg_entry is not None
+                and reg_entry.platform == DOMAIN
+                and reg_entry.device_id
+            ):
+                device_ids.add(reg_entry.device_id)
         return list(device_ids)
 
     def _extract_entity_ids(
@@ -1379,14 +1385,7 @@ def async_setup_services(
         await coord.async_set_grid_mode(call.data["mode"], call.data["otp"])
 
     async def _svc_clear_issue(call: ServiceCall) -> None:
-        site_ids: set[str] = set()
-        for device_id in _extract_device_ids(call):
-            site_id = await _resolve_site_id(device_id)
-            if site_id:
-                site_ids.add(site_id)
-        explicit = call.data.get("site_id")
-        if explicit:
-            site_ids.add(str(explicit))
+        site_ids = await _resolve_site_ids_from_call(call)
 
         issue_ids = {
             ISSUE_REAUTH_REQUIRED,

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -1209,16 +1209,28 @@ def async_setup_services(
         call: ServiceCall,
     ) -> list[tuple[str, str, EnphaseCoordinator]]:
         device_ids = _extract_device_ids(call)
-        if not device_ids:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="grid_site_required",
+        # Group targets may include lights, gateways, or other non-chargers.
+        # Keep explicit device/entity selections strict, even in a mixed call.
+        explicit_device_ids = set(device_ids)
+        if any(key in call.data for key in ("area_id", "floor_id", "label_id")):
+            direct_call = ServiceCall(
+                hass,
+                call.domain,
+                call.service,
+                {
+                    key: value
+                    for key, value in call.data.items()
+                    if key not in {"area_id", "floor_id", "label_id"}
+                },
             )
+            explicit_device_ids = set(_extract_device_ids(direct_call))
 
         targets: list[tuple[str, str, EnphaseCoordinator]] = []
         for device_id in device_ids:
             routing_context = await _resolve_device_routing_context(device_id)
             if routing_context is None:
+                if device_id not in explicit_device_ids:
+                    continue
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
                     translation_key="grid_site_required",
@@ -1230,12 +1242,19 @@ def async_setup_services(
                 config_entry_ids=config_entry_ids,
             )
             if coord is None:
+                if device_id not in explicit_device_ids:
+                    continue
                 raise ServiceValidationError(
                     translation_domain=DOMAIN,
                     translation_key="grid_site_required",
                 )
             targets.append((device_id, sn, coord))
 
+        if not targets:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="grid_site_required",
+            )
         return targets
 
     async def _svc_force_refresh(call: ServiceCall) -> None:

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -3361,7 +3361,8 @@ async def test_service_helper_resolve_functions_cover_none_branches(
     resolve_device_routing_context = _extract_helper(
         resolve_targets, "_resolve_device_routing_context"
     )
-    resolve_site = _extract_helper(svc_clear, "_resolve_site_id")
+    resolve_sites = _extract_helper(svc_clear, "_resolve_site_ids_from_call")
+    resolve_site = _extract_helper(resolve_sites, "_resolve_site_id")
 
     dev_reg = dr.async_get(hass)
     assert await resolve_device_routing_context("does-not-exist") is None

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -2298,3 +2298,126 @@ async def test_update_tariff_rejects_duplicate_and_cross_site_rates(
             )
         )
     assert err.value.translation_key == "tariff_rate_entity_invalid"
+
+
+def test_advertised_entity_targets_pass_registered_schemas(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Every entity picker must produce a payload its registered schema accepts."""
+    registered = _register_service_metadata(hass, monkeypatch)
+    descriptions = yaml.safe_load(SERVICES_YAML.read_text())
+    fields = {
+        "requested_message": "Heartbeat",
+        "profile_id": "agf:test",
+        "confirm": True,
+        "schedule_type": "dtg",
+        "schedule_id": "schedule-1",
+        "start_time": "01:00",
+        "end_time": "02:00",
+        "limit": 50,
+        "days": [1],
+    }
+    for service, description in descriptions.items():
+        if "entity" not in description.get("target", {}):
+            continue
+        data = {
+            name: fields[name]
+            for name, field in description.get("fields", {}).items()
+            if field.get("required")
+        }
+        if service == "update_cfg_schedule":
+            data["limit"] = 50
+        if service == "update_tariff":
+            data["rate"] = 0.25
+        schema = registered[(DOMAIN, service)]["schema"]
+        for target in ("sensor.enphase_target", ["sensor.enphase_target"]):
+            assert schema({**data, "entity_id": target})["entity_id"] == [
+                "sensor.enphase_target"
+            ], service
+        with pytest.raises(vol.Invalid):
+            schema({**data, "entity_id": "invalid entity"})
+        with pytest.raises(vol.Invalid):
+            schema({**data, "entity_id": "sensor.enphase_target", "unknown": True})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_kind", ["entity_id", "device_id", "area_id"])
+async def test_charging_service_routes_ui_targets(
+    hass: HomeAssistant, target_kind: str
+) -> None:
+    """A selected charger entity or area reaches only its owning charger."""
+    coord = _fake_service_coordinator(site_id="target-site", serials={"charger-1"})
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_SITE_ID: "target-site"})
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    area = ar.async_get(hass).async_create("Target Garage")
+    registry = dr.async_get(hass)
+    device = registry.async_get_or_create(
+        config_entry_id=entry.entry_id, identifiers={(DOMAIN, "charger-1")}
+    )
+    registry.async_update_device(device.id, area_id=area.id)
+    entity = er.async_get(hass).async_get_or_create(
+        "button", DOMAIN, "charger-start", config_entry=entry, device_id=device.id
+    )
+    targets = {
+        "entity_id": entity.entity_id,
+        "device_id": device.id,
+        "area_id": area.id,
+    }
+    async_setup_services(hass)
+    for service in ("start_charging", "stop_charging"):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {},
+            target={target_kind: targets[target_kind]},
+            blocking=True,
+        )
+    coord.async_start_charging.assert_awaited_once_with(
+        "charger-1", requested_amps=32, connector_id=1
+    )
+    coord.async_stop_charging.assert_awaited_once_with("charger-1")
+
+
+@pytest.mark.asyncio
+async def test_validate_schedule_entity_target_routes_selected_site(
+    hass: HomeAssistant,
+) -> None:
+    """The issue's DTG payload passes validation and calls the selected site's API."""
+    coords = []
+    entities = []
+    for site_id in ("selected-site", "other-site"):
+        coord = _fake_service_coordinator(site_id=site_id, serials=set())
+        coord.battery_write_access_confirmed = True
+        coord.client = SimpleNamespace(
+            validate_battery_schedule=AsyncMock(return_value={"valid": True})
+        )
+        entry = MockConfigEntry(domain=DOMAIN, data={CONF_SITE_ID: site_id})
+        entry.add_to_hass(hass)
+        entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+        entities.append(
+            er.async_get(hass).async_get_or_create(
+                "switch", DOMAIN, f"{site_id}-dtg", config_entry=entry
+            )
+        )
+        coords.append(coord)
+    async_setup_services(hass)
+    result = await hass.services.async_call(
+        DOMAIN,
+        "validate_schedule",
+        {"schedule_type": "dtg"},
+        target={"entity_id": entities[0].entity_id},
+        blocking=True,
+        return_response=True,
+    )
+    assert result == {"valid": True}
+    coords[0].client.validate_battery_schedule.assert_awaited_once_with("dtg")
+    coords[1].client.validate_battery_schedule.assert_not_awaited()
+    with pytest.raises(ServiceValidationError):
+        await hass.services.async_call(
+            DOMAIN,
+            "validate_schedule",
+            {"schedule_type": "dtg"},
+            target={"entity_id": [entity.entity_id for entity in entities]},
+            blocking=True,
+        )

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -15,6 +15,8 @@ from homeassistant.exceptions import ServiceValidationError, Unauthorized
 from homeassistant.helpers import area_registry as ar
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import floor_registry as fr
+from homeassistant.helpers import label_registry as lr
 
 from custom_components.enphase_ev.api import (
     OCPP_TRIGGER_MESSAGES,
@@ -2341,7 +2343,9 @@ def test_advertised_entity_targets_pass_registered_schemas(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("target_kind", ["entity_id", "device_id", "area_id"])
+@pytest.mark.parametrize(
+    "target_kind", ["entity_id", "device_id", "area_id", "floor_id", "label_id"]
+)
 async def test_charging_service_routes_ui_targets(
     hass: HomeAssistant, target_kind: str
 ) -> None:
@@ -2351,11 +2355,32 @@ async def test_charging_service_routes_ui_targets(
     entry.add_to_hass(hass)
     entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
     area = ar.async_get(hass).async_create("Target Garage")
+    floor = fr.async_get(hass).async_create("Target Floor", level=0)
+    ar.async_get(hass).async_update(area.id, floor_id=floor.floor_id)
+    label = lr.async_get(hass).async_create("Target Chargers")
     registry = dr.async_get(hass)
     device = registry.async_get_or_create(
         config_entry_id=entry.entry_id, identifiers={(DOMAIN, "charger-1")}
     )
-    registry.async_update_device(device.id, area_id=area.id)
+    registry.async_update_device(device.id, area_id=area.id, labels={label.label_id})
+    unrelated_entry = MockConfigEntry(domain="hue", data={})
+    unrelated_entry.add_to_hass(hass)
+    unrelated_devices = [
+        registry.async_get_or_create(
+            config_entry_id=unrelated_entry.entry_id,
+            identifiers={("hue", "garage-light")},
+        ),
+        registry.async_get_or_create(
+            config_entry_id=entry.entry_id, identifiers={(DOMAIN, "site:target-site")}
+        ),
+        registry.async_get_or_create(
+            config_entry_id=entry.entry_id, identifiers={(DOMAIN, "not-a-charger")}
+        ),
+    ]
+    for unrelated in unrelated_devices:
+        registry.async_update_device(
+            unrelated.id, area_id=area.id, labels={label.label_id}
+        )
     entity = er.async_get(hass).async_get_or_create(
         "button", DOMAIN, "charger-start", config_entry=entry, device_id=device.id
     )
@@ -2363,6 +2388,8 @@ async def test_charging_service_routes_ui_targets(
         "entity_id": entity.entity_id,
         "device_id": device.id,
         "area_id": area.id,
+        "floor_id": floor.floor_id,
+        "label_id": label.label_id,
     }
     async_setup_services(hass)
     for service in ("start_charging", "stop_charging"):
@@ -2377,6 +2404,36 @@ async def test_charging_service_routes_ui_targets(
         "charger-1", requested_amps=32, connector_id=1
     )
     coord.async_stop_charging.assert_awaited_once_with("charger-1")
+
+    if target_kind in {"area_id", "floor_id", "label_id"}:
+        for service in ("start_charging", "stop_charging"):
+            for invalid_device_id in [
+                "missing-device",
+                *(d.id for d in unrelated_devices),
+            ]:
+                with pytest.raises(ServiceValidationError):
+                    await hass.services.async_call(
+                        DOMAIN,
+                        service,
+                        {},
+                        target={
+                            target_kind: targets[target_kind],
+                            "device_id": invalid_device_id,
+                        },
+                        blocking=True,
+                    )
+        # A group containing only unrelated devices must not silently succeed.
+        registry.async_update_device(device.id, area_id=None, labels=set())
+        with pytest.raises(ServiceValidationError):
+            await hass.services.async_call(
+                DOMAIN,
+                "start_charging",
+                {},
+                target={target_kind: targets[target_kind]},
+                blocking=True,
+            )
+        assert coord.async_start_charging.await_count == 1
+        assert coord.async_stop_charging.await_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #844. Actions that advertise an entity target now accept Home Assistant target fields instead of rejecting the UI-generated payload with `extra keys not allowed @ data['entity_id']`. For example, `validate_schedule` with a discharge-to-grid switch target reaches that entity's Enphase site and calls the schedule validation API.

Reuse the existing live-stream schema approach for charging, schedule, grid-profile, refresh, and authentication actions. Resolve selected Enphase entities to their charger devices for charging commands, and use the common site resolver when clearing authentication issues. Filter unrelated devices out of area, floor, and label charging selections while retaining errors for explicitly selected invalid devices and groups with no eligible chargers. Preserve explicit routing fields, strict rejection of unknown fields, and existing authorization requirements.

Add a descriptor-to-schema regression check for every advertised entity picker, real service-registry calls for entity/device/area/floor/label charger targets, mixed-device groups, and explicit invalid devices, and the reported DTG payload with two-site isolation and ambiguous-site rejection. Current main already supports tariff entity targets; the regression check covers that existing behavior.

## Related Issues

Builds on the live-stream target fix in #843.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Docker validation commands:

```bash
docker compose -f devtools/docker/docker-compose.yml build ha-dev
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black custom_components/enphase_ev/services.py tests/components/enphase_ev/test_services.py && ruff check . && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black custom_components/enphase_ev/services.py tests/components/enphase_ev/test_services.py tests/components/enphase_ev/test_init_module.py && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/services.py --fail-under=100'
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc 'python -m pre_commit run --all-files'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'pytest tests/components/enphase_ev -q && pytest'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'ruff check . && pytest -q tests/components/enphase_ev/test_service_translations.py'
```

The read-only Git metadata mount lets pre-commit inspect this linked worktree. All listed checks passed. Integration suite: 3,957 tests passed; repository-wide suite: 4,096 tests passed; translation suite: 54 tests passed. Targeted coverage: `services.py` 100% (874 statements).

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Review-fix validation also ran:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black custom_components/enphase_ev/services.py tests/components/enphase_ev/test_services.py && pytest -q tests/components/enphase_ev/test_services.py && ruff check . && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/services.py --fail-under=100'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log && pytest tests/components/enphase_ev -q && pytest && pytest -q tests/components/enphase_ev/test_service_translations.py'
```

The full pre-commit command above was also rerun after the fix.

No translation strings or diagnostics payloads changed. No live charger commands were issued; service tests use mocked coordinator/API calls.
