### PR TITLE
Prepare release 4.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,35 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v4.3.3 - 2026-09-12
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
 - Recover Current Power Consumption on the first comparable sample after source
   gaps of up to 30 minutes, using the actual averaging interval while preserving
-  the 15-minute expiry of each accepted reading.
+  the 15-minute expiry of each accepted reading. (#867)
 
 ### 🔧 Improvements
 - Add site-energy fetch diagnostics for attempts, failures, cancellation, invalid
   payloads, and source timestamp progression to distinguish request failures from
   unchanged cloud data. Empty payloads count as failures and future timestamps
-  cannot prevent normal source updates from being recognized.
+  cannot prevent normal source updates from being recognized. (#867)
 
 ### 🔄 Other changes
-- None
+- Bumped the integration manifest version to `4.3.3`.
 
 ## v4.3.2 - 2026-09-11
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "4.3.2"
+  "version": "4.3.3"
 }


### PR DESCRIPTION
## Summary

Prepare release 4.3.3 by bumping the integration manifest and moving the Unreleased notes into a dated 2026-09-12 section. Restore the empty Unreleased template. Release notes cover consumption-power recovery and site-energy fetch diagnostics from #867.

## Related Issues

- #867

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (release metadata)

## Testing

All checks passed. Integration suite: 4,214 passed; translation suite: 54 passed; full repository suite: 4,372 passed.

```bash
git diff --check
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'ruff check . && black custom_components/enphase_ev tests/components/enphase_ev && python scripts/validate_quality_scale.py && python scripts/validate_quality_scale.py --validate-remote-brands && python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev && pre-commit run --all-files && pytest -q tests/components/enphase_ev && pytest -q tests/components/enphase_ev/test_service_translations.py && pytest'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black custom_components/enphase_ev tests/components/enphase_ev && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev'
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed. (Not applicable: release metadata only.)
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage. (Not applicable: no Python modules changed.)
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Only `CHANGELOG.md` and `custom_components/enphase_ev/manifest.json` change. No runtime behavior changes in this PR.
