### PR TITLE
Isolate optional VPP authorization failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
+- Isolated optional VPP enrollment and event authorization failures to their
+  endpoint families so a VPP-only 401 no longer triggers whole-integration
+  reauthentication. Existing cooldowns and bounded cached data remain in use. (#855)
 - Retained the last valid Current Power Consumption reading during invalid or
   discontinuous consumption samples, up to 15 minutes from its original source
   timestamp. Bad samples and restarts cannot extend that deadline, and rejected

--- a/custom_components/enphase_ev/vpp_runtime.py
+++ b/custom_components/enphase_ev/vpp_runtime.py
@@ -11,11 +11,9 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import aiohttp
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.util import dt as dt_util
 
 from .api import (
-    EnphaseLoginWallUnauthorized,
     OptionalEndpointUnavailable,
     Unauthorized,
 )
@@ -347,14 +345,14 @@ class VppRuntime:
                 self._program_id = None
                 self._program_last_confirmed_mono = None
                 raise OptionalEndpointUnavailable("Ambiguous VPP program response")
-        except EnphaseLoginWallUnauthorized as err:
+        except Unauthorized as err:
+            # Grid Services authorization does not establish account-wide expiry.
+            # The client owns the bounded stored-credential retry, when available.
             self.coordinator._note_endpoint_family_failure(
                 VPP_ENROLLMENT_ENDPOINT_FAMILY,
                 self._safe_failure("VPP enrollment unavailable", err),
             )
             return
-        except Unauthorized as err:
-            raise ConfigEntryAuthFailed from err
         except Exception as err:  # noqa: BLE001
             safe = (
                 err
@@ -385,14 +383,13 @@ class VppRuntime:
             parsed = parse_vpp_events(payload)
             if parsed is None:
                 raise OptionalEndpointUnavailable("Invalid VPP events response")
-        except EnphaseLoginWallUnauthorized as err:
+        except Unauthorized as err:
+            # Isolate event authorization failures just like enrollment failures.
             self.coordinator._note_endpoint_family_failure(
                 VPP_EVENTS_ENDPOINT_FAMILY,
                 self._safe_failure("VPP events unavailable", err),
             )
             return
-        except Unauthorized as err:
-            raise ConfigEntryAuthFailed from err
         except Exception as err:  # noqa: BLE001
             if isinstance(err, aiohttp.ClientResponseError) and err.status in (
                 400,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,6 +170,10 @@ Runtime managers keep endpoint-family behavior out of the main coordinator:
   reuse a confirmed program for seven days; event data is refreshed every five
   minutes. Its immutable snapshot participates in aggregate snapshot equality so
   VPP-only changes notify entity listeners.
+  VPP enrollment and event authorization failures, including repeated HTTP 401s
+  after the client's stored-credential retry, enter only that endpoint family's
+  cooldown. They preserve bounded cached data and do not independently trigger
+  config-entry reauthentication; core authentication failures still can.
 
 These managers should own cache lifetimes, stale data decisions, and endpoint-specific parsing for their family. The coordinator should expose their normalized state through properties and helper methods.
 

--- a/tests/components/enphase_ev/test_vpp_api.py
+++ b/tests/components/enphase_ev/test_vpp_api.py
@@ -34,9 +34,6 @@ class _Response:
     async def json(self) -> object:
         return {"data": None}
 
-    async def text(self) -> str:
-        return ""
-
 
 def _client() -> api.EnphaseEVClient:
     client = api.EnphaseEVClient(
@@ -126,6 +123,50 @@ async def test_vpp_api_uses_stateless_session_even_when_shared_jar_has_cookies()
     request_headers = stateless.request.call_args.kwargs["headers"]
     assert "Cookie" not in request_headers
     assert request_headers["Authorization"] == "MANAGER"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "args"),
+    [
+        ("vpp_enrollment_id", ()),
+        ("vpp_enrollment_details", (ENROLLMENT_ID,)),
+        ("vpp_events", (PROGRAM_ID,)),
+    ],
+)
+async def test_vpp_401_retries_once_with_refreshed_credentials(
+    method: str, args: tuple[str, ...]
+) -> None:
+    response = _Response()
+    response.status = 401
+    session = SimpleNamespace(
+        cookie_jar=aiohttp.DummyCookieJar(),
+        request=MagicMock(return_value=response),
+    )
+    client = api.EnphaseEVClient(
+        session,  # type: ignore[arg-type]
+        "1234567",
+        "OLD",
+        "session=private",
+        cookie_header_session=session,  # type: ignore[arg-type]
+    )
+
+    async def refresh() -> bool:
+        client.update_credentials(eauth="NEW", cookie="session=refreshed")
+        return True
+
+    reauth = AsyncMock(side_effect=refresh)
+    client.set_reauth_callback(reauth)
+
+    with pytest.raises(api.Unauthorized):
+        await getattr(client, method)(*args)
+
+    reauth.assert_awaited_once_with()
+    assert session.request.call_count == 2
+    assert [
+        call.kwargs["headers"]["Authorization"]
+        for call in session.request.call_args_list
+    ] == ["OLD", "NEW"]
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_vpp_runtime.py
+++ b/tests/components/enphase_ev/test_vpp_runtime.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
-from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from custom_components.enphase_ev.api import (
     EnphaseLoginWallUnauthorized,
@@ -19,6 +18,7 @@ from custom_components.enphase_ev.api import (
 from custom_components.enphase_ev.const import OPT_VPP_EVENTS_ENABLED
 from custom_components.enphase_ev.state_models import EndpointFamilyHealth
 from custom_components.enphase_ev.vpp_runtime import (
+    VPP_ENROLLMENT_ENDPOINT_FAMILY,
     VPP_EVENTS_ENDPOINT_FAMILY,
     VppRuntime,
     _datetime,
@@ -383,18 +383,145 @@ async def test_runtime_handles_missing_fetchers_and_invalid_event_shape() -> Non
 
 
 @pytest.mark.asyncio
-async def test_runtime_propagates_authentication_failures() -> None:
-    coord = _coordinator()
+@pytest.mark.parametrize(
+    ("method", "family"),
+    [
+        ("vpp_enrollment_id", VPP_ENROLLMENT_ENDPOINT_FAMILY),
+        ("vpp_enrollment_details", VPP_ENROLLMENT_ENDPOINT_FAMILY),
+        ("vpp_events", VPP_EVENTS_ENDPOINT_FAMILY),
+    ],
+)
+@pytest.mark.parametrize("cached", [False, True])
+async def test_runtime_isolates_authorization_failures_and_recovers(
+    method: str, family: str, cached: bool
+) -> None:
+    coord = _coordinator(events={"data": [_event()]})
     runtime = VppRuntime(coord)
-    coord.client.vpp_enrollment_id.side_effect = Unauthorized()
+    if cached:
+        await runtime.async_refresh()
+    original = runtime.events
+    last_success = runtime.diagnostics()["last_success_utc"]
+    fetcher = getattr(coord.client, method)
+    fetcher.side_effect = Unauthorized("private site or program details")
 
-    with pytest.raises(ConfigEntryAuthFailed):
-        await runtime._async_refresh_enrollment()  # noqa: SLF001
+    await runtime.async_refresh()
 
-    runtime._program_id = PROGRAM_ID  # noqa: SLF001
-    coord.client.vpp_events.side_effect = Unauthorized()
-    with pytest.raises(ConfigEntryAuthFailed):
-        await runtime._async_refresh_events()  # noqa: SLF001
+    failure_family, failure = coord._note_endpoint_family_failure.call_args.args
+    assert failure_family == family
+    assert isinstance(failure, OptionalEndpointUnavailable)
+    assert "private" not in str(failure)
+    assert runtime.events == original
+    assert runtime.available is cached
+    assert runtime.enrollment_state == (
+        "enrolled" if cached or method == "vpp_events" else "unknown"
+    )
+    if method == "vpp_events":
+        assert runtime.diagnostics()["last_success_utc"] == last_success
+        assert runtime.diagnostics()["using_cached_data"] is cached
+    elif not cached:
+        coord.client.vpp_events.assert_not_awaited()
+        if method == "vpp_enrollment_id":
+            coord.client.vpp_enrollment_details.assert_not_awaited()
+    if cached:
+        runtime._events_last_success_mono = time.monotonic() - 3601  # noqa: SLF001
+        assert runtime.available is False
+
+    fetcher.side_effect = None
+    await runtime.async_refresh()
+
+    assert runtime.available is True
+    assert runtime.enrollment_state == "enrolled"
+    assert coord._endpoint_family_state(family).consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "family"),
+    [
+        ("vpp_enrollment_id", VPP_ENROLLMENT_ENDPOINT_FAMILY),
+        ("vpp_enrollment_details", VPP_ENROLLMENT_ENDPOINT_FAMILY),
+        ("vpp_events", VPP_EVENTS_ENDPOINT_FAMILY),
+    ],
+)
+async def test_coordinator_refresh_isolates_vpp_401_with_cooldown(
+    hass, coordinator_factory, monkeypatch, method: str, family: str
+) -> None:
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    from custom_components.enphase_ev.const import DOMAIN
+    from custom_components.enphase_ev.coordinator import RefreshPipelineContext
+    from custom_components.enphase_ev.refresh_plan import (
+        RefreshPlan,
+        RefreshStage,
+        object_method_task,
+    )
+
+    coord = coordinator_factory()
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={}, options={OPT_VPP_EVENTS_ENABLED: True}
+    )
+    entry.add_to_hass(hass)
+    coord.config_entry = entry
+    client = _coordinator().client
+    coord.client.vpp_enrollment_id = client.vpp_enrollment_id
+    coord.client.vpp_enrollment_details = client.vpp_enrollment_details
+    coord.client.vpp_events = client.vpp_events
+    fetcher = getattr(coord.client, method)
+    fetcher.side_effect = Unauthorized("private authorization details")
+    # Exercise the actual post-status pipeline and staged runner with VPP due.
+    plan = RefreshPlan(
+        stages=(
+            RefreshStage(
+                parallel_tasks=(
+                    object_method_task(
+                        "vpp_s", "VPP events", "vpp_runtime", "async_refresh"
+                    ),
+                )
+            ),
+        )
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.coordinator.build_followup_plan",
+        lambda *_args, **_kwargs: plan,
+    )
+    context = RefreshPipelineContext(
+        started_mono=time.monotonic(),
+        refresh_started_utc=datetime.now(UTC),
+        phase_timings={},
+        fallback_data=coord.data,
+        first_refresh=False,
+    )
+
+    coord._record_status_refresh_success(context)  # noqa: SLF001
+    await coord._async_run_post_status_refresh_pipeline(context)  # noqa: SLF001
+
+    health = coord._endpoint_family_state(family)  # noqa: SLF001
+    assert health.consecutive_failures == 1
+    assert health.cooldown_active is True
+    assert health.last_error == (
+        "VPP events unavailable"
+        if method == "vpp_events"
+        else "VPP enrollment unavailable"
+    )
+    assert coord._unauth_errors == 0  # noqa: SLF001
+    assert coord.last_success_utc is not None
+    assert "vpp_s" in context.phase_timings
+    assert coord.vpp_runtime.available is False
+    assert coord.vpp_runtime.refresh_due() is False
+
+    await coord._async_run_post_status_refresh_pipeline(context)  # noqa: SLF001
+    fetcher.assert_awaited_once()
+    assert health.consecutive_failures == 1
+
+    health.next_retry_mono = time.monotonic() - 1
+    fetcher.side_effect = None
+    await coord._async_run_post_status_refresh_pipeline(context)  # noqa: SLF001
+
+    assert fetcher.await_count == 2
+    assert health.consecutive_failures == 0
+    assert health.cooldown_active is False
+    assert health.support_state == "supported"
+    assert coord.vpp_runtime.available is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

A repeated HTTP 401 from optional VPP enrollment or event reads raised `ConfigEntryAuthFailed`, prompting whole-entry reauthentication even when core Enphase endpoints remained authenticated. Treat these failures like existing VPP login-wall failures: record a sanitized endpoint-family failure and apply its cooldown while preserving bounded cached data. Core authentication failures still trigger reauthentication, and the client retains its single stored-credential retry.

Regression coverage exercises enrollment lookup, enrollment details, and event reads; fresh and cached state; cooldown and recovery; and retries using refreshed credentials. Nine regression cases fail against the original implementation with `ConfigEntryAuthFailed` and pass with this fix.

Fixes #855.

## Related Issues

The affected error handling originated in the VPP feature added by #813.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

The pinned Docker integration suite passes all 4,155 tests; the full repository suite passes all 4,312 tests. Targeted coverage is 100% for `vpp_runtime.py` and both modified test files. The focused review run passes 36 API, runtime, entity, and core-authentication tests. Local quality gates include Ruff, Black, full-package mypy, pre-commit, translations, quality-scale checks including remote brands, and strict import-time validation.

Exact validation commands run:

```bash
docker compose -f devtools/docker/docker-compose.yml build ha-dev

docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'ruff check . && black --check custom_components/enphase_ev tests/components/enphase_ev && python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && pytest -q tests/components/enphase_ev/test_service_translations.py'

docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black custom_components/enphase_ev/vpp_runtime.py tests/components/enphase_ev/test_vpp_runtime.py tests/components/enphase_ev/test_vpp_api.py && ruff check . && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/vpp_runtime.py,tests/components/enphase_ev/test_vpp_runtime.py,tests/components/enphase_ev/test_vpp_api.py --fail-under=100'

docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'pytest -q tests/components/enphase_ev/test_vpp_runtime.py tests/components/enphase_ev/test_vpp_api.py tests/components/enphase_ev/test_vpp_entities.py tests/components/enphase_ev/test_coordinator_additional_coverage.py::test_async_update_data_unauthorized_promotes_config_error'

docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'ruff check . && black custom_components/enphase_ev/vpp_runtime.py tests/components/enphase_ev/test_vpp_runtime.py tests/components/enphase_ev/test_vpp_api.py && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && pytest -q tests/components/enphase_ev && pytest'

docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc 'python -m pre_commit run --all-files'

git diff --check
```

The additional read-only Git metadata mount allows pre-commit to resolve the linked worktree inside Docker.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

VPP failures retain the existing identifier-free summaries (`VPP enrollment unavailable` / `VPP events unavailable`) in endpoint-family diagnostics. No new diagnostic fields or user-facing strings are introduced. Validation uses mocked Enphase responses; no live site was modified or queried. A defect-first review of the full patch found no actionable regressions.
