### PR TITLE
Remove detailed operational sections from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,67 +137,6 @@ Manual install steps: see the wiki Installation page.
 
 Sign in with your Enlighten credentials; MFA is supported. See the wiki for details.
 
-## Data updates and recovery
-
-Core telemetry updates independently of optional cloud services. Startup enrichment
-preserves newer charging changes, and changing device options recreates the runtime
-from detached discovery data so known entities can return before optional requests
-finish. Incomplete inverter discovery retains existing devices until a complete
-inventory response is available.
-
-Instantaneous site measurements become unavailable after 15 minutes of a core
-outage. Battery and heat-pump measurements expire after 30 minutes without a
-successful family update, even if other cloud services keep responding. Historical
-energy totals remain available; current-power and VPP data retain their own
-source-specific freshness policies.
-
-Daily heat-pump energy uses the source day's reset time, including its timezone,
-so midnight starts a new statistics cycle while same-day corrections remain valid.
-Invalid nonfinite inverter energy readings retain the last valid measurement.
-Diagnostic timestamps and repeated detail payloads remain visible as live entity
-attributes but are excluded from recorder history where they duplicate telemetry.
-
-## Action targets
-
-Charging, battery schedule, grid-profile, refresh, and authentication actions
-accept the entity targets offered in Developer Tools → Actions. Site actions
-resolve the selected Enphase entity to its site; charging actions resolve it to
-its charger. Device, area, floor, and label targets are also supported for these
-actions. Charging actions ignore unrelated devices selected through an area, floor,
-or label, but reject explicitly selected invalid devices. Actions operating on a
-single site reject selections spanning multiple sites.
-Existing explicit `device_id`, `site_id`, and `config_entry_id` fields remain
-supported where offered by the action.
-
-Actions remain registered while the integration is unloaded or retrying setup,
-so Home Assistant can still validate automations. Calling an action requires its
-target config entry to be loaded; unavailable targets return a validation error.
-
-```yaml
-action: enphase_ev.validate_schedule
-target:
-  entity_id: switch.my_discharge_to_grid_schedule
-data:
-  schedule_type: dtg
-```
-
-## Live-stream actions
-
-`enphase_ev.start_live_stream` and `enphase_ev.stop_live_stream` are
-administrator-only, site-scoped actions for IQ EV Charger live updates. Select an
-Enphase entity, device, area, floor, or label belonging to the intended site, or
-enter the numeric Enphase site ID under Advanced options. A selected entity only
-identifies its owning site; it does not limit updates to that entity.
-
-When writing YAML manually, `device_id` means the Home Assistant device-registry
-ID. Use `site_id` for the numeric identifier shown by Enphase.
-
-```yaml
-action: enphase_ev.start_live_stream
-target:
-  entity_id: sensor.iq_battery_battery_available_power
-```
-
 ## Documentation
 
 Refer to the [Wiki](https://github.com/barneyonline/ha-enphase-energy/wiki) for setup,


### PR DESCRIPTION
## Summary

Remove the README sections covering data updates and recovery, action targets, and live-stream actions, including their YAML examples. This keeps the README concise and retains the link to the wiki for detailed guidance.

## Related Issues

None.

## Type of change

- [x] Documentation

## Testing

Validation uses the pinned Docker environment:

```bash
docker compose -f devtools/docker/docker-compose.yml build ha-dev
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'set -e
ruff check .
black --check custom_components/enphase_ev tests/components/enphase_ev
python -m pre_commit run --all-files
python scripts/validate_quality_scale.py
python scripts/validate_quality_scale.py --validate-remote-brands
python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log
mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev
pytest -q tests/components/enphase_ev
pytest'
git diff --check
```

## Checklist

- [x] Documentation updated.
- [x] Scoped to one logical change.
- Changelog, translations, and targeted Python coverage are not applicable: only README prose and examples were removed.

## Diagnostics / Screenshots / Notes

No runtime behavior changes.

Results: all validation gates passed; integration suite: 4,155 passed; full repository suite: 4,312 passed.
