### PR TITLE
Close integration lifecycle and fixture coverage gaps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,8 +75,8 @@ jobs:
           }
 
           common='^(\.github/workflows/(ci|tests)\.yml|devtools/docker/(Dockerfile|docker-compose\.yml|constraints-[^/]+\.txt))$'
-          set_output integration "${common}|^scripts/benchmark_snapshots\.py$|^custom_components/enphase_ev/|^tests/(components/enphase_ev|compatibility)/|^devtools/docker/requirements-dev\.txt$|^pytest\.ini$|^\.pre-commit-config\.yaml$|^\.ruff\.toml$"
-          set_output compatibility "${common}|^custom_components/enphase_ev/.*\.py$|^custom_components/enphase_ev/manifest\.json$|^tests/compatibility/|^tests/components/enphase_ev/(conftest|test_(device_action|device_trigger|entry_lifecycle|init_module|manifest|runtime_data|schedule_sync|services))\.py$|^devtools/docker/requirements-(min-ha|ha-2026\.8)\.txt$|^pytest\.ini$"
+          set_output integration "${common}|^scripts/(benchmark_snapshots|check_statement_coverage)\.py$|^custom_components/enphase_ev/|^tests/(components/enphase_ev|compatibility)/|^devtools/docker/requirements-dev\.txt$|^pytest\.ini$|^\.pre-commit-config\.yaml$|^\.ruff\.toml$"
+          set_output compatibility "${common}|^custom_components/enphase_ev/.*\.py$|^custom_components/enphase_ev/manifest\.json$|^tests/compatibility/|^tests/components/enphase_ev/(conftest|test_(device_action|device_trigger|entry_lifecycle|integration_lifecycle|reload_snapshot|init_module|manifest|runtime_data|schedule_sync|services))\.py$|^devtools/docker/requirements-(min-ha|ha-2026\.8)\.txt$|^pytest\.ini$"
           set_output diagnostics "${common}|^custom_components/enphase_ev/.*\.py$|^scripts/importtime_profile\.py$|^tests/scripts/test_importtime_profile\.py$|^devtools/docker/requirements-dev\.txt$"
           set_output quality "${common}|^custom_components/enphase_ev/|^tests/components/enphase_ev/|^quality_scale\.yaml$|^scripts/validate_quality_scale\.py$|^tests/scripts/test_validate_quality_scale\.py$|^devtools/docker/requirements-(dev|ci-quality)\.txt$|^\.pre-commit-config\.yaml$|^\.strict-typing$"
           set_output scripts "${common}|^scripts/.*\.py$|^tests/scripts/.*\.py$|^devtools/docker/requirements-ci-scripts\.txt$"
@@ -205,6 +205,7 @@ jobs:
           tests/components/enphase_ev/test_device_trigger.py
           tests/components/enphase_ev/test_schedule_sync.py
           tests/components/enphase_ev/test_entry_lifecycle.py
+          tests/components/enphase_ev/test_integration_lifecycle.py
           tests/components/enphase_ev/test_reload_snapshot.py
           tests/components/enphase_ev/test_services.py
 
@@ -238,6 +239,7 @@ jobs:
           pytest -q --asyncio-mode=auto
           tests/compatibility/test_ha_2026_8_device_registry.py
           tests/components/enphase_ev/test_entry_lifecycle.py
+          tests/components/enphase_ev/test_integration_lifecycle.py
           tests/components/enphase_ev/test_reload_snapshot.py
           tests/components/enphase_ev/test_init_module.py::test_async_setup_entry_updates_existing_device
           tests/components/enphase_ev/test_init_module.py::test_remove_legacy_site_device_preserves_real_devices_with_site_identifier
@@ -301,12 +303,12 @@ jobs:
         env:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
           PYTEST_PLUGINS: pytest_asyncio.plugin,pytest_homeassistant_custom_component.plugins,pytest_cov.plugin,pytest_github_actions_annotate_failures.plugin
-        run: pytest -q tests/components/enphase_ev tests/compatibility --cov=custom_components.enphase_ev --cov-report=term-missing --cov-report=xml --cov-fail-under=95 --junitxml=junit.xml -o junit_family=legacy
+        run: pytest -q tests/components/enphase_ev tests/compatibility --cov=custom_components.enphase_ev --cov-branch --cov-report=term-missing --cov-report=xml --cov-report=json --cov-fail-under=95 --junitxml=junit.xml -o junit_family=legacy
       - name: Enforce 100% coverage on changed integration modules
         id: targeted_coverage
         if: ${{ steps.changed.outputs.include != '' }}
         continue-on-error: true
-        run: python -m coverage report -m --include="${{ steps.changed.outputs.include }}" --fail-under=100
+        run: python scripts/check_statement_coverage.py --report coverage.json --include="${{ steps.changed.outputs.include }}"
       - name: Import Codecov GPG key
         if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
         run: curl -fsSL https://keybase.io/codecovsecops/pgp_keys.asc | gpg --import

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,15 +87,26 @@ docker compose -f devtools/docker/docker-compose.yml exec ha-dev pytest -q tests
 ```
 
 For a full coverage run, collect coverage once and reuse that data when enforcing
-100% coverage on the integration modules you changed. Replace the example
-`--include` value with your changed module paths. This coverage run replaces the
+100% statement coverage on the integration modules you changed. Branch data is
+also collected to expose untested decisions; the changed-module gate checks
+statements independently so it does not impose blanket 100% branch coverage.
+Replace the example `--include` value with your changed module paths. This coverage run replaces the
 plain integration pytest command above:
 
 ```bash
-docker compose -f devtools/docker/docker-compose.yml exec -e COVERAGE_FILE=/tmp/enphase_ev.coverage ha-dev python -m coverage run --source=custom_components.enphase_ev -m pytest -q tests/components/enphase_ev
+docker compose -f devtools/docker/docker-compose.yml exec -e COVERAGE_FILE=/tmp/enphase_ev.coverage ha-dev python -m coverage run --branch --source=custom_components.enphase_ev -m pytest -q tests/components/enphase_ev
 docker compose -f devtools/docker/docker-compose.yml exec -e COVERAGE_FILE=/tmp/enphase_ev.coverage ha-dev python -m coverage report -m --fail-under=95
-docker compose -f devtools/docker/docker-compose.yml exec -e COVERAGE_FILE=/tmp/enphase_ev.coverage ha-dev python -m coverage report -m --include="custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py" --fail-under=100
+docker compose -f devtools/docker/docker-compose.yml exec -e COVERAGE_FILE=/tmp/enphase_ev.coverage ha-dev python -m coverage json -o /tmp/enphase_ev.coverage.json
+docker compose -f devtools/docker/docker-compose.yml exec ha-dev python scripts/check_statement_coverage.py --report /tmp/enphase_ev.coverage.json --include="custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py"
 ```
+
+Shared fixtures preserve explicit empty serial lists and payloads. Give unit-test
+coordinator doubles an explicit `inventory_view` with only the capabilities the
+test needs; do not modify standard-library classes to supply missing behavior.
+`test_integration_lifecycle.py` covers charger and site-only setup with real
+platforms, topology-option reload, registry customization, polling, and unload.
+It replaces cloud methods and fails on unexpected cloud calls. These scenarios
+also run in both Home Assistant compatibility lanes.
 
 Maintenance-script tests use only lightweight dependencies and can be run
 separately while iterating on `scripts/`:

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -878,7 +878,7 @@ class EvseRuntime:
                 fast_seconds=fast_seconds,
                 allow_unplugged=True,
             )
-        except asyncio.CancelledError:  # pragma: no cover
+        except asyncio.CancelledError:
             raise
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
@@ -890,13 +890,13 @@ class EvseRuntime:
         if delay_s:
             try:
                 await asyncio.sleep(delay_s)
-            except asyncio.CancelledError:  # pragma: no cover
+            except asyncio.CancelledError:
                 raise
             except Exception:  # noqa: BLE001
                 return
         try:
             await coord.async_start_charging(sn_str)
-        except asyncio.CancelledError:  # pragma: no cover
+        except asyncio.CancelledError:
             raise
         except ServiceValidationError as err:
             reason = "validation error"

--- a/scripts/check_statement_coverage.py
+++ b/scripts/check_statement_coverage.py
@@ -1,0 +1,39 @@
+"""Enforce statement coverage from a report that also measures branches."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def check_report(report: dict, paths: list[str]) -> list[str]:
+    """Return modules without evidence of complete statement coverage."""
+    failures = []
+    for path in paths:
+        result = report.get("files", {}).get(path)
+        if result is None:
+            failures.append(f"{path}: missing coverage data")
+        elif result["summary"]["covered_lines"] != result["summary"]["num_statements"]:
+            failures.append(f"{path}: uncovered lines {result['missing_lines']}")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument("--include", required=True, help="Comma-separated module paths")
+    args = parser.parse_args()
+    paths = [path for path in args.include.split(",") if path]
+    if not paths:
+        parser.error("--include must name at least one module")
+    failures = check_report(json.loads(args.report.read_text()), paths)
+    for failure in failures:
+        print(failure)
+    if not failures:
+        print(f"100% statement coverage across {len(paths)} changed modules")
+    return int(bool(failures))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/components/enphase_ev/conftest.py
+++ b/tests/components/enphase_ev/conftest.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import sys
-import types as types_module
 from collections.abc import Callable
 from contextlib import ExitStack
 from pathlib import Path
@@ -58,107 +57,6 @@ from .random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 
-_ORIGINAL_SIMPLE_NAMESPACE = SimpleNamespace
-
-
-def _inventory_view_callable(owner: Any, attr: str, default: Any):
-    if hasattr(owner, attr):
-        value = getattr(owner, attr)
-        if callable(value):
-            return value
-        return lambda *_args, **_kwargs: value
-    return default
-
-
-def _build_inventory_view(owner: Any) -> SimpleNamespace:
-    has_type = _inventory_view_callable(owner, "has_type", lambda *_args: True)
-    has_type_for_entities = _inventory_view_callable(
-        owner, "has_type_for_entities", has_type
-    )
-    attrs: dict[str, Any] = {
-        "has_type": has_type,
-        "has_type_for_entities": has_type_for_entities,
-        "type_device_info": _inventory_view_callable(
-            owner, "type_device_info", lambda *_args: None
-        ),
-        "type_label": _inventory_view_callable(
-            owner, "type_label", lambda *_args: None
-        ),
-        "type_bucket": _inventory_view_callable(
-            owner, "type_bucket", lambda *_args: None
-        ),
-        "iter_type_keys": _inventory_view_callable(owner, "iter_type_keys", lambda: []),
-        "gateway_iq_energy_router_records": _inventory_view_callable(
-            owner, "gateway_iq_energy_router_records", lambda: []
-        ),
-        "gateway_iq_energy_router_record": _inventory_view_callable(
-            owner, "gateway_iq_energy_router_record", lambda *_args: None
-        ),
-        "type_identifier": _inventory_view_callable(
-            owner, "type_identifier", lambda *_args: None
-        ),
-    }
-    for attr in (
-        "type_device_name",
-        "type_device_model",
-        "type_device_hw_version",
-        "type_device_serial_number",
-        "type_device_model_id",
-        "type_device_sw_version",
-    ):
-        if hasattr(owner, attr):
-            attrs[attr] = _inventory_view_callable(owner, attr, None)
-    return _ORIGINAL_SIMPLE_NAMESPACE(**attrs)
-
-
-class InventoryAwareSimpleNamespace(_ORIGINAL_SIMPLE_NAMESPACE):
-    """Test helper namespace that mirrors legacy coordinator attrs into inventory_view."""
-
-    _INVENTORY_VIEW_ATTRS = {
-        "has_type",
-        "has_type_for_entities",
-        "type_device_name",
-        "type_device_model",
-        "type_device_hw_version",
-        "type_device_serial_number",
-        "type_device_model_id",
-        "type_device_info",
-        "type_label",
-        "type_bucket",
-        "type_device_sw_version",
-        "iter_type_keys",
-        "gateway_iq_energy_router_records",
-        "gateway_iq_energy_router_record",
-        "type_identifier",
-    }
-
-    def __init__(self, /, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-        inventory_view = kwargs.get("inventory_view")
-        if inventory_view is None:
-            inventory_view = _build_inventory_view(self)
-        else:
-            for attr, value in vars(_build_inventory_view(self)).items():
-                if not hasattr(inventory_view, attr):
-                    setattr(inventory_view, attr, value)
-        object.__setattr__(self, "inventory_view", inventory_view)
-
-    def __setattr__(self, name: str, value: Any) -> None:
-        super().__setattr__(name, value)
-        if name == "inventory_view":
-            return
-        inventory_view = getattr(self, "inventory_view", None)
-        if inventory_view is None or name not in self._INVENTORY_VIEW_ATTRS:
-            return
-        setattr(
-            inventory_view,
-            name,
-            _inventory_view_callable(self, name, lambda *_args, **_kwargs: None),
-        )
-
-
-types_module.SimpleNamespace = InventoryAwareSimpleNamespace
-
 
 def _seed_default_type_buckets(coord: Any) -> None:
     """Populate default type buckets for coordinator stubs in tests."""
@@ -170,11 +68,7 @@ def _seed_default_type_buckets(coord: Any) -> None:
     serials = [str(sn) for sn in (getattr(coord, "serials", set()) or set()) if sn]
     if not callable(setter):
         return
-    iqevse_devices = (
-        [{"serial_number": sn, "name": f"Charger {sn}"} for sn in serials]
-        if serials
-        else [{"name": "Charger"}]
-    )
+    iqevse_devices = [{"serial_number": sn, "name": f"Charger {sn}"} for sn in serials]
     grouped = {
         "envoy": {
             "type_key": "envoy",
@@ -195,7 +89,9 @@ def _seed_default_type_buckets(coord: Any) -> None:
             "devices": iqevse_devices,
         },
     }
-    setter(grouped, ["envoy", "encharge", "iqevse"])
+    if not serials:
+        grouped.pop("iqevse")
+    setter(grouped, list(grouped))
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -396,22 +292,28 @@ def coordinator_factory(hass, mock_clientsession, mock_issue_registry, monkeypat
         client: Any | None = None,
         data: dict[str, Any] | None = None,
     ) -> EnphaseCoordinator:
-        active_serials = serials or [RANDOM_SERIAL]
-        cfg = config or {
-            CONF_SITE_ID: RANDOM_SITE_ID,
-            CONF_SERIALS: active_serials,
-            CONF_EAUTH: "EAUTH",
-            CONF_COOKIE: "COOKIE",
-            CONF_SCAN_INTERVAL: 15,
-            CONF_SITE_ONLY: False,
-        }
+        active_serials = [RANDOM_SERIAL] if serials is None else serials
+        cfg = (
+            config
+            if config is not None
+            else {
+                CONF_SITE_ID: RANDOM_SITE_ID,
+                CONF_SERIALS: active_serials,
+                CONF_EAUTH: "EAUTH",
+                CONF_COOKIE: "COOKIE",
+                CONF_SCAN_INTERVAL: 15,
+                CONF_SITE_ONLY: False,
+            }
+        )
         coord = EnphaseCoordinator(hass, cfg)
         # Most legacy coordinator tests exercise Grid Toggle behavior directly.
         # Individual opt-in tests override this to validate the production default.
         coord.serials = set(active_serials)
-        coord.data = data or {
-            sn: {"sn": sn, "name": f"Charger {sn}"} for sn in coord.serials
-        }
+        coord.data = (
+            data
+            if data is not None
+            else {sn: {"sn": sn, "name": f"Charger {sn}"} for sn in coord.serials}
+        )
         _seed_default_type_buckets(coord)
         coord.last_set_amps = getattr(coord, "last_set_amps", {}) or {}
         if client is not None:

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -969,6 +969,12 @@ def test_battery_runtime_top_level_helper_passthroughs_cover_private_hooks() -> 
     refreshed = Mock()
     runtime = BatteryRuntime(
         SimpleNamespace(
+            inventory_view=SimpleNamespace(
+                type_bucket=lambda _key: None,
+                type_device_info=lambda _key: None,
+                has_type=lambda _key: False,
+                has_type_for_entities=lambda _key: False,
+            ),
             _coerce_optional_int=lambda value: 7 if value == "7" else None,
             _coerce_optional_float=lambda value: 1.5 if value == "1.5" else None,
             _coerce_optional_kwh=lambda value: 2.5 if value == "2.5" else None,
@@ -1012,7 +1018,16 @@ def test_battery_runtime_top_level_helper_passthroughs_cover_private_hooks() -> 
 
 
 def test_battery_runtime_top_level_helper_passthroughs_cover_fallback_paths() -> None:
-    runtime = BatteryRuntime(SimpleNamespace())
+    runtime = BatteryRuntime(
+        SimpleNamespace(
+            inventory_view=SimpleNamespace(
+                type_bucket=lambda _key: None,
+                type_device_info=lambda _key: None,
+                has_type=lambda _key: False,
+                has_type_for_entities=lambda _key: False,
+            ),
+        )
+    )
     source = {"id": 1, "nested": {"value": 2}, "items": [{"x": 1}]}
 
     assert runtime._coerce_optional_int("7") == 7
@@ -1044,7 +1059,16 @@ def test_battery_runtime_top_level_helper_passthroughs_cover_fallback_paths() ->
 def test_battery_runtime_dry_contact_member_collection_handles_callable_none_bucket() -> (
     None
 ):
-    runtime = BatteryRuntime(SimpleNamespace(type_bucket=lambda _key: None))
+    runtime = BatteryRuntime(
+        SimpleNamespace(
+            inventory_view=SimpleNamespace(
+                type_bucket=lambda _key: None,
+                type_device_info=lambda _key: None,
+                has_type=lambda _key: False,
+                has_type_for_entities=lambda _key: False,
+            ),
+        )
+    )
 
     assert runtime._dry_contact_members_for_settings() == []
 
@@ -1052,7 +1076,14 @@ def test_battery_runtime_dry_contact_member_collection_handles_callable_none_buc
 def test_battery_runtime_dry_contact_member_collection_skips_non_dict_members() -> None:
     runtime = BatteryRuntime(
         SimpleNamespace(
-            type_bucket=lambda key: {"devices": ["bad"]} if key == "dry_contact" else {}
+            inventory_view=SimpleNamespace(
+                type_bucket=lambda key: (
+                    {"devices": ["bad"]} if key == "dry_contact" else {}
+                ),
+                type_device_info=lambda _key: None,
+                has_type=lambda _key: False,
+                has_type_for_entities=lambda _key: False,
+            ),
         )
     )
 

--- a/tests/components/enphase_ev/test_buttons_and_fast.py
+++ b/tests/components/enphase_ev/test_buttons_and_fast.py
@@ -668,12 +668,17 @@ def test_storm_alert_opt_out_button_availability_guards() -> None:
     from custom_components.enphase_ev.button import StormAlertOptOutButton
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            has_type=lambda key: key == "envoy",
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type_for_entities=lambda key: key == "envoy",
+        ),
         site_id="site",
         last_update_success=False,
         battery_has_encharge=True,
         battery_has_enpower=True,
         battery_show_storm_guard=True,
-        has_type=lambda key: key == "envoy",
     )
     button = StormAlertOptOutButton(coord)
     assert button.available is False

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -191,6 +191,7 @@ class DummyCoordinator(SimpleNamespace):
 
     def __init__(self) -> None:
         super().__init__()
+        self.inventory_view = SimpleNamespace(type_bucket=lambda _key: None)
         self.client = DummyClient()
         self.update_interval = timedelta(seconds=45)
         self._charge_mode_cache = {RANDOM_SERIAL: ("FAST", 0)}
@@ -1700,7 +1701,7 @@ async def test_device_diagnostics_redacts_session_auth_fields(
 @pytest.mark.asyncio
 async def test_device_diagnostics_type_device_payload(hass, config_entry) -> None:
     coord = DummyCoordinator()
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Battery",
             "count": 2,
@@ -1738,7 +1739,7 @@ async def test_device_diagnostics_heatpump_includes_runtime_payloads(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Heat Pump",
             "count": 1,
@@ -1808,7 +1809,7 @@ async def test_device_diagnostics_ac_battery_type_includes_payloads(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
-    coord.type_bucket = lambda type_key: (  # type: ignore[attr-defined]
+    coord.inventory_view.type_bucket = lambda type_key: (  # type: ignore[attr-defined]
         {
             "type_label": "AC Battery",
             "count": 1,
@@ -1904,7 +1905,7 @@ async def test_device_diagnostics_heatpump_runtime_errors_are_swallowed(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Heat Pump",
             "count": 1,
@@ -1940,7 +1941,7 @@ async def test_device_diagnostics_ac_battery_capture_errors_are_swallowed(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
-    coord.type_bucket = lambda type_key: (  # type: ignore[attr-defined]
+    coord.inventory_view.type_bucket = lambda type_key: (  # type: ignore[attr-defined]
         {
             "type_label": "AC Battery",
             "count": 1,
@@ -1974,7 +1975,7 @@ async def test_device_diagnostics_envoy_includes_gateway_summary(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Gateway",
             "count": 3,
@@ -2042,7 +2043,7 @@ async def test_device_diagnostics_envoy_gateway_summary_handles_bad_bucket_shape
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Gateway",
             "count": "bad",
@@ -2072,7 +2073,7 @@ async def test_device_diagnostics_microinverter_includes_summary(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Microinverters",
             "count": 3,
@@ -2145,7 +2146,7 @@ async def test_device_diagnostics_encharge_includes_system_dashboard_details(
     coord = DummyCoordinator()
     coord.async_ensure_system_dashboard_diagnostics = AsyncMock()
     coord.async_ensure_battery_status_diagnostics = AsyncMock()
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Battery",
             "count": 1,
@@ -2197,7 +2198,7 @@ async def test_device_diagnostics_encharge_does_not_prefetch_battery_status(
     )
     coord._battery_status_payload = None
     coord.battery_status_summary = {}
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Battery",
             "count": 1,
@@ -2232,7 +2233,7 @@ async def test_device_diagnostics_does_not_prefetch_dashboard(
     coord.async_ensure_system_dashboard_diagnostics = AsyncMock(
         side_effect=RuntimeError("boom")
     )
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Gateway",
             "count": 1,
@@ -2266,7 +2267,7 @@ async def test_device_diagnostics_handles_system_dashboard_capture_error(
             raise RuntimeError("boom")
 
     coord = BrokenDashboardCoordinator()
-    coord.type_bucket = lambda type_key: (
+    coord.inventory_view.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Gateway",
             "count": 1,

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -861,3 +861,78 @@ def test_coordinator_evse_runtime_wrapper_delegation(coordinator_factory) -> Non
     runtime.cached_charge_mode_preference.assert_called_once_with("EV1", now=None)
     runtime.normalize_effective_charge_mode.assert_called_once_with("idle")
     runtime.charge_mode_start_preferences.assert_called_once_with("EV1")
+
+
+@pytest.mark.parametrize("phase", ["stop", "delay", "start"])
+async def test_amp_restart_cancellation_propagates(
+    coordinator_factory, monkeypatch, phase
+):
+    """Cancellation at each await must stop the real restart sequence."""
+    coord = coordinator_factory(serials=["EV1"])
+    entered = asyncio.Event()
+    stopped = asyncio.Event()
+
+    async def blocked(*_args, **_kwargs):
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            stopped.set()
+
+    coord.async_stop_charging = AsyncMock(
+        side_effect=blocked if phase == "stop" else None
+    )
+    coord.async_start_charging = AsyncMock(
+        side_effect=blocked if phase == "start" else None
+    )
+    if phase == "delay":
+        monkeypatch.setattr(
+            "custom_components.enphase_ev.evse_runtime.asyncio",
+            SimpleNamespace(**(vars(asyncio) | {"sleep": blocked})),
+        )
+    task = asyncio.create_task(
+        coord.evse_runtime.async_restart_after_amp_change(
+            "EV1", 30 if phase == "delay" else 0
+        )
+    )
+    await asyncio.wait_for(entered.wait(), 1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 1)
+    assert stopped.is_set()
+    assert coord.async_start_charging.await_count == (1 if phase == "start" else 0)
+
+
+async def test_replacing_amp_restart_cancels_old_sequence(
+    coordinator_factory, monkeypatch
+):
+    """Only the replacement restart may send a start command."""
+    coord = coordinator_factory(serials=["EV1"])
+    sleeping = asyncio.Event()
+    release = asyncio.Event()
+    original_sleep = asyncio.sleep
+
+    async def delay(_seconds):
+        sleeping.set()
+        await release.wait()
+
+    coord.async_stop_charging = AsyncMock()
+    coord.async_start_charging = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.evse_runtime.asyncio",
+        SimpleNamespace(**(vars(asyncio) | {"sleep": delay})),
+    )
+    coord.schedule_amp_restart("EV1", delay=30)
+    old = coord._amp_restart_tasks["EV1"]
+    await asyncio.wait_for(sleeping.wait(), 1)
+    coord.schedule_amp_restart("EV1", delay=30)
+    current = coord._amp_restart_tasks["EV1"]
+    with pytest.raises(asyncio.CancelledError):
+        await old
+    assert coord._amp_restart_tasks["EV1"] is current
+    coord.async_start_charging.assert_not_awaited()
+    release.set()
+    await asyncio.wait_for(current, 1)
+    await original_sleep(0)
+    coord.async_start_charging.assert_awaited_once_with("EV1")
+    assert coord._amp_restart_tasks == {}

--- a/tests/components/enphase_ev/test_fixture_efficiency.py
+++ b/tests/components/enphase_ev/test_fixture_efficiency.py
@@ -2,7 +2,39 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
+
+from .random_ids import RANDOM_SERIAL
+
 
 def test_pure_unit_test_does_not_start_home_assistant(hass_fixture_setup) -> None:
     """Keep the shared autouse fixtures from constructing Home Assistant."""
     assert hass_fixture_setup == []
+
+
+def test_namespace_has_no_implicit_inventory_capabilities():
+    """Importing test fixtures must not modify the standard library."""
+    assert SimpleNamespace.__module__ == "types"
+    assert not hasattr(SimpleNamespace(), "inventory_view")
+
+
+def test_coordinator_factory_preserves_empty_inputs(coordinator_factory):
+    empty = coordinator_factory(serials=[], data={})
+    assert empty.serials == set()
+    assert empty.data == {}
+    assert not empty.inventory_view.has_type("iqevse")
+
+    waiting = coordinator_factory(serials=[RANDOM_SERIAL], data={})
+    assert waiting.serials == {RANDOM_SERIAL}
+    assert waiting.data == {}
+
+    default = coordinator_factory()
+    assert default.serials == {RANDOM_SERIAL}
+    assert RANDOM_SERIAL in default.data
+
+
+def test_coordinator_factory_preserves_empty_config(coordinator_factory):
+    with pytest.raises(KeyError, match="site_id"):
+        coordinator_factory(config={}, serials=[])

--- a/tests/components/enphase_ev/test_integration_lifecycle.py
+++ b/tests/components/enphase_ev/test_integration_lifecycle.py
@@ -1,0 +1,263 @@
+"""Whole integration lifecycle with real platforms and cloud boundary doubles."""
+
+import asyncio
+from copy import deepcopy
+from datetime import timedelta
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from freezegun import freeze_time
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.aiohttp_client import (
+    async_create_clientsession,
+    async_get_clientsession,
+)
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.enphase_ev.api import EnphaseEVClient
+from custom_components.enphase_ev.const import (
+    CONF_SELECTED_TYPE_KEYS,
+    CONF_SERIALS,
+    CONF_SITE_ONLY,
+    OPT_WEATHER_ENABLED,
+)
+from .random_ids import RANDOM_SERIAL
+
+
+@pytest.fixture
+def freezer():
+    with freeze_time("2026-09-05 01:00:00", real_asyncio=True) as clock:
+        yield clock
+
+
+@pytest.fixture
+def platform_cloud(monkeypatch, load_fixture):
+    """Only replace cloud calls; retain coordinators, sessions and HA platforms."""
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.async_create_clientsession",
+        async_create_clientsession,
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.coordinator.async_get_clientsession",
+        async_get_clientsession,
+    )
+    responses = {
+        "status": load_fixture("status_idle.json"),
+        "summary_v2": [],
+        "site_tariff_bundle": ({}, {}),
+        "charger_auth_settings": [],
+        "devices_inventory": {
+            "result": [
+                {
+                    "type": "envoy",
+                    "devices": [{"serial_number": "GW-TEST", "name": "IQ Gateway"}],
+                }
+            ]
+        },
+        "inverters_inventory": {"inverters": [], "total": 0},
+        "system_dashboard_envoy_inverters": {"inverters": []},
+        "inverter_status": {},
+        "charge_mode": "MANUAL_CHARGING",
+        "evse_timeseries_lifetime_energy": {},
+        "evse_timeseries_daily_energy": {},
+        "site_livestream_payload": {},
+        "battery_site_settings": {"data": {"hasEncharge": False, "hasEnpower": False}},
+        "battery_backup_history": {"data": []},
+        "battery_settings_details": {"data": {}},
+        "battery_schedules": {"data": []},
+        "battery_status": {"data": {}},
+        "storm_guard_profile": {"data": {}},
+        "storm_guard_alert": {"criticalAlertActive": False, "stormAlerts": []},
+        "off_grid_due_to_grid_outage": {},
+        "green_charging_settings": [],
+        "charger_config": [],
+        "evse_feature_flags": {},
+        "evse_fw_details": [],
+        "homeowner_events_page": {"events": []},
+        "system_dashboard_events": {"events": []},
+        "system_dashboard_standing_alarms": {"alarms": []},
+        "phase_map_multiple_envoy": {},
+        "hems_consumption_lifetime": {},
+        "dry_contacts_settings": {},
+        "session_history": {"data": []},
+        "session_history_filter_criteria": {},
+        "weather": {"code": "sunny", "temperature": {"value": 20, "display": "20°C"}},
+        "latest_power": {"value": 1250, "units": "W", "precision": 0},
+        "lifetime_energy": {
+            "production": [1000],
+            "consumption": [2000],
+            "interval": 15,
+        },
+        "get_schedules": {"data": [], "meta": {"serverTimeStamp": 1}},
+    }
+    calls = {}
+    unexpected = []
+    for name, method in inspect.getmembers(
+        EnphaseEVClient, inspect.iscoroutinefunction
+    ):
+        if name.startswith("_") or name == "async_close":
+            continue
+
+        async def response(*_args, _name=name, **_kwargs):
+            if _name not in responses:
+                unexpected.append(_name)
+                raise AssertionError(f"Unexpected cloud call: {_name}")
+            return deepcopy(responses[_name])
+
+        calls[name] = AsyncMock(side_effect=response)
+        monkeypatch.setattr(EnphaseEVClient, name, calls[name])
+    return responses, calls, unexpected
+
+
+async def _finish_startup(hass, entry):
+    await hass.async_block_till_done()
+    warmup = entry.runtime_data.coordinator._warmup_task
+    assert warmup is not None
+    await asyncio.wait_for(asyncio.shield(warmup), 5)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.session_history_real
+@pytest.mark.parametrize("site_only", [False, True])
+async def test_real_platform_setup_reload_and_unload(
+    hass, config_entry, platform_cloud, site_only, freezer, monkeypatch
+):
+    responses, calls, unexpected = platform_cloud
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={
+            **config_entry.data,
+            CONF_SERIALS: [] if site_only else [RANDOM_SERIAL],
+            CONF_SITE_ONLY: site_only,
+            CONF_SELECTED_TYPE_KEYS: ["envoy"] if site_only else ["envoy", "iqevse"],
+        },
+    )
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await _finish_startup(hass, config_entry)
+    assert unexpected == [], ", ".join(unexpected)
+    assert config_entry.state is ConfigEntryState.LOADED
+    registry = er.async_get(hass)
+    entries = er.async_entries_for_config_entry(registry, config_entry.entry_id)
+    power = next(
+        e for e in entries if e.unique_id.endswith("_current_production_power")
+    )
+    assert hass.states.get(power.entity_id).state == "1250"
+    assert bool([e for e in entries if RANDOM_SERIAL in e.unique_id]) is not site_only
+    if not site_only:
+        assert hass.states.get("binary_sensor.garage_ev_charging").state == "off"
+        calls["get_schedules"].assert_awaited()
+    else:
+        calls["status"].assert_not_awaited()
+
+    registry.async_update_entity(power.entity_id, name="Roof production")
+    identities = {e.unique_id: (e.entity_id, e.device_id) for e in entries}
+    old = config_entry.runtime_data
+    old_session = old.coordinator.client._cookie_header_session
+    # Exercise the real topology option listener and its snapshot handoff.
+    hass.config_entries.async_update_entry(
+        config_entry, options={**config_entry.options, OPT_WEATHER_ENABLED: True}
+    )
+    await hass.async_block_till_done()
+    await _finish_startup(hass, config_entry)
+    current = config_entry.runtime_data
+    assert current.coordinator is not old.coordinator
+    assert old_session.closed
+    assert not current.coordinator.client._cookie_header_session.closed
+    assert registry.async_get(power.entity_id).name == "Roof production"
+    restored = {
+        e.unique_id: (e.entity_id, e.device_id)
+        for e in er.async_entries_for_config_entry(registry, config_entry.entry_id)
+    }
+    # Confirmed battery absence removes provisional battery controls. All
+    # retained entities keep their entity and device registry identities.
+    site = current.coordinator.site_id
+    unsupported = {
+        f"enphase_ev_site_{site}_storm_guard",
+        f"enphase_ev_site_{site}_system_profile",
+    }
+    assert identities.keys() - restored.keys() == unsupported
+    assert all(
+        restored[key] == identities[key] for key in identities.keys() - unsupported
+    )
+    assert hass.states.get(power.entity_id).state == "1250"
+
+    before = calls["latest_power"].await_count
+    responses["latest_power"]["value"] = 2500
+    responses["status"]["evChargerData"][0]["charging"] = True
+    responses["status"]["evChargerData"][0]["connectorStatusType"] = "CHARGING"
+    power_changed = asyncio.Event()
+
+    @callback
+    def on_state(event):
+        state = event.data.get("new_state")
+        if (
+            state is not None
+            and state.entity_id == power.entity_id
+            and state.state == "2500"
+        ):
+            power_changed.set()
+
+    unsubscribe = hass.bus.async_listen("state_changed", on_state)
+    try:
+        freezer.tick(timedelta(minutes=16))
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await asyncio.wait_for(power_changed.wait(), 5)
+        await hass.async_block_till_done()
+    finally:
+        unsubscribe()
+    assert unexpected == [], ", ".join(unexpected)
+    assert calls["latest_power"].await_count > before
+    assert hass.states.get(power.entity_id).state == "2500"
+    if not site_only:
+        assert hass.states.get("binary_sensor.garage_ev_charging").state == "on"
+
+    restart = None
+    if not site_only:
+        responses.update(
+            {
+                "stop_charging": {"status": "ok"},
+                "start_charging": {"status": "ok"},
+                "start_live_stream": {"status": "ok", "duration_s": 90},
+                "stop_live_stream": {"status": "ok"},
+            }
+        )
+        sleeping = asyncio.Event()
+
+        async def restart_delay(_seconds):
+            sleeping.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(
+            "custom_components.enphase_ev.evse_runtime.asyncio",
+            SimpleNamespace(**(vars(asyncio) | {"sleep": restart_delay})),
+        )
+        current.coordinator.schedule_amp_restart(RANDOM_SERIAL, delay=30)
+        restart = current.coordinator._amp_restart_tasks[RANDOM_SERIAL]
+        await asyncio.wait_for(sleeping.wait(), 5)
+        calls["stop_charging"].assert_awaited_once_with(RANDOM_SERIAL)
+        calls["start_charging"].assert_not_awaited()
+
+    session = current.coordinator.client._cookie_header_session
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert session.closed
+    if restart is not None:
+        assert restart.cancelled()
+        assert current.coordinator._amp_restart_tasks == {}
+        calls["start_charging"].assert_not_awaited()
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
+    assert getattr(config_entry, "runtime_data", None) is None
+    # HA retains a registry placeholder for unloaded entities.
+    assert hass.states.get(power.entity_id).state == "unavailable"
+    assert registry.async_get(power.entity_id).name == "Roof production"
+    call_counts = {name: call.await_count for name, call in calls.items()}
+    freezer.tick(timedelta(minutes=16))
+    async_fire_time_changed(hass, dt_util.utcnow())
+    await hass.async_block_till_done()
+    assert {name: call.await_count for name, call in calls.items()} == call_counts
+    assert unexpected == [], ", ".join(unexpected)

--- a/tests/components/enphase_ev/test_registry_cleanup.py
+++ b/tests/components/enphase_ev/test_registry_cleanup.py
@@ -297,8 +297,9 @@ async def test_prune_inactive_serial_entities_removes_retired_charger_entities(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("ac_capability", [True, None])
 async def test_prune_inactive_serial_entities_skips_unknown_device_families(
-    hass: HomeAssistant, config_entry
+    hass: HomeAssistant, config_entry, ac_capability
 ) -> None:
     site_id = config_entry.data[CONF_SITE_ID]
     ent_reg = er.async_get(hass)
@@ -312,7 +313,7 @@ async def test_prune_inactive_serial_entities_skips_unknown_device_families(
             has_type_for_entities=lambda key: key
             in {"encharge", "ac_battery", "microinverter"}
         ),
-        battery_has_acb=True,
+        battery_has_acb=ac_capability,
         include_inverters=True,
         _battery_status_payload=None,
         _ac_battery_devices_payload=None,

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -270,9 +270,14 @@ def test_select_helper_fallbacks() -> None:
     from custom_components.enphase_ev import select as select_mod
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            has_type=lambda type_key: type_key == "envoy",
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type_for_entities=lambda type_key: type_key == "envoy",
+        ),
         site_id="site",
         battery_has_encharge=True,
-        has_type=lambda type_key: type_key == "envoy",
         battery_write_access_confirmed=None,
         battery_user_is_owner=True,
         battery_user_is_installer=False,
@@ -1357,11 +1362,16 @@ def test_system_profile_select_available_with_legacy_fallback_controls() -> None
     from custom_components.enphase_ev.select import SystemProfileSelect
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            has_type=lambda type_key: type_key == "envoy",
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type_for_entities=lambda type_key: type_key == "envoy",
+        ),
         site_id="site",
         hass=None,
         last_update_success=True,
         battery_has_encharge=True,
-        has_type=lambda type_key: type_key == "envoy",
         battery_profile_selection_available=None,
         battery_controls_available=True,
         battery_write_access_confirmed=None,

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -2531,31 +2531,36 @@ def test_microinverter_snapshot_fallback_covers_summary_error_and_zero_status_pa
     None
 ):
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _type_key: {
+                "count": 2,
+                "devices": [
+                    {
+                        "serial_number": "INV-A",
+                        "name": "Inverter A",
+                        "status": "normal",
+                        "last_report": "2026-02-15T10:00:00Z",
+                    }
+                ],
+                "status_counts": {
+                    "total": 0,
+                    "normal": 0,
+                    "warning": 0,
+                    "error": 0,
+                    "not_reporting": 0,
+                    "unknown": 0,
+                },
+                "panel_info": {"panels": 1},
+                "status_type_counts": {"ok": 1},
+                "connectivity_state": " ",
+            },
+            type_device_info=lambda _key: None,
+            has_type=lambda _key: False,
+            has_type_for_entities=lambda _key: False,
+        ),
         microinverter_inventory_summary=lambda: (_ for _ in ()).throw(
             RuntimeError("boom")
         ),
-        type_bucket=lambda _type_key: {
-            "count": 2,
-            "devices": [
-                {
-                    "serial_number": "INV-A",
-                    "name": "Inverter A",
-                    "status": "normal",
-                    "last_report": "2026-02-15T10:00:00Z",
-                }
-            ],
-            "status_counts": {
-                "total": 0,
-                "normal": 0,
-                "warning": 0,
-                "error": 0,
-                "not_reporting": 0,
-                "unknown": 0,
-            },
-            "panel_info": {"panels": 1},
-            "status_type_counts": {"ok": 1},
-            "connectivity_state": " ",
-        },
     )
 
     snapshot = sensor_mod._microinverter_inventory_snapshot(coord)
@@ -3220,48 +3225,53 @@ def test_heatpump_snapshot_fallback_covers_summary_error_and_type_snapshot_paths
 ):
     mono_now = time.monotonic()
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _type_key: {
+                "count": "bad-count",
+                "devices": [
+                    {
+                        "device-type": "HEAT_PUMP",
+                        "name": "Heat Pump",
+                        "status": "not_reporting",
+                        "last-report": "2026-02-15T10:00:00Z",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "name": "Meter 1",
+                        "status": "warning",
+                        "device_uid": "EM-1",
+                        "last_reported": "2026-02-15T10:05:00Z",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "name": "Meter 2",
+                        "status_text": "Normal",
+                        "device-uid": "EM-2",
+                        "last_reported_at": "2026-02-15T10:06:00Z",
+                    },
+                    {"device_type": "", "name": "Unknown Member"},
+                    "bad-member",
+                ],
+                "status_counts": {"total": "bad"},
+                "overall_status_text": " ",
+                "device_type_counts": {
+                    None: 1,
+                    "ENERGY_METER": "2",
+                    "SG_READY_GATEWAY": "bad",
+                    "ZERO": 0,
+                },
+                "status_summary": " ",
+                "model_summary": "Model A x1",
+                "firmware_summary": "FW x1",
+            },
+            type_device_info=lambda _key: None,
+            has_type=lambda _key: False,
+            has_type_for_entities=lambda _key: False,
+        ),
         heatpump_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
         heatpump_type_summary=lambda _device_type: (_ for _ in ()).throw(
             RuntimeError("boom")
         ),
-        type_bucket=lambda _type_key: {
-            "count": "bad-count",
-            "devices": [
-                {
-                    "device-type": "HEAT_PUMP",
-                    "name": "Heat Pump",
-                    "status": "not_reporting",
-                    "last-report": "2026-02-15T10:00:00Z",
-                },
-                {
-                    "device_type": "ENERGY_METER",
-                    "name": "Meter 1",
-                    "status": "warning",
-                    "device_uid": "EM-1",
-                    "last_reported": "2026-02-15T10:05:00Z",
-                },
-                {
-                    "device_type": "ENERGY_METER",
-                    "name": "Meter 2",
-                    "status_text": "Normal",
-                    "device-uid": "EM-2",
-                    "last_reported_at": "2026-02-15T10:06:00Z",
-                },
-                {"device_type": "", "name": "Unknown Member"},
-                "bad-member",
-            ],
-            "status_counts": {"total": "bad"},
-            "overall_status_text": " ",
-            "device_type_counts": {
-                None: 1,
-                "ENERGY_METER": "2",
-                "SG_READY_GATEWAY": "bad",
-                "ZERO": 0,
-            },
-            "status_summary": " ",
-            "model_summary": "Model A x1",
-            "firmware_summary": "FW x1",
-        },
         _hems_devices_last_success_utc=datetime(
             2026, 2, 15, 10, 7, tzinfo=timezone.utc
         ),
@@ -3322,30 +3332,39 @@ def test_heatpump_snapshot_fallback_covers_summary_error_and_type_snapshot_paths
 
 def test_heatpump_snapshot_fallback_covers_remaining_edge_paths() -> None:
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _type_key: {
+                "count": 0,
+                "devices": [
+                    {
+                        "device_type": "ENERGY_METER",
+                        "name": "Meter A",
+                        "status": "warning",
+                    },
+                    {
+                        "device_type": "SG_READY_GATEWAY",
+                        "name": "Gateway",
+                        "status": "normal",
+                        "last_report": "2026-02-15T10:00:00Z",
+                    },
+                ],
+                "status_counts": {
+                    "total": 2,
+                    "normal": 1,
+                    "warning": 1,
+                    "error": 0,
+                    "not_reporting": 0,
+                    "unknown": 0,
+                },
+            },
+            type_device_info=lambda _key: None,
+            has_type=lambda _key: False,
+            has_type_for_entities=lambda _key: False,
+        ),
         heatpump_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
         heatpump_type_summary=lambda _device_type: (_ for _ in ()).throw(
             RuntimeError("boom")
         ),
-        type_bucket=lambda _type_key: {
-            "count": 0,
-            "devices": [
-                {"device_type": "ENERGY_METER", "name": "Meter A", "status": "warning"},
-                {
-                    "device_type": "SG_READY_GATEWAY",
-                    "name": "Gateway",
-                    "status": "normal",
-                    "last_report": "2026-02-15T10:00:00Z",
-                },
-            ],
-            "status_counts": {
-                "total": 2,
-                "normal": 1,
-                "warning": 1,
-                "error": 0,
-                "not_reporting": 0,
-                "unknown": 0,
-            },
-        },
         _hems_devices_last_success_utc="bad",
         _hems_devices_last_success_mono=None,
         _hems_devices_using_stale=False,
@@ -5223,36 +5242,41 @@ def test_gateway_inventory_snapshot_fallback_covers_summary_error_and_dashboard_
     None
 ):
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _type_key: {
+                "count": "bad-count",
+                "devices": [
+                    {
+                        "name": "Gateway A",
+                        "serial_number": "GW-A",
+                        "statusText": "Normal",
+                        "model": "IQ Gateway",
+                        "sw_version": "8.2.0",
+                        "last_reported": "2026-02-15T10:00:00Z",
+                    },
+                    {
+                        "name": "Gateway B",
+                        "serial_number": "GW-B",
+                        "status": "offline",
+                        "connected": None,
+                        "model_name": "System Controller",
+                        "firmware": "1.0.0",
+                    },
+                    {
+                        "name": "Gateway C",
+                        "serial_number": "GW-C",
+                        "status": "warn",
+                        "connected": "maybe",
+                        "firmwareVersion": "2.0.0",
+                        "last-report": "2026-02-15T10:05:00Z",
+                    },
+                ],
+            },
+            type_device_info=lambda _key: None,
+            has_type=lambda _key: False,
+            has_type_for_entities=lambda _key: False,
+        ),
         gateway_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
-        type_bucket=lambda _type_key: {
-            "count": "bad-count",
-            "devices": [
-                {
-                    "name": "Gateway A",
-                    "serial_number": "GW-A",
-                    "statusText": "Normal",
-                    "model": "IQ Gateway",
-                    "sw_version": "8.2.0",
-                    "last_reported": "2026-02-15T10:00:00Z",
-                },
-                {
-                    "name": "Gateway B",
-                    "serial_number": "GW-B",
-                    "status": "offline",
-                    "connected": None,
-                    "model_name": "System Controller",
-                    "firmware": "1.0.0",
-                },
-                {
-                    "name": "Gateway C",
-                    "serial_number": "GW-C",
-                    "status": "warn",
-                    "connected": "maybe",
-                    "firmwareVersion": "2.0.0",
-                    "last-report": "2026-02-15T10:05:00Z",
-                },
-            ],
-        },
         system_dashboard_envoy_detail=lambda: {
             "name": "",
             "serial_number": "GW-D",
@@ -5287,8 +5311,13 @@ def test_gateway_inventory_snapshot_fallback_covers_summary_error_and_dashboard_
     assert "statusText" in snapshot["property_keys"]
 
     dashboard_only_coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _type_key: {"count": 0, "devices": []},
+            type_device_info=lambda _key: None,
+            has_type=lambda _key: False,
+            has_type_for_entities=lambda _key: False,
+        ),
         gateway_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
-        type_bucket=lambda _type_key: {"count": 0, "devices": []},
         system_dashboard_envoy_detail=lambda: {
             "name": "",
             "serial_number": "GW-FALLBACK",
@@ -5308,8 +5337,13 @@ def test_gateway_inventory_snapshot_fallback_covers_summary_error_and_dashboard_
 
 def test_gateway_inventory_snapshot_zero_devices_returns_empty_status_summary() -> None:
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _type_key: {"count": 0, "devices": []},
+            type_device_info=lambda _key: None,
+            has_type=lambda _key: False,
+            has_type_for_entities=lambda _key: False,
+        ),
         gateway_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
-        type_bucket=lambda _type_key: {"count": 0, "devices": []},
         system_dashboard_envoy_detail=lambda: None,
     )
 
@@ -5327,36 +5361,41 @@ def test_microinverter_snapshot_fallback_covers_bad_counts_and_missing_status_co
             raise ValueError("bad")
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _type_key: {
+                "count": BadInt(),
+                "devices": [
+                    {"serial_number": "INV-A", "last_report": "invalid"},
+                    {
+                        "serial_number": "INV-B",
+                        "name": "Inverter B",
+                        "status": "warning",
+                        "last_reported_at": "2026-02-15T11:00:00Z",
+                    },
+                ],
+                "status_counts": {
+                    "total": 1,
+                    "normal": BadInt(),
+                    "warning": 0,
+                    "error": 0,
+                    "not_reporting": 1,
+                    "unknown": 2,
+                },
+                "latest_reported_utc": "2026-02-15T07:00:00Z",
+                "latest_reported_device": {
+                    "serial_number": "TOPOLOGY",
+                    "name": "Topology summary",
+                    "status": "normal",
+                },
+                "connectivity_state": " ",
+            },
+            type_device_info=lambda _key: None,
+            has_type=lambda _key: False,
+            has_type_for_entities=lambda _key: False,
+        ),
         microinverter_inventory_summary=lambda: (_ for _ in ()).throw(
             RuntimeError("boom")
         ),
-        type_bucket=lambda _type_key: {
-            "count": BadInt(),
-            "devices": [
-                {"serial_number": "INV-A", "last_report": "invalid"},
-                {
-                    "serial_number": "INV-B",
-                    "name": "Inverter B",
-                    "status": "warning",
-                    "last_reported_at": "2026-02-15T11:00:00Z",
-                },
-            ],
-            "status_counts": {
-                "total": 1,
-                "normal": BadInt(),
-                "warning": 0,
-                "error": 0,
-                "not_reporting": 1,
-                "unknown": 2,
-            },
-            "latest_reported_utc": "2026-02-15T07:00:00Z",
-            "latest_reported_device": {
-                "serial_number": "TOPOLOGY",
-                "name": "Topology summary",
-                "status": "normal",
-            },
-            "connectivity_state": " ",
-        },
     )
 
     snapshot = sensor_mod._microinverter_inventory_snapshot(coord)
@@ -5372,15 +5411,20 @@ def test_microinverter_snapshot_fallback_covers_bad_counts_and_missing_status_co
     assert snapshot["connectivity_state"] == "offline"
 
     missing_status_counts_coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _type_key: {
+                "count": 2,
+                "devices": [],
+                "status_counts": "bad",
+                "connectivity_state": " ",
+            },
+            type_device_info=lambda _key: None,
+            has_type=lambda _key: False,
+            has_type_for_entities=lambda _key: False,
+        ),
         microinverter_inventory_summary=lambda: (_ for _ in ()).throw(
             RuntimeError("boom")
         ),
-        type_bucket=lambda _type_key: {
-            "count": 2,
-            "devices": [],
-            "status_counts": "bad",
-            "connectivity_state": " ",
-        },
     )
     snapshot2 = sensor_mod._microinverter_inventory_snapshot(
         missing_status_counts_coord

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -452,6 +452,12 @@ def test_battery_overall_charge_sensor_states():
     from custom_components.enphase_ev.sensor import EnphaseBatteryOverallChargeSensor
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site",
         battery_aggregate_charge_pct=47.8,
         battery_status_summary={
@@ -507,6 +513,12 @@ def test_battery_overall_status_sensor_states():
     from homeassistant.helpers.entity import EntityCategory
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site",
         battery_aggregate_status="warning",
         battery_status_summary={
@@ -555,6 +567,12 @@ def test_battery_cfg_schedule_status_sensor_states():
     from homeassistant.helpers.entity import EntityCategory
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site",
         battery_cfg_schedule_status="pending",
         charge_from_grid_control_available=True,
@@ -855,6 +873,12 @@ def test_battery_site_summary_sensors_state_and_attributes():
     )
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site",
         battery_status_summary={
             "site_available_energy_kwh": 4.75,
@@ -950,6 +974,12 @@ def test_battery_last_reported_sensor_states_and_attributes():
         ]
     }
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site",
         battery_status_payload=payload,
         iter_battery_serials=lambda: ["BAT-FALLBACK"],
@@ -1437,6 +1467,12 @@ def test_battery_mode_sensor_states():
     from custom_components.enphase_ev.sensor import EnphaseBatteryModeSensor
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site",
         battery_grid_mode="ImportExport",
         battery_mode_display="Import and Export",
@@ -1509,6 +1545,12 @@ def test_battery_mode_sensor_falls_back_to_status_payload():
     from custom_components.enphase_ev.sensor import EnphaseBatteryModeSensor
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site",
         battery_grid_mode=None,
         battery_mode_display=None,
@@ -1559,6 +1601,12 @@ def test_battery_mode_sensor_skips_invalid_status_payload_entries():
             raise ValueError("boom")
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site",
         battery_grid_mode=None,
         battery_mode_display=None,
@@ -1605,9 +1653,14 @@ def test_grid_mode_sensor_states_and_attributes():
     from custom_components.enphase_ev.sensor import EnphaseGridModeSensor
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            has_type=lambda key: key in ("envoy", "enpower"),
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type_for_entities=lambda key: key in ("envoy", "enpower"),
+        ),
         site_id="site",
         battery_has_encharge=True,
-        has_type=lambda key: key in ("envoy", "enpower"),
         grid_mode="off_grid",
         grid_mode_raw_states=["is_grid_outage:false", "show_grid_connect:true"],
         grid_mode_source="grid_outage_context",
@@ -1720,14 +1773,17 @@ def test_microinverter_inventory_zero_total_paths():
         "connectivity_state": "unknown",
     }
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: bucket,
+            has_type=lambda key: key == "microinverter",
+            has_type_for_entities=lambda key: key == "microinverter",
+            type_device_info=lambda _key: None,
+        ),
         site_id="site",
         include_inverters=True,
         last_success_utc=datetime(2026, 2, 15, 5, 31, 33, tzinfo=timezone.utc),
         last_update_success=False,
         _devices_inventory_ready=False,
-        type_bucket=lambda _key: bucket,
-        has_type=lambda key: key == "microinverter",
-        has_type_for_entities=lambda key: key == "microinverter",
     )
 
     connectivity = EnphaseMicroinverterConnectivityStatusSensor(coord)
@@ -1742,6 +1798,12 @@ def test_system_profile_status_sensor_states():
     from custom_components.enphase_ev.sensor import EnphaseSystemProfileStatusSensor
 
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site",
         storm_alert_active=None,
         last_success_utc=None,

--- a/tests/components/enphase_ev/test_type_device_entity_fallbacks.py
+++ b/tests/components/enphase_ev/test_type_device_entity_fallbacks.py
@@ -70,6 +70,12 @@ def test_site_binary_sensor_device_info_falls_back_without_type_info() -> None:
 
 def test_site_device_info_fallbacks_without_type_device_info_provider() -> None:
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site-1",
         last_update_success=True,
         battery_profile_pending=True,
@@ -153,10 +159,14 @@ def test_system_profile_select_and_storm_guard_availability_type_checks() -> Non
     assert StormGuardSwitch(coord).available is False
 
 
-def test_site_entities_fall_back_to_role_checks_without_property_or_type_helpers() -> (
-    None
-):
+def test_site_entities_fall_back_to_role_checks_with_explicit_inventory() -> None:
     coord = SimpleNamespace(
+        inventory_view=SimpleNamespace(
+            type_bucket=lambda _key: None,
+            type_device_info=lambda _key: None,
+            has_type=lambda key: key in {"envoy", "encharge"},
+            has_type_for_entities=lambda key: key in {"envoy", "encharge"},
+        ),
         site_id="site-3",
         last_update_success=True,
         battery_user_is_owner=True,
@@ -176,6 +186,21 @@ def test_site_entities_fall_back_to_role_checks_without_property_or_type_helpers
     assert BatteryReserveNumber(coord).available is True
     assert SystemProfileSelect(coord).available is True
     assert StormGuardSwitch(coord).available is True
+
+    # Neither a missing inventory view nor missing capability methods may grant
+    # access, even when the account role permits battery controls.
+    enabled_view = coord.inventory_view
+    for unavailable_view in (
+        None,
+        SimpleNamespace(),
+        SimpleNamespace(has_type_for_entities=lambda _key: False),
+    ):
+        coord.inventory_view = unavailable_view
+        assert BatteryReserveNumber(coord).available is False
+        assert SystemProfileSelect(coord).available is False
+        assert StormGuardSwitch(coord).available is False
+    coord.inventory_view = enabled_view
+    assert BatteryReserveNumber(coord).available is True
 
 
 def test_system_profile_select_fallback_unavailable_without_battery_controls() -> None:

--- a/tests/scripts/test_check_statement_coverage.py
+++ b/tests/scripts/test_check_statement_coverage.py
@@ -1,0 +1,64 @@
+"""Statement gates must stay independent of diagnostic branch coverage."""
+
+import json
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Script tests also run without the integration conftest or repository imports.
+check_report = runpy.run_path(
+    str(Path(__file__).resolve().parents[2] / "scripts/check_statement_coverage.py")
+)["check_report"]
+
+
+@pytest.mark.parametrize(
+    "covered,expected", [(2, []), (1, ["module.py: uncovered lines [3]"])]
+)
+def test_statement_gate_ignores_missing_branches(covered, expected):
+    report = {
+        "files": {
+            "module.py": {
+                "summary": {
+                    "covered_lines": covered,
+                    "num_statements": 2,
+                    "missing_branches": 1,
+                },
+                "missing_lines": [3] if covered < 2 else [],
+            }
+        }
+    }
+    assert check_report(report, ["module.py"]) == expected
+
+
+def test_missing_module_fails_closed():
+    assert check_report({"files": {}}, ["new.py"]) == ["new.py: missing coverage data"]
+
+
+@pytest.mark.parametrize(
+    "include,status", [("empty.py", 0), ("missing.py", 1), ("", 2)]
+)
+def test_command_line(tmp_path, include, status):
+    report = tmp_path / "coverage.json"
+    report.write_text(
+        json.dumps(
+            {
+                "files": {
+                    "empty.py": {
+                        "summary": {"covered_lines": 0, "num_statements": 0},
+                        "missing_lines": [],
+                    }
+                }
+            }
+        )
+    )
+    script = Path(__file__).resolve().parents[2] / "scripts/check_statement_coverage.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--report", str(report), "--include", include],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == status

--- a/tests/scripts/test_ci_workflow.py
+++ b/tests/scripts/test_ci_workflow.py
@@ -3,6 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+import os
+import shlex
+import subprocess
+
+import pytest
 
 import yaml
 
@@ -57,7 +62,9 @@ def test_pytest_reuses_one_coverage_run_and_loads_only_required_plugins() -> Non
     assert "pytest_cov.plugin" in test_step["env"]["PYTEST_PLUGINS"]
     assert "tests/scripts" not in test_step["run"]
     assert "coverage run" not in coverage_step["run"]
-    assert "coverage report" in coverage_step["run"]
+    assert "check_statement_coverage.py" in coverage_step["run"]
+    assert "--cov-branch" in test_step["run"]
+    assert "--cov-report=json" in test_step["run"]
 
 
 def test_uv_caches_depend_only_on_dependency_inputs() -> None:
@@ -89,3 +96,33 @@ def test_duplicate_static_gates_have_single_ci_owners() -> None:
     assert (
         sum(command.lstrip().startswith("mypy ") for command in quality_commands) == 1
     )
+
+
+def _compatibility_test_paths():
+    paths = set()
+    for name in ("minimum-homeassistant", "homeassistant-2026-8"):
+        for step in _jobs()[name]["steps"]:
+            for token in shlex.split(step.get("run", "")):
+                if token.startswith("tests/"):
+                    paths.add(token.split("::")[0])
+    return sorted(paths)
+
+
+@pytest.mark.parametrize("path", _compatibility_test_paths())
+def test_every_compatibility_test_triggers_its_lane(path, tmp_path):
+    """Execute the workflow classifier with a test-only changed path."""
+    step = next(
+        step
+        for step in _jobs()["changes"]["steps"]
+        if step.get("name") == "Classify changed paths"
+    )
+    script = step["run"]
+    # The classifier below consumes git's changed-path output. No network/git
+    # mutation is needed to exercise its actual shell expressions.
+    script = script[script.index("          set_output()".strip()) :]
+    output = tmp_path / "outputs"
+    env = {**os.environ, "GITHUB_OUTPUT": str(output), "changed_files": path}
+    subprocess.run(
+        ["bash", "-c", script], env=env, check=True, capture_output=True, text=True
+    )
+    assert "compatibility=true" in output.read_text().splitlines()


### PR DESCRIPTION
## Summary

Close test gaps that allowed implicit inventory capabilities and mocked lifecycle boundaries to conceal integration regressions. Add real Home Assistant platform setup, option reload, polling, registry preservation, and unload scenarios for charger and site-only entries, plus cancellation tests for the actual amp-restart sequence.

Preserve explicitly empty coordinator fixture inputs, replace the global `SimpleNamespace` patch with explicit inventory doubles, and ensure every test executed by a compatibility lane also triggers that lane when changed. Collect branch coverage while retaining the existing 100% statement requirement for changed integration modules.

## Related Issues

No linked issue; follows the integration test-suite review.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [x] Other: test coverage and CI validation

## Testing

Validation uses the repository Docker configuration with the existing pinned Home Assistant 2026.9 image selected by this local override:

```yaml
services:
  ha-dev:
    image: enphase-architecture-ha-dev:2026.9
```

After rebasing on `origin/main`: 4,130 integration tests, all 54 translation tests, and the full 4,285-test repository suite passed. Formatting, lint, full-package strict typing, both quality-scale checks, and strict import diagnostics passed.

Exact commands run:

```bash
docker compose -f devtools/docker/docker-compose.yml -f /private/tmp/enphase-architecture-compose.yml run --rm ha-dev bash -lc 'black custom_components/enphase_ev tests/components/enphase_ev scripts/check_statement_coverage.py tests/scripts/test_check_statement_coverage.py tests/scripts/test_ci_workflow.py && ruff check . && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log'
docker compose -f devtools/docker/docker-compose.yml -f /private/tmp/enphase-architecture-compose.yml run --rm ha-dev bash -lc 'COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run --branch --source=custom_components.enphase_ev -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage json -o /tmp/enphase_ev.coverage.json && python scripts/check_statement_coverage.py --report /tmp/enphase_ev.coverage.json --include=custom_components/enphase_ev/evse_runtime.py && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report --include=custom_components/enphase_ev/evse_runtime.py && pytest -q tests/components/enphase_ev/test_service_translations.py && pytest'
docker compose -f devtools/docker/docker-compose.yml -f /private/tmp/enphase-architecture-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro -v /private/tmp/enphase-review-precommit:/tmp/pre-commit -e PRE_COMMIT_HOME=/tmp/pre-commit -e BLACK_NUM_WORKERS=2 ha-dev bash -lc 'python -m pre_commit run --all-files && python -m pre_commit run --files scripts/check_statement_coverage.py tests/components/enphase_ev/test_integration_lifecycle.py tests/scripts/test_check_statement_coverage.py'
```

The changed integration module, `evse_runtime.py`, has 100% statement coverage. Its source changes only remove three cancellation-handler coverage exclusions. Earlier validation also passed both compatibility lanes: 208 tests on Home Assistant 2026.6 and 28 on Home Assistant 2026.8.3.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes. Not applicable: integration behavior is unchanged.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed. Contributor testing guidance is updated in `CONTRIBUTING.md`.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. Translation regression tests pass; no strings changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage. Applies to the changed integration module.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The lifecycle tests replace cloud API methods while retaining real coordinators, sessions, platform forwarding, scheduling, and cleanup. Unexpected cloud calls fail the tests. These tests do not contact a live Enphase account.
