### PR TITLE
Fix VPP authentication retries and event reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,16 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Preserve VPP HTTP status and Retry-After delays without exposing private request
+  details, and clear cached events when the enrolled program changes.
+- Keep bounded VPP event data during wholly malformed responses instead of
+  reporting a successful empty schedule.
+- Publish VPP calendar transitions, next-event changes, and one-hour cache expiry
+  even when cloud polling stops or unchanged responses suppress notifications.
+- Prevented optional VPP authorization failures from triggering stored-credential
+  logins on every poll, avoiding unnecessary authentication traffic. (#859)
+- Record authentication-block failures immediately so Cloud Error Code reports
+  `auth_blocked` on the refresh that activates the block. (#859)
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/api_client/vpp_surface.py
+++ b/custom_components/enphase_ev/api_client/vpp_surface.py
@@ -28,6 +28,8 @@ async def enrollment_id(client: VppClient, *, gs_base_url: str) -> object:
         "GET",
         url,
         headers=client._vpp_headers,
+        # Grid Services may reject sites without VPP entitlement; login cannot fix it.
+        allow_reauth=False,
         log_invalid_payload=False,
         use_cookie_header_only=True,
     )
@@ -49,6 +51,8 @@ async def enrollment_details(
         "GET",
         url,
         headers=client._vpp_headers,
+        # Grid Services may reject sites without VPP entitlement; login cannot fix it.
+        allow_reauth=False,
         log_invalid_payload=False,
         redaction_identifiers=(validated,),
         use_cookie_header_only=True,
@@ -78,6 +82,8 @@ async def events(client: VppClient, program_id: str, *, gs_base_url: str) -> obj
         "GET",
         url,
         headers=client._vpp_headers,
+        # Grid Services may reject sites without VPP entitlement; login cannot fix it.
+        allow_reauth=False,
         log_invalid_payload=False,
         redaction_identifiers=(validated,),
         use_cookie_header_only=True,

--- a/custom_components/enphase_ev/calendar.py
+++ b/custom_components/enphase_ev/calendar.py
@@ -28,6 +28,7 @@ from .system_events import (
     SystemEventHistoryEntry,
 )
 from .vpp_runtime import VppEvent
+from .vpp_entity import VppCoordinatorEntity
 
 PARALLEL_UPDATES = 0
 
@@ -125,7 +126,7 @@ async def async_setup_entry(
 
 
 class VppEventsCalendarEntity(
-    CoordinatorEntity,  # type: ignore[misc]
+    VppCoordinatorEntity,
     CalendarEntity,  # type: ignore[misc]
 ):
     """Expose Enphase VPP/ELRP events as a read-only calendar."""

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -4136,16 +4136,6 @@ class EnphaseCoordinator(
         first_refresh = context.first_refresh
 
         if self._auth_block_active():
-            self._last_error = "auth_blocked"
-            self.last_failure_utc = dt_util.utcnow()
-            self.last_failure_status = None
-            self.last_failure_description = self._blocked_auth_failure_message()
-            self.last_failure_response = self.last_failure_description
-            self.last_failure_source = "auth"
-            self.last_failure_endpoint = None
-            self._network_errors = 0
-            self._http_errors = 0
-            self._payload_errors = 0
             self.diagnostics.create_auth_block_issue()
             raise self._auth_block_update_failed()
 
@@ -6195,6 +6185,18 @@ class EnphaseCoordinator(
 
     def _auth_block_update_failed(self) -> UpdateFailed:
         """Return a recoverable update failure while Enphase auth is blocked."""
+
+        self._last_error = "auth_blocked"
+        self.last_failure_utc = dt_util.utcnow()
+        self.last_failure_status = None
+        self.last_failure_description = self._blocked_auth_failure_message()
+        self.last_failure_response = self.last_failure_description
+        self.last_failure_source = "auth"
+        self.last_failure_endpoint = None
+        self._network_errors = 0
+        self._http_errors = 0
+        self._payload_errors = 0
+        self.payload_failure_kind = None
 
         return UpdateFailed(
             self._blocked_auth_failure_message(),

--- a/custom_components/enphase_ev/sensor_vpp.py
+++ b/custom_components/enphase_ev/sensor_vpp.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .vpp_entity import VppCoordinatorEntity
 from .const import DOMAIN
 from .coordinator import EnphaseCoordinator
 from .device_info_helpers import _cloud_device_info
@@ -21,7 +21,7 @@ VPP_SENSOR_KEYS: tuple[str, ...] = (
 )
 
 
-class _VppNextEventSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
+class _VppNextEventSensor(VppCoordinatorEntity, SensorEntity):  # type: ignore[misc]
     """Base sensor reading the next actionable VPP event."""
 
     _attr_has_entity_name = True

--- a/custom_components/enphase_ev/vpp_entity.py
+++ b/custom_components/enphase_ev/vpp_entity.py
@@ -1,0 +1,60 @@
+"""Publish VPP event boundaries and freshness expiry without cloud polling."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+from typing import TypeVar, cast
+
+from homeassistant.core import callback as ha_callback
+from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .coordinator import EnphaseCoordinator
+
+_CallbackT = TypeVar("_CallbackT", bound=Callable[..., object])
+callback = cast(Callable[[_CallbackT], _CallbackT], ha_callback)
+
+
+class VppCoordinatorEntity(CoordinatorEntity[EnphaseCoordinator]):  # type: ignore[misc]
+    """Keep time-dependent VPP state current between coordinator updates."""
+
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
+        super().__init__(coordinator)
+        self._cancel_vpp_transition: Callable[[], None] | None = None
+
+    @callback
+    def _schedule_vpp_transition(self) -> None:
+        if self._cancel_vpp_transition is not None:
+            self._cancel_vpp_transition()
+            self._cancel_vpp_transition = None
+        deadline = self.coordinator.vpp_runtime.next_transition_utc()
+        if deadline is None:
+            return
+
+        @callback
+        def transition(_now: datetime) -> None:
+            self._cancel_vpp_transition = None
+            # An unchanged successful response can extend freshness without
+            # notifying listeners. Re-evaluate the deadline before publishing.
+            self._schedule_vpp_transition()
+            self.async_write_ha_state()
+
+        self._cancel_vpp_transition = async_track_point_in_utc_time(
+            self.hass, transition, deadline
+        )
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._schedule_vpp_transition()
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._cancel_vpp_transition is not None:
+            self._cancel_vpp_transition()
+            self._cancel_vpp_transition = None
+        await super().async_will_remove_from_hass()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._schedule_vpp_transition()
+        super()._handle_coordinator_update()

--- a/custom_components/enphase_ev/vpp_runtime.py
+++ b/custom_components/enphase_ev/vpp_runtime.py
@@ -7,10 +7,12 @@ import time
 from collections import Counter
 from collections.abc import Mapping
 from dataclasses import dataclass
-from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, cast
 
 import aiohttp
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
 from homeassistant.util import dt as dt_util
 
 from .api import (
@@ -154,6 +156,9 @@ def parse_vpp_events(payload: object) -> tuple[tuple[VppEvent, ...], bool] | Non
                 or _normalized(status) in {"superseded", "superceded"}
             ),
         )
+    if rows and not parsed:
+        return None
+
     all_events = sorted(
         parsed.values(), key=lambda item: (item.start, item.end, item.fingerprint)
     )
@@ -182,6 +187,26 @@ def parse_vpp_events(payload: object) -> tuple[tuple[VppEvent, ...], bool] | Non
             key=lambda item: (item.start, item.end, item.fingerprint),
         )
     return tuple(all_events), truncated
+
+
+class VppHttpUnavailable(aiohttp.ClientResponseError, OptionalEndpointUnavailable):  # type: ignore[misc]
+    """Sanitized HTTP failure that always retains optional-family cooldowns."""
+
+    def __init__(self, summary: str, status: int, retry_after: str | None) -> None:
+        url = URL("https://gs.enphaseenergy.com/")
+        headers = CIMultiDict[str]()
+        if retry_after:
+            headers["Retry-After"] = retry_after
+        aiohttp.ClientResponseError.__init__(
+            self,
+            request_info=aiohttp.RequestInfo(
+                url, "GET", CIMultiDictProxy(CIMultiDict()), url
+            ),
+            history=(),
+            status=status,
+            message=summary,
+            headers=CIMultiDictProxy(headers),
+        )
 
 
 class VppRuntime:
@@ -223,8 +248,25 @@ class VppRuntime:
         last_success = self._events_last_success_mono
         return bool(
             isinstance(last_success, (int, float))
-            and time.monotonic() - float(last_success) <= VPP_EVENT_STALE_AFTER_S
+            and time.monotonic() - float(last_success) < VPP_EVENT_STALE_AFTER_S
         )
+
+    def next_transition_utc(self) -> datetime | None:
+        """Return the next event boundary or monotonic cache-expiry deadline."""
+
+        if not self.available:
+            return None
+        now = cast(datetime, dt_util.utcnow())
+        assert self._events_last_success_mono is not None
+        remaining = max(
+            0.0,
+            self._events_last_success_mono + VPP_EVENT_STALE_AFTER_S - time.monotonic(),
+        )
+        deadline = now + timedelta(seconds=remaining)
+        event = self.next_actionable(now)
+        if event is not None:
+            deadline = min(deadline, event.start if event.start > now else event.end)
+        return deadline
 
     @property
     def events(self) -> tuple[VppEvent, ...]:
@@ -292,10 +334,16 @@ class VppRuntime:
         )
 
     @staticmethod
-    def _safe_failure(summary: str, err: Exception) -> OptionalEndpointUnavailable:
-        status = err.status if isinstance(err, aiohttp.ClientResponseError) else None
-        suffix = f" (status {status})" if isinstance(status, int) else ""
-        return OptionalEndpointUnavailable(f"{summary}{suffix}")
+    def _safe_failure(summary: str, err: Exception) -> Exception:
+        """Preserve HTTP backoff metadata without retaining private request data."""
+
+        if isinstance(err, aiohttp.ClientResponseError):
+            return VppHttpUnavailable(
+                summary,
+                err.status,
+                err.headers.get("Retry-After") if err.headers else None,
+            )
+        return OptionalEndpointUnavailable(summary)
 
     async def _async_refresh_enrollment(self) -> None:
         force_lookup = self._force_enrollment_lookup
@@ -347,7 +395,7 @@ class VppRuntime:
                 raise OptionalEndpointUnavailable("Ambiguous VPP program response")
         except Unauthorized as err:
             # Grid Services authorization does not establish account-wide expiry.
-            # The client owns the bounded stored-credential retry, when available.
+            # VPP requests do not trigger stored-credential refresh.
             self.coordinator._note_endpoint_family_failure(
                 VPP_ENROLLMENT_ENDPOINT_FAMILY,
                 self._safe_failure("VPP enrollment unavailable", err),
@@ -364,6 +412,11 @@ class VppRuntime:
                 safe,
             )
             return
+        if program_id != self._program_id:
+            self._events = ()
+            self._truncated = False
+            self._events_last_success_mono = None
+            self._events_last_success_utc = None
         self._enrollment_state = "enrolled"
         self._program_id = program_id
         self._program_last_confirmed_mono = time.monotonic()

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -3658,22 +3658,28 @@ hexadecimal object IDs.
 Requests use the raw control token as `Authorization: <control token>` (with no
 `Bearer` prefix) together with the Enlighten origin and referer. Enlighten
 cookies, XSRF, `X-Requested-With`, and `e-auth-token` headers are intentionally
-omitted across the host boundary. Auth headers are rebuilt for retries after
-successful reauthentication.
+omitted across the host boundary. Each request uses current credentials; VPP
+authorization failures do not trigger stored-credential login.
 
 Event normalization retains only a hashed fingerprint, aware UTC start/end,
 type, subtype, status, and cancellation/superseded state. Rows with invalid
-timestamps or `end <= start` are discarded, duplicates are collapsed, unknown
+timestamps or `end <= start` are discarded; a nonempty response with no valid
+rows is treated as a failure and preserves bounded cached data. Duplicates are
+collapsed, unknown
 string values are preserved, and the sorted cache is capped at 500 records.
 A valid empty enrollment response means unenrolled; a valid empty events list
 means enrolled with no events. Malformed/ambiguous responses and 403/404 failures
-remain isolated from core setup. Authentication failures follow the integration's
-normal reauthentication path.
+remain isolated from core setup. VPP authorization failures enter only their
+endpoint-family cooldown; HTTP status and Retry-After delays are preserved in
+sanitized errors. Core authentication retains its normal reauthentication path.
 
 Enrollment lookup uses a six-hour refresh interval and a seven-day cached-program
 lifetime. Events refresh every five minutes and retain the last successful data
 for up to one hour after transient failures. An invalid-program events response
 clears the cached program so the next cycle repeats the authoritative lookup.
+A changed program invalidates previously cached events. Entity timers publish
+calendar and next-event transitions and one-hour cache expiry even when polling
+is paused.
 
 ### 2.11 Battery Backup History
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,10 +170,17 @@ Runtime managers keep endpoint-family behavior out of the main coordinator:
   reuse a confirmed program for seven days; event data is refreshed every five
   minutes. Its immutable snapshot participates in aggregate snapshot equality so
   VPP-only changes notify entity listeners.
-  VPP enrollment and event authorization failures, including repeated HTTP 401s
-  after the client's stored-credential retry, enter only that endpoint family's
+  VPP enrollment and event authorization failures, including repeated HTTP 401s,
+  never trigger stored-credential login and enter only that endpoint family's
   cooldown. They preserve bounded cached data and do not independently trigger
   config-entry reauthentication; core authentication failures still can.
+  Sanitized HTTP failures retain their status and Retry-After delay. Program
+  changes invalidate event data from the previous program while respecting active
+  event-family cooldowns. Nonempty event lists with no valid rows are failures;
+  valid empty lists clear the event cache.
+  `vpp_entity.py` schedules event boundaries and cache expiry for the calendar and
+  next-event sensors independently of polling. Timers recheck freshness after
+  unchanged successful responses and are cancelled when entities are removed.
 
 These managers should own cache lifetimes, stale data decisions, and endpoint-specific parsing for their family. The coordinator should expose their normalized state through properties and helper methods.
 

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -2157,6 +2157,11 @@ async def test_async_update_data_login_wall_during_refresh_cooldown_blocks(
         lambda *_args, **_kwargs: (lambda: None),
     )
     coord = EnphaseCoordinator(hass, entry.data, config_entry=entry)
+    from custom_components.enphase_ev.sensor import EnphaseSiteLastErrorCodeSensor
+
+    coord.last_success_utc = datetime.now(timezone.utc) - timedelta(seconds=5)
+    coord.last_failure_utc = None
+    coord.payload_failure_kind = "json_decode"
     coord._auth_refresh_rejected_until = time.monotonic() + 60
     coord._auth_refresh_rejected_ends_utc = datetime.now(timezone.utc) + timedelta(
         seconds=60
@@ -2177,6 +2182,13 @@ async def test_async_update_data_login_wall_during_refresh_cooldown_blocks(
     assert coord._auth_block_reason == "login_wall_after_refresh_reject"
     assert coord._auth_blocked_until_utc is not None
     assert 86390 <= exc_info.value.retry_after <= 86400
+
+    assert coord.last_failure_utc > coord.last_success_utc
+    assert coord.last_failure_source == "auth"
+    assert coord.last_failure_status is None
+    assert coord.last_failure_description == coord._blocked_auth_failure_message()
+    assert coord.payload_failure_kind is None
+    assert EnphaseSiteLastErrorCodeSensor(coord).native_value == "auth_blocked"
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_vpp_api.py
+++ b/tests/components/enphase_ev/test_vpp_api.py
@@ -90,6 +90,7 @@ async def test_vpp_api_uses_observed_paths_queries_and_callable_headers() -> Non
         "sort_by=&ascending=&time="
     )
     assert calls[2].kwargs["redaction_identifiers"] == (PROGRAM_ID,)
+    assert all(call.kwargs["allow_reauth"] is False for call in calls)
     assert all(call.kwargs["log_invalid_payload"] is False for call in calls)
     assert all(call.kwargs["use_cookie_header_only"] is True for call in calls)
 
@@ -134,7 +135,7 @@ async def test_vpp_api_uses_stateless_session_even_when_shared_jar_has_cookies()
         ("vpp_events", (PROGRAM_ID,)),
     ],
 )
-async def test_vpp_401_retries_once_with_refreshed_credentials(
+async def test_vpp_401_never_refreshes_stored_credentials(
     method: str, args: tuple[str, ...]
 ) -> None:
     response = _Response()
@@ -151,22 +152,20 @@ async def test_vpp_401_retries_once_with_refreshed_credentials(
         cookie_header_session=session,  # type: ignore[arg-type]
     )
 
-    async def refresh() -> bool:
-        client.update_credentials(eauth="NEW", cookie="session=refreshed")
-        return True
-
-    reauth = AsyncMock(side_effect=refresh)
+    reauth = AsyncMock(return_value=True)
     client.set_reauth_callback(reauth)
 
-    with pytest.raises(api.Unauthorized):
-        await getattr(client, method)(*args)
+    # Repeated polls must not turn an entitlement failure into a login loop.
+    for _ in range(3):
+        with pytest.raises(api.Unauthorized):
+            await getattr(client, method)(*args)
 
-    reauth.assert_awaited_once_with()
-    assert session.request.call_count == 2
-    assert [
-        call.kwargs["headers"]["Authorization"]
+    reauth.assert_not_awaited()
+    assert session.request.call_count == 3
+    assert all(
+        call.kwargs["headers"]["Authorization"] == "OLD"
         for call in session.request.call_args_list
-    ] == ["OLD", "NEW"]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_vpp_entities.py
+++ b/tests/components/enphase_ev/test_vpp_entities.py
@@ -244,3 +244,94 @@ async def test_disabled_vpp_removes_registered_calendar(
     )
 
     assert registry.async_get(registered.entity_id) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["sensor", "calendar"])
+async def test_vpp_deadlines_publish_state_without_polling(
+    hass, coordinator_factory, config_entry, monkeypatch, kind
+):
+    from pytest_homeassistant_custom_component.common import async_fire_time_changed
+    from custom_components.enphase_ev import vpp_runtime as runtime_module
+
+    now = [dt_util.utcnow()]
+    mono = [1000.0]
+    monkeypatch.setattr(dt_util, "utcnow", lambda: now[0])
+    monkeypatch.setattr(dt_util, "now", lambda *args: now[0])
+    monkeypatch.setattr(
+        runtime_module, "time", SimpleNamespace(monotonic=lambda: mono[0])
+    )
+    coord = coordinator_factory()
+    coord.update_interval = None
+    event = VppEvent(
+        "first",
+        now[0] + timedelta(seconds=10),
+        now[0] + timedelta(seconds=20),
+        "charge",
+        "first",
+        "scheduled",
+    )
+    second = VppEvent(
+        "second",
+        now[0] + timedelta(seconds=30),
+        now[0] + timedelta(seconds=40),
+        "discharge",
+        "second",
+        "pending",
+    )
+    _enable_with_events(coord, (event, second))
+    runtime = coord.vpp_runtime
+    runtime._events_last_success_mono = mono[0]
+    entity = (
+        EnphaseVppNextEventStatusSensor(coord)
+        if kind == "sensor"
+        else VppEventsCalendarEntity(coord)
+    )
+    entity.hass = hass
+    entity.entity_id = f"{kind}.vpp_deadline"
+    import logging
+    from homeassistant.helpers.entity_component import EntityComponent
+
+    component = EntityComponent(logging.getLogger(__name__), kind, hass)
+    component._platforms[kind].config_entry = config_entry
+    await component.async_add_entities([entity])
+    await hass.async_block_till_done()
+
+    async def advance(seconds):
+        now[0] += timedelta(seconds=seconds)
+        mono[0] += seconds
+        async_fire_time_changed(hass, now[0])
+        await hass.async_block_till_done()
+
+    await advance(11)
+    assert hass.states.get(entity.entity_id).state == (
+        "scheduled" if kind == "sensor" else "on"
+    )
+    await advance(10)
+    assert hass.states.get(entity.entity_id).state == (
+        "pending" if kind == "sensor" else "off"
+    )
+    await advance(10)
+    assert hass.states.get(entity.entity_id).state == (
+        "pending" if kind == "sensor" else "on"
+    )
+    await advance(10)
+    assert hass.states.get(entity.entity_id).state == (
+        "unknown" if kind == "sensor" else "off"
+    )
+    # An identical successful response refreshes the source without notifying entities.
+    runtime._events_last_success_mono = mono[0]
+    await advance(3560)
+    assert hass.states.get(entity.entity_id).state != "unavailable"
+    assert entity._cancel_vpp_transition is not None
+    await advance(41)
+    assert hass.states.get(entity.entity_id).state == "unavailable"
+    assert entity._cancel_vpp_transition is None
+    # Recovery restarts the timer; removal cancels it.
+    runtime._events_last_success_mono = mono[0]
+    entity._handle_coordinator_update()
+    assert hass.states.get(entity.entity_id).state != "unavailable"
+    entity._handle_coordinator_update()
+    await component.async_remove_entity(entity.entity_id)
+    assert entity._cancel_vpp_transition is None
+    await entity.async_will_remove_from_hass()

--- a/tests/components/enphase_ev/test_vpp_runtime.py
+++ b/tests/components/enphase_ev/test_vpp_runtime.py
@@ -328,7 +328,8 @@ async def test_runtime_retains_stale_events_and_reresolves_invalid_program() -> 
     assert runtime._program_id is None  # noqa: SLF001
     assert runtime.refresh_due() is True
     failure = coord._note_endpoint_family_failure.call_args.args[1]
-    assert isinstance(failure, OptionalEndpointUnavailable)
+    assert isinstance(failure, aiohttp.ClientResponseError)
+    assert failure.status == 404
     assert "private" not in str(failure)
 
     coord._endpoint_family_should_run.return_value = False
@@ -550,3 +551,100 @@ async def test_runtime_isolates_optional_grid_services_login_walls() -> None:
     ]
     assert all(isinstance(failure, OptionalEndpointUnavailable) for failure in failures)
     assert all("/login" not in str(failure) for failure in failures)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("method", ["vpp_enrollment_id", "vpp_events"])
+@pytest.mark.parametrize("retry_after", [None, "7200"])
+async def test_http_failures_preserve_sanitized_backoff(
+    coordinator_factory, method, retry_after
+):
+    coord = _coordinator(events={"data": [_event()]})
+    runtime = VppRuntime(coord)
+    await runtime.async_refresh()
+    real_coord = coordinator_factory()
+    coord._note_endpoint_family_failure = real_coord._note_endpoint_family_failure
+    headers = {"Set-Cookie": "private"}
+    if retry_after is not None:
+        headers["Retry-After"] = retry_after
+    getattr(coord.client, method).side_effect = aiohttp.ClientResponseError(
+        request_info=SimpleNamespace(real_url="https://gs.invalid/private"),
+        history=(),
+        status=429,
+        message="private",
+        headers=headers,
+    )
+    await runtime.async_refresh()
+    family = (
+        VPP_EVENTS_ENDPOINT_FAMILY
+        if method == "vpp_events"
+        else VPP_ENROLLMENT_ENDPOINT_FAMILY
+    )
+    health = real_coord._endpoint_family_state(family)
+    assert health.last_status == 429
+    assert "private" not in health.last_error
+    assert health.next_retry_mono - time.monotonic() >= (7190 if retry_after else 290)
+    error = runtime._safe_failure(
+        "Unavailable", getattr(coord.client, method).side_effect
+    )
+    assert "Set-Cookie" not in error.headers
+    assert "private" not in str(error.request_info.real_url)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("events_due", [True, False])
+async def test_program_change_cannot_publish_previous_program_events(events_due):
+    coord = _coordinator(events={"data": [_event()]})
+    runtime = VppRuntime(coord)
+    await runtime.async_refresh()
+    coord.client.vpp_enrollment_details.return_value = {
+        "data": {"program_id": "c" * 24}
+    }
+    coord._endpoint_family_should_run.side_effect = (
+        lambda family: family == VPP_ENROLLMENT_ENDPOINT_FAMILY or events_due
+    )
+    coord.client.vpp_events.side_effect = RuntimeError("offline")
+    await runtime.async_refresh()
+    assert runtime._program_id == "c" * 24
+    assert runtime.events == ()
+    assert runtime.available is False
+    assert runtime.next_actionable() is None
+    assert runtime._events_last_success_utc is None
+    coord._endpoint_family_should_run.side_effect = None
+    coord.client.vpp_events.side_effect = None
+    await runtime.async_refresh()
+    assert runtime.available is True
+    coord.client.vpp_events.assert_awaited_with("c" * 24)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "rows",
+    [
+        [None],
+        [{"start_time": "invalid"}],
+        [{"start_time": "2026-09-10T01:00:00Z", "end_time": "2026-09-10T00:00:00Z"}],
+    ],
+)
+async def test_all_invalid_rows_preserve_cached_events_and_freshness(rows):
+    coord = _coordinator(events={"data": [_event()]})
+    runtime = VppRuntime(coord)
+    await runtime.async_refresh()
+    original = runtime.events
+    last_success = runtime._events_last_success_mono
+    coord.client.vpp_events.return_value = {"data": rows}
+    await runtime.async_refresh()
+    assert runtime.events == original
+    assert runtime._events_last_success_mono == last_success
+    assert (
+        coord._endpoint_family_state(VPP_EVENTS_ENDPOINT_FAMILY).consecutive_failures
+        == 1
+    )
+    coord.client.vpp_events.return_value = {"data": []}
+    await runtime.async_refresh()
+    assert runtime.events == ()
+    assert runtime.available is True
+    assert (
+        coord._endpoint_family_state(VPP_EVENTS_ENDPOINT_FAMILY).consecutive_failures
+        == 0
+    )


### PR DESCRIPTION
## Summary

Fixes #859.

VPP authorization failures were still triggering stored-credential logins inside the API client before the optional runtime isolated the error. Disable password refresh for all three VPP requests and record authentication-block failures immediately so Cloud Error Code reports `auth_blocked` on the triggering refresh.

Also preserve sanitized HTTP status and Retry-After delays, invalidate events when the enrolled program changes, retain bounded cached events when every response row is malformed, and publish calendar/event transitions and cache expiry independently of cloud polling. Entity timers handle unchanged successful responses and cancel on removal.

## Related Issues

Follow-up to #855 and #856.

## Type of change

- [x] Bugfix
- [x] Documentation

## Testing

All checks passed in the pinned Docker environment after synchronizing with `origin/main`: 4,323 repository tests and 4,166 integration tests. All six touched runtime modules have 100% targeted coverage. Regression tests cover repeated VPP 401s, immediate auth-block sensor state, sanitized rate-limit backoff, program changes, malformed event lists, and real Home Assistant entity publication across event deadlines, freshness extension, recovery, and removal.

Exact validation commands:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev && ruff check . && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api_client/vpp_surface.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/vpp_runtime.py,custom_components/enphase_ev/vpp_entity.py,custom_components/enphase_ev/sensor_vpp.py,custom_components/enphase_ev/calendar.py --fail-under=100 && pytest -q tests/components/enphase_ev && pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc "pre-commit run --all-files"
git diff --check
```

The read-only Git metadata mount allows pre-commit to inspect this linked worktree.

## Checklist

- [x] Updated `CHANGELOG.md` for user-facing changes.
- [x] Updated architecture and API documentation.
- [x] No translation changes; translation tests pass in the integration suite.
- [x] Confirmed 100% targeted coverage for every touched runtime module.
- [ ] Reviewed GitHub Actions results (pending CI).
- [x] Scoped to VPP reliability and the associated authentication-block diagnostic fix.

## Diagnostics / Screenshots / Notes

HTTP failures preserve only the public Grid Services root, a generic message, status, and Retry-After header; private URLs, response messages, cookies, and history are discarded. Auth blocks now record the failure timestamp and source immediately and clear stale payload-error classification. No live account requests or deployed Home Assistant changes were used for validation.
