### PR TITLE
Fix login-wall race with shared credential refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
   telemetry freshness, and the existing polling schedule.
 
 ### 🐛 Bug fixes
+- Retry JSON login-wall responses through the shared credential refresh so a
+  concurrent successful token rollover does not create a false reauthentication
+  repair. (#863)
 - Preserve VPP HTTP status and Retry-After delays without exposing private request
   details, and clear cached events when the enrolled program changes.
 - Keep bounded VPP event data during wholly malformed responses instead of

--- a/custom_components/enphase_ev/api_client/request_surface.py
+++ b/custom_components/enphase_ev/api_client/request_surface.py
@@ -385,6 +385,28 @@ async def _json(
                                 payload=body_text,
                             ):
                                 self._last_unauthorized_request = safe_request_label
+                                if (
+                                    allow_reauth
+                                    and not self._is_hems_api_endpoint(endpoint or None)
+                                    and self._reauth_cb
+                                    and attempt == 0
+                                ):
+                                    # Join the same shared refresh as concurrent 401s
+                                    # before exposing a whole-entry auth failure.
+                                    from homeassistant.exceptions import (
+                                        ConfigEntryAuthFailed,
+                                    )
+
+                                    attempt += 1
+                                    try:
+                                        with _enlighten_reauth_read_scope():
+                                            reauth_ok = await self._reauth_cb()
+                                    except ConfigEntryAuthFailed:
+                                        # Preserve login-wall-specific token variants
+                                        # and rejected-refresh cooldown handling.
+                                        reauth_ok = False
+                                    if reauth_ok:
+                                        continue
                                 raise self._login_wall_unauthorized(
                                     endpoint=endpoint or None,
                                     request_label=safe_request_label,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -91,7 +91,12 @@ The coordinator distinguishes core failures from optional endpoint failures:
 - Optional endpoint failures mark that family stale, preserve recent useful data where safe, and report repairs when needed.
 
 Authentication refresh uses its own lock and one shared, cancellation-shielded
-login task, so a 401 during a poll cannot reacquire the poll lock. Each retry
+login task, so a 401 during a poll cannot reacquire the poll lock. JSON login-wall
+responses use the same shared refresh, including reuse of a recent success, and
+retry once before surfacing an authentication failure. Both paths preserve
+endpoint policies that disable stored-credential refresh. Failed login-wall
+refreshes retain the typed login-wall error so BatteryConfig can try alternate
+credentials and the refresh runner can apply rejected-login cooldowns. Each retry
 builds authentication headers from current credentials. Startup enrichment
 merges its changes into current charger data after awaits, preserving intervening
 commands, polls, and removals.

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -10382,3 +10382,68 @@ async def test_session_history_wraps_unavailable(monkeypatch, status) -> None:
     monkeypatch.setattr(client, "_json", _RequestMock(side_effect=err))
     with pytest.raises(api.SessionHistoryUnavailable):
         await client.session_history("SN", start_date="01-01-2024")
+
+
+def _login_wall_response() -> _FakeResponse:
+    return _FakeResponse(
+        status=200,
+        json_body=ValueError("invalid-json"),
+        text_body="<html><script>window.OptanonWrapper = function () {};</script></html>",
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("first_status", [200, 401])
+@pytest.mark.parametrize("retry_status", [200, 401])
+async def test_json_login_wall_retry_is_bounded(first_status, retry_status):
+    session = _FakeSession(
+        [
+            (
+                _login_wall_response()
+                if status == 200
+                else _FakeResponse(status=401, json_body={})
+            )
+            for status in (first_status, retry_status)
+        ]
+    )
+    client = api.EnphaseEVClient(session, "SITE", None, None)
+    refresh = AsyncMock(return_value=True)
+    client.set_reauth_callback(refresh)
+    error = (
+        api.EnphaseLoginWallUnauthorized if retry_status == 200 else api.Unauthorized
+    )
+    with pytest.raises(error):
+        await client._json("GET", "https://example.test/service/test")
+    refresh.assert_awaited_once()
+    assert len(session.calls) == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "allow_reauth,endpoint,success",
+    [
+        (False, "/service/test", True),
+        (True, "/service/hems/test", True),
+        (True, "/service/test", False),
+    ],
+)
+async def test_json_login_wall_respects_refresh_policy(
+    monkeypatch, allow_reauth, endpoint, success
+):
+    monkeypatch.setattr(
+        api.EnphaseEVClient,
+        "_is_hems_api_endpoint",
+        staticmethod(lambda value: value == "/service/hems/test"),
+    )
+    session = _FakeSession([_login_wall_response()])
+    client = api.EnphaseEVClient(session, "SITE", None, None)
+    refresh = AsyncMock(return_value=success)
+    client.set_reauth_callback(refresh)
+    with pytest.raises(api.EnphaseLoginWallUnauthorized):
+        await client._json(
+            "GET", f"https://example.test{endpoint}", allow_reauth=allow_reauth
+        )
+    assert refresh.await_count == int(
+        allow_reauth and not client._is_hems_api_endpoint(endpoint)
+    )
+    assert len(session.calls) == 1

--- a/tests/components/enphase_ev/test_transport_publication_contracts.py
+++ b/tests/components/enphase_ev/test_transport_publication_contracts.py
@@ -359,3 +359,176 @@ async def test_direct_warmup_helpers_preserve_concurrent_control(
         coord.evse_runtime.async_resolve_charger_config = AsyncMock(return_value={})
         await coord.refresh_runner.async_refresh_secondary_evse_state_for_warmup()
     assert coord.data["EVSE"]["charging"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("recent_success", [False, True])
+async def test_login_wall_joins_shared_401_refresh(
+    coordinator_factory, monkeypatch, recent_success
+):
+    from custom_components.enphase_ev import auth_refresh_runtime
+    from .test_api_client_methods import _login_wall_response
+
+    coord = coordinator_factory()
+    coord._email = "synthetic@example.test"
+    coord._remember_password = True
+    coord._stored_password = "synthetic-password"
+    session = _FakeSession(
+        [
+            _FakeResponse(status=401, json_body={}),
+            *(
+                [
+                    _FakeResponse(status=200, json_body={"ok": True}),
+                    _login_wall_response(),
+                ]
+                if recent_success
+                else [
+                    _login_wall_response(),
+                    _FakeResponse(status=200, json_body={"ok": True}),
+                ]
+            ),
+            _FakeResponse(status=200, json_body={"ok": True}),
+        ]
+    )
+    coord.client = api.EnphaseEVClient(session, "SITE", "old", "session=old")
+    entered = asyncio.Event()
+    finish = asyncio.Event()
+    joined = asyncio.Event()
+
+    async def authenticate(*args, **kwargs):
+        entered.set()
+        await finish.wait()
+        return (
+            api.AuthTokens(
+                cookie="session=new",
+                session_id="new",
+                access_token="new",
+                token_expires_at=9999999999,
+            ),
+            {},
+        )
+
+    login = AsyncMock(side_effect=authenticate)
+    monkeypatch.setattr(auth_refresh_runtime, "async_authenticate", login)
+
+    async def refresh():
+        if entered.is_set():
+            joined.set()
+        return await coord._handle_client_unauthorized()
+
+    coord.client.set_reauth_callback(refresh)
+
+    async def request():
+        return await coord.client._json("GET", "https://example.test/service/test")
+
+    first = asyncio.create_task(request())
+    second = None
+    try:
+        await asyncio.wait_for(entered.wait(), 1)
+        if recent_success:
+            finish.set()
+            assert await asyncio.wait_for(first, 1) == {"ok": True}
+        second = asyncio.create_task(request())
+        await asyncio.wait_for(joined.wait(), 1)
+        finish.set()
+        assert await asyncio.wait_for(first, 1) == {"ok": True}
+        assert await asyncio.wait_for(second, 1) == {"ok": True}
+    finally:
+        finish.set()
+        await asyncio.gather(
+            first, *([second] if second else []), return_exceptions=True
+        )
+    login.assert_awaited_once()
+    assert [call[2]["headers"]["e-auth-token"] for call in session.calls] == (
+        ["old", "new", "new", "new"] if recent_success else ["old", "old", "new", "new"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_login_wall_preserves_battery_variant_without_stored_credentials(
+    coordinator_factory,
+):
+    from .test_api_client_methods import _login_wall_response
+
+    coord = coordinator_factory()
+    coord._remember_password = False
+    session = _FakeSession(
+        [
+            _login_wall_response(),
+            _FakeResponse(status=200, json_body={"message": "success"}),
+        ]
+    )
+    coord.client = api.EnphaseEVClient(
+        session, "SITE", "EAUTH", "_enlighten_4_session=fresh-session"
+    )
+    coord.client.set_reauth_callback(coord._handle_client_unauthorized)
+    result = await coord.client._battery_config_request(
+        "GET",
+        "https://example.test/service/batteryConfig/api/v1/siteSettings/SITE",
+        endpoint_family="profile",
+        cache_on_success=True,
+    )
+    assert result == {"message": "success"}
+    assert len(session.calls) == 2
+    first, second = [call[2]["headers"] for call in session.calls]
+    assert first["Cookie"] == "_enlighten_4_session=fresh-session"
+    assert "e-auth-token" not in first
+    assert "Cookie" not in second
+    assert second["e-auth-token"] == "EAUTH"
+
+
+@pytest.mark.asyncio
+async def test_login_wall_preserves_rejected_refresh_cooldown(
+    coordinator_factory,
+    monkeypatch,
+):
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+    from custom_components.enphase_ev import auth_refresh_runtime
+    from .test_api_client_methods import _login_wall_response
+
+    coord = coordinator_factory()
+    coord._email = "synthetic@example.test"
+    coord._remember_password = True
+    coord._stored_password = "synthetic-password"
+    session = _FakeSession([_login_wall_response()])
+    coord.client = api.EnphaseEVClient(session, "SITE", "old", "session=old")
+    coord.client.set_reauth_callback(coord._handle_client_unauthorized)
+    login = AsyncMock(side_effect=api.EnlightenAuthInvalidCredentials())
+    monkeypatch.setattr(auth_refresh_runtime, "async_authenticate", login)
+
+    async def request():
+        return await coord.client._json("GET", "https://example.test/service/test")
+
+    with pytest.raises(UpdateFailed, match="temporarily blocked") as caught:
+        await coord.refresh_runner.async_run_refresh_call("test", "test", request)
+    login.assert_awaited_once()
+    assert len(session.calls) == 1
+    assert coord._auth_block_reason == "login_wall_after_refresh_reject"
+    assert 86390 <= caught.value.retry_after <= 86400
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocked", [False, True])
+async def test_login_wall_preserves_production_auth_failure(
+    coordinator_factory, blocked
+):
+    from homeassistant.exceptions import ConfigEntryAuthFailed
+    from homeassistant.helpers.update_coordinator import UpdateFailed
+    from .test_api_client_methods import _login_wall_response
+
+    coord = coordinator_factory()
+    coord._remember_password = False
+    if blocked:
+        coord.auth_refresh_runtime.note_login_wall_block(
+            reason="too_many_active_sessions"
+        )
+    session = _FakeSession([_login_wall_response()])
+    coord.client = api.EnphaseEVClient(session, "SITE", "old", "session=old")
+    coord.client.set_reauth_callback(coord._handle_client_unauthorized)
+
+    async def request():
+        return await coord.client._json("GET", "https://example.test/service/test")
+
+    with pytest.raises(UpdateFailed if blocked else ConfigEntryAuthFailed):
+        await coord.refresh_runner.async_run_refresh_call("test", "test", request)
+    assert len(session.calls) == 1


### PR DESCRIPTION
## Summary

JSON requests that received an HTTP 200 Enlighten login page could raise a whole-entry authentication failure while a concurrent HTTP 401 request was successfully refreshing credentials. Route login-wall responses through the same shared refresh and retry once with current credentials, including reuse of a recent successful refresh.

Preserve endpoint refresh exclusions, BatteryConfig's alternate-token fallback, and rejected-login cooldown handling when the production callback raises `ConfigEntryAuthFailed`. Add regression coverage for concurrent recovery, bounded mixed-response retries, and production callback failure paths.

Fixes #863.

## Related Issues

- #528 and #859 concern the existing shared-refresh and optional-endpoint authentication boundaries.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Run in the pinned Docker environment. The linked worktree's backing Git directory is mounted read-only so pre-commit can resolve repository metadata.

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc 'ruff check . && black custom_components/enphase_ev/api_client/request_surface.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_transport_publication_contracts.py && python -m pre_commit run --all-files && python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api_client/request_surface.py --fail-under=100 && pytest tests/components/enphase_ev -q && pytest'
git diff --check
```

The concurrency regressions failed before the fix. Additional tests reproduced and verified the production callback's exception handling. The changed integration module has 100% targeted coverage. Final local runs passed 4,186 integration tests and 4,344 tests across the full suite. All applicable GitHub Actions checks passed.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No translation or diagnostics schema changes. HTTP responses are simulated in regression tests; live Enphase token rollover has not been verified.
