### PR TITLE
Fix delayed EVSE Storm Guard switch discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Create EV charger Storm Guard switches when battery capabilities or write access
+  arrive after charger discovery, without requiring a reload. (#869)
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -330,6 +330,7 @@ async def async_setup_entry(
 
     site_entity_keys: set[str] = set()
     known_serials: set[str] = set()
+    known_storm_guard: set[str] = set()
     known_green_battery: set[str] = set()
     known_app_auth: set[str] = set()
     known_evse_schedule_days: set[tuple[str, str]] = set()
@@ -489,12 +490,15 @@ async def async_setup_entry(
         entities: list[SwitchEntity] = []
         if serials:
             entities.extend(ChargingSwitch(coord, sn) for sn in serials)
-            if (
-                site_has_battery
-                and _battery_write_access_confirmed(coord)
-                and _storm_guard_visible(coord)
-            ):
-                entities.extend(StormGuardEvseSwitch(coord, sn) for sn in serials)
+        retain_storm_guard = (
+            current_serials
+            if site_has_battery and _storm_guard_visible(coord)
+            else set()
+        )
+        if _battery_write_access_confirmed(coord):
+            for sn in retain_storm_guard - known_storm_guard:
+                entities.append(StormGuardEvseSwitch(coord, sn))
+                known_storm_guard.add(sn)
         data_source = coord.data or {}
         retain_green_battery: set[str] = set()
         retain_app_auth: set[str] = set()
@@ -541,6 +545,7 @@ async def async_setup_entry(
             async_add_entities(entities, update_before_add=False)
         known_serials.intersection_update(current_serials)
         known_serials.update(serials)
+        known_storm_guard.intersection_update(retain_storm_guard)
         known_green_battery.intersection_update(retain_green_battery)
         known_app_auth.intersection_update(retain_app_auth)
         known_evse_schedule_days.intersection_update(
@@ -553,10 +558,9 @@ async def async_setup_entry(
         if not inventory_ready:
             return
         active_unique_ids = {f"{DOMAIN}_{sn}_charging_switch" for sn in current_serials}
-        if site_has_battery and _storm_guard_visible(coord):
-            active_unique_ids.update(
-                f"{DOMAIN}_{sn}_storm_guard_evse_charge" for sn in current_serials
-            )
+        active_unique_ids.update(
+            f"{DOMAIN}_{sn}_storm_guard_evse_charge" for sn in retain_storm_guard
+        )
         active_unique_ids.update(
             f"{DOMAIN}_{sn}_green_battery" for sn in retain_green_battery
         )

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -220,6 +220,11 @@ Entity platforms under `sensor.py`, `binary_sensor.py`, `button.py`, `number.py`
 3. Wait for inventory readiness before pruning managed entity registry entries.
 4. Use optimistic coordinator caches only when Enphase writes are known to settle asynchronously.
 
+Per-charger Storm Guard switches track discovery independently from charging
+switches, so delayed battery capabilities or write access can create them on a
+later coordinator update. Existing registry entries are retained while write access
+is unknown; availability still requires confirmed access.
+
 Instantaneous site telemetry has bounded freshness: after a core outage, the
 last successful sample has a 15-minute grace period. Battery and heat-pump
 measurements with an established family success expire after 30 minutes without

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -554,6 +554,73 @@ def coordinator_factory(hass, config_entry, monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("delayed_field", "initial_value"),
+    [
+        ("_battery_has_encharge", False),
+        ("_battery_show_storm_guard", False),
+        ("_battery_user_is_owner", None),
+    ],
+)
+async def test_storm_guard_evse_discovered_after_battery_warmup(
+    hass, config_entry, coordinator_factory, monkeypatch, delayed_field, initial_value
+) -> None:
+    """Existing chargers gain Storm Guard when each delayed gate becomes ready."""
+    coord = coordinator_factory(
+        {"storm_guard_state": "enabled", "storm_evse_enabled": False}
+    )
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    setattr(coord, delayed_field, initial_value)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    serials = [RANDOM_SERIAL, "EV0002"]
+    monkeypatch.setattr(coord, "iter_serials", lambda: list(serials))
+    added = []
+    listener_spy = MagicMock(wraps=coord.async_add_listener)
+    monkeypatch.setattr(coord, "async_add_listener", listener_spy)
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **kwargs: added.extend(entities)
+    )
+    listener = listener_spy.call_args[0][0]
+    assert sum(isinstance(entity, ChargingSwitch) for entity in added) == 2
+    assert not any(isinstance(entity, StormGuardEvseSwitch) for entity in added)
+
+    setattr(coord, delayed_field, True)
+    listener()
+    storm_entities = [
+        entity for entity in added if isinstance(entity, StormGuardEvseSwitch)
+    ]
+    assert {entity._sn for entity in storm_entities} == set(serials)
+    assert len(storm_entities) == 2
+    assert all(entity.is_on is False for entity in storm_entities)
+    registry = er.async_get(hass)
+    registered = registry.async_get_or_create(
+        "switch",
+        "enphase_ev",
+        storm_entities[0].unique_id,
+        config_entry=config_entry,
+        suggested_object_id="custom_storm_guard",
+    )
+
+    # Temporary permission uncertainty retains existing entities and custom IDs.
+    coord._battery_user_is_owner = None  # noqa: SLF001
+    listener()
+    assert registry.async_get(registered.entity_id) is not None
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    listener()
+    assert sum(isinstance(entity, StormGuardEvseSwitch) for entity in added) == 2
+    assert sum(isinstance(entity, ChargingSwitch) for entity in added) == 2
+
+    # Authoritative removal prunes the registry and permits rediscovery.
+    serials.clear()
+    listener()
+    assert registry.async_get(registered.entity_id) is None
+    serials.append(RANDOM_SERIAL)
+    listener()
+    assert sum(isinstance(entity, StormGuardEvseSwitch) for entity in added) == 3
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_syncs_chargers(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

Create per-charger Storm Guard switches when battery capabilities or write permission arrive after charger discovery. Previously, creation ran only for newly seen charger serials, leaving existing chargers without a switch until reload—and potentially on every reload when battery data was consistently delayed.

Track Storm Guard discovery independently, re-evaluate it on coordinator updates, and clear tracking when the charger or capability is removed. Retain existing registry entries during permission uncertainty to preserve entity IDs and customizations; availability still requires confirmed write access.

Fixes #869.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

All validation used the pinned Docker environment. Full repository suite: **4,375 passed**. Integration suite: **4,217 passed**. Switch suite: **120 passed**. Translation suite: **54 passed**. Targeted coverage for `custom_components/enphase_ev/switch.py`: **100%**.

The three new regression cases cover delayed battery presence, Storm Guard visibility, and write access with two chargers. They also check duplicate prevention, permission uncertainty, registry retention, removal, and rediscovery. All three fail against the original switch module and pass with this fix.

Commands run (some checks were combined with `&&` in a single container):

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'ruff check .'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black custom_components/enphase_ev/switch.py tests/components/enphase_ev/test_switch_module.py'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'black --check custom_components/enphase_ev tests/components/enphase_ev'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'python scripts/validate_quality_scale.py'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'python scripts/validate_quality_scale.py --validate-remote-brands'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'python scripts/importtime_profile.py --strict-integration-warnings --output /tmp/importtime-enphase-ev.log'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'pytest -q tests/components/enphase_ev/test_switch_module.py'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/switch.py --fail-under=100'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'pytest -q tests/components/enphase_ev/test_service_translations.py && pytest -q'
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git -v /Users/james/.codex/worktrees/40ee/ha-enphase-ev-charger:/Users/james/.codex/worktrees/40ee/ha-enphase-ev-charger -w /Users/james/.codex/worktrees/40ee/ha-enphase-ev-charger ha-dev bash -lc 'pre-commit run --all-files'
git diff --check
```

Pre-commit required the additional Git metadata mount because this checkout is a linked worktree. All hooks passed. The final Black and full-package mypy checks were repeated before push.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No user-facing strings or API write behavior changed. An upstream EVSE participation value of `false` represents an off switch and does not prevent discovery. Live verification on the reporter's Home Assistant instance remains outstanding.
