### PR TITLE
Prevent incompatible Dependabot updates to Home Assistant pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,17 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: pip
+    directory: /devtools/docker
+    schedule:
+      interval: weekly
+    # Keep routine Python version PRs disabled; other security updates remain enabled.
+    open-pull-requests-limit: 0
+    # Home Assistant pins these dependencies exactly. Upgrade the Home Assistant
+    # and test-plugin pair together, then regenerate each lane's constraints.
+    # These ignores suppress update PRs, including security PRs, not security alerts.
+    ignore:
+      - dependency-name: cryptography
+      - dependency-name: pyjwt
+      - dependency-name: aiohttp
+      - dependency-name: pillow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,27 @@ separately while iterating on `scripts/`:
 docker compose -f devtools/docker/docker-compose.yml exec ha-dev pytest -q tests/scripts
 ```
 
+## Dependency Maintenance
+
+Dependabot continues to propose weekly GitHub Actions updates. For
+`devtools/docker`, routine Python version PRs are disabled. Standalone updates
+to `cryptography`, `PyJWT`, `aiohttp`, and `Pillow`, including security-update
+PRs, are ignored because Home Assistant requires exact versions of these
+packages. Other Python security updates remain enabled.
+
+Keep Dependabot alerts enabled and review new advisories even for ignored
+packages. Address applicable advisories through a compatible Home Assistant
+upgrade: update the Home Assistant version and matching test plugin together,
+regenerate that lane's constraints, and validate it in Docker. Preserve the
+exact dependency stacks for older compatibility lanes while those Home
+Assistant versions remain supported. Do not override their dependency pins
+independently to clear an alert.
+
+The `open-pull-requests-limit: 0` setting only disables version-update PRs;
+the explicit `ignore` rules suppress security-update PRs for these four
+packages. Neither setting disables Dependabot alerts. See GitHub's
+[security-update configuration guidance](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configure-security-updates).
+
 ## Coding Standards and Tooling
 
 Home Assistant integrations must follow the [core development guidelines](https://developers.home-assistant.io/docs/development_guidelines/). Key points:


### PR DESCRIPTION
## Summary

Prevent Dependabot from proposing standalone upgrades to `cryptography`, `pyjwt`, `aiohttp`, and `pillow` in the pinned Home Assistant test environments. These updates conflict with Home Assistant's exact dependency requirements, as demonstrated by #847 and #848.

Add scoped pip ignore rules while preserving security alerts, security updates for other packages, and weekly GitHub Actions updates. Keep routine Python version PRs disabled and document coordinated Home Assistant/test-plugin upgrades in `CONTRIBUTING.md`.

## Related Issues

- #847 and #848 will be closed after this PR merges.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Validation uses the existing `enphase-architecture-ha-dev:2026.9` Docker image. Its Home Assistant 2026.9.0, pytest-homeassistant-custom-component 0.13.363, PyYAML 6.0.3, mypy 2.2.0, Ruff 0.16.4, and pre-commit 4.6.2 match this checkout's pins. A fresh `docker compose -f devtools/docker/docker-compose.yml build ha-dev` was attempted but blocked by insufficient Docker disk space during apt installation.

The following commands were run inside that Docker environment, with the checkout at `/workspace`, its backing Git metadata mounted read-only, and `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`:

```bash
ruff check .
python -m pre_commit run --all-files
python scripts/validate_quality_scale.py
python scripts/validate_quality_scale.py --validate-remote-brands
python scripts/importtime_profile.py --strict-integration-warnings --output /review/dependabot-importtime.log
mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev
pytest -q tests/components/enphase_ev
pytest
```

Results: all checks passed; integration tests **4,120 passed**; full repository pytest **4,259 passed**.

Additional validation: Docker PyYAML parsing, `git diff --check`, and read-only review against GitHub's documented security-update configuration semantics. No Python modules changed, so targeted Python coverage is not applicable. Actual Dependabot suppression takes effect when the configuration reaches the default branch.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes. (Not applicable: contributor tooling only.)
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed. (Updated `CONTRIBUTING.md`.)
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (No string or translation changes.)
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage. (No Python modules changed.)
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate). (All triggered checks passed: CodeQL Actions/Python, codespell, HACS validation, and auto-assignment. Runtime test workflows are path-filtered for this configuration/docs-only diff; full tests and quality checks passed locally in Docker.)
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No integration runtime or dependency versions change. Security alerts remain enabled; applicable advisories for the ignored packages require a coordinated compatible Home Assistant upgrade.
