### PR TITLE
Prepare release 4.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v4.3.2 - 2026-09-11
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
 - Added disabled-by-default diagnostic sensors for cumulative stored-credential
   login attempts, successes, and failures. Counters persist across integration
   reloads and Home Assistant restarts. Counter updates preserve cloud availability,
@@ -29,10 +46,16 @@ All notable changes to this project will be documented in this file.
   `auth_blocked` on the refresh that activates the block. (#859)
 
 ### 🔧 Improvements
-- None
+- Simplified the README by removing detailed operational sections for data updates,
+  recovery, action targets, and live-stream actions. (#858)
 
 ### 🔄 Other changes
-- None
+- Preserved merge-base history in CI change detection so checks still work when
+  the base branch advances or an older workflow run is retried. (#862)
+- Documented EV battery preference API captures, capability and state fields,
+  and the observed Storm Guard rejection; successful preference writes remain
+  unverified and this release adds no controls for that endpoint. (#865)
+- Bumped the integration manifest version to `4.3.2`.
 
 ## v4.3.1 - 2026-09-08
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "4.3.1"
+  "version": "4.3.2"
 }


### PR DESCRIPTION
## Summary

Prepare release 4.3.2 by updating the integration manifest and publishing the dated changelog for all six merged changes since 4.3.1. Reset the Unreleased section for future changes.

The release notes cover stored-credential login counters, authentication and VPP reliability fixes, README cleanup, CI merge-base handling, and EV battery preference API documentation.

## Related Issues

Included changes: #858, #860, #861, #862, #864, #865. Related issues: #859 and #863.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (release metadata)

## Testing

All validation passed in the pinned Docker environment. The integration suite passed 4,186 tests; the full repository suite passed 4,344 tests.

Exact validation commands:

```bash
git diff --check
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'ruff check . && black --check custom_components/enphase_ev tests/components/enphase_ev && python -m pre_commit run --all-files && python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev-4.3.2.log && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && pytest -q tests/components/enphase_ev && pytest -q'
```

No Python modules changed, so targeted module coverage is not applicable. Translation tests passed as part of the integration suite.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed. (No behaviour or option changes in this PR.)
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (Existing translation tests passed.)
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage. (Not applicable: no Python modules changed.)
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Only `CHANGELOG.md` and `custom_components/enphase_ev/manifest.json` changed. No release tag or GitHub release has been created.
