### PR TITLE
Preserve Git history for CI change detection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,9 @@ jobs:
             exit 0
           fi
 
-          git fetch origin "${{ github.base_ref }}" --depth=1
+          # Preserve history for the merge-base diff if the base branch advances
+          # after checkout (including when an older workflow run is retried).
+          git fetch origin "${{ github.base_ref }}"
           # Disable rename detection so cross-group moves expose both the deleted
           # source path and the added destination path to the classifiers below.
           changed_files="$(git diff --name-only --no-renames "origin/${{ github.base_ref }}...HEAD")"

--- a/tests/scripts/test_ci_workflow.py
+++ b/tests/scripts/test_ci_workflow.py
@@ -49,6 +49,70 @@ def test_path_classification_exposes_both_sides_of_renames() -> None:
     assert "git diff --name-only --no-renames" in classify_step["run"]
 
 
+def test_path_classification_when_base_advances_after_checkout(tmp_path):
+    """Keep the merge base when main advances after the PR checkout was made."""
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Workflow Test",
+        "GIT_AUTHOR_EMAIL": "workflow@example.test",
+        "GIT_COMMITTER_NAME": "Workflow Test",
+        "GIT_COMMITTER_EMAIL": "workflow@example.test",
+    }
+
+    def git(cwd, *args):
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    git(origin, "init", "--initial-branch=main")
+    git(origin, "commit", "--allow-empty", "-m", "Initial main")
+    checkout = tmp_path / "checkout"
+    git(tmp_path, "clone", origin.as_uri(), str(checkout))
+    git(checkout, "switch", "-c", "feature")
+    source = checkout / "custom_components/enphase_ev/example.py"
+    source.parent.mkdir(parents=True)
+    source.write_text("# Integration change\n")
+    git(checkout, "add", ".")
+    git(checkout, "commit", "-m", "Change integration")
+    git(checkout, "switch", "main")
+    git(checkout, "merge", "--no-ff", "feature", "-m", "PR merge")
+    git(origin, "commit", "--allow-empty", "-m", "Advance main")
+
+    step = next(
+        step
+        for step in _jobs()["changes"]["steps"]
+        if step.get("name") == "Classify changed paths"
+    )
+    script = step["run"].replace("${{ github.event_name }}", "pull_request")
+    script = script.replace("${{ github.base_ref }}", "main")
+    output = tmp_path / "outputs"
+    result = subprocess.run(
+        ["bash", "-e", "-o", "pipefail", "-c", script],
+        cwd=checkout,
+        env={**env, "GITHUB_OUTPUT": str(output)},
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert set(output.read_text().splitlines()) == {
+        "integration=true",
+        "compatibility=true",
+        "diagnostics=true",
+        "quality=true",
+        "scripts=false",
+    }
+    assert (
+        git(checkout, "rev-parse", "--is-shallow-repository").stdout.strip() == "false"
+    )
+
+
 def test_pytest_reuses_one_coverage_run_and_loads_only_required_plugins() -> None:
     pytest_job = _jobs()["pytest"]
     steps = pytest_job["steps"]


### PR DESCRIPTION
## Summary

The Tests workflow can fail with `fatal: origin/main...HEAD: no merge base` when the base branch advances after the PR checkout. Its depth-one fetch creates a shallow history boundary despite the initial full checkout.

Remove the depth limit from the change-classification fetch so the three-dot diff retains its merge base. Add a regression that executes the actual classifier against local Git repositories after advancing the base branch and checks every classification output.

## Related Issues

- Resolves the workflow failure observed on #861. The authentication-counter changes in that PR are separate.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

The new regression reproduced the original exit-code-128 failure before the workflow edit and passed afterward. All 4,324 repository tests passed, including all 20 workflow tests. Black, Ruff, strict mypy, pre-commit, import-time validation, and both quality-scale checks passed in the pinned Docker environment.

Exact successful validation commands:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black tests/scripts/test_ci_workflow.py && ruff check . && pytest -q tests/scripts/test_ci_workflow.py && python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && pytest -q'
docker compose -f devtools/docker/docker-compose.yml run --rm -e BLACK_NUM_WORKERS=2 -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc 'pre-commit run --all-files'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'COVERAGE_FILE=/tmp/workflow.coverage python -m coverage run --rcfile=/dev/null --include="*/tests/scripts/test_ci_workflow.py" -m pytest -q tests/scripts/test_ci_workflow.py && COVERAGE_FILE=/tmp/workflow.coverage python -m coverage report --rcfile=/dev/null -m'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black --check tests/scripts/test_ci_workflow.py && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev'
git diff --check
```

The read-only Git metadata mount lets pre-commit inspect this linked worktree inside Docker. All new test statements are covered; the test module has 99% coverage because its existing non-dictionary-job guard at line 136 is not exercised. No integration Python modules changed.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes. (Not applicable: CI-only change.)
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed. (Not applicable.)
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (Unchanged; existing translation tests passed in the full suite.)
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage. (All new statements covered; existing test-module gap noted above.)
- [x] I reviewed GitHub Actions results. All reported checks passed, including change classification, pytest, minimum Home Assistant, script tests, diagnostics, quality scale, pre-commit, HACS validation, and CodeQL. Hassfest was not triggered for this CI-only change.
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Read-only review of the change found no actionable defects. The fix preserves the existing full-history checkout and rename classification behavior.
